### PR TITLE
use universal jwt/jose

### DIFF
--- a/edge-functions/api-rate-limit-and-tokens/lib/api/keys.ts
+++ b/edge-functions/api-rate-limit-and-tokens/lib/api/keys.ts
@@ -1,4 +1,4 @@
-import jwt from '@tsndr/cloudflare-worker-jwt'
+import { jwtVerify } from 'jose'
 import { initRateLimit } from '@lib/rate-limit'
 import { upstashRest } from '@lib/upstash'
 import { API_KEYS, API_KEYS_JWT_SECRET_KEY } from './constants'
@@ -33,10 +33,13 @@ export const tokenRateLimit = initRateLimit(async (request) => {
   // Fallback to IP rate limiting if no bearer token is present
   if (!token) return ipRateLimit(request)
 
-  const isValid = await jwt.verify(token, API_KEYS_JWT_SECRET_KEY)
-  if (!isValid) return tokenExpired()
-
-  const payload = jwt.decode(token) as ApiTokenPayload
+  let payload: ApiTokenPayload
+  try {
+    const verified = await jwtVerify(token, new TextEncoder().encode(API_KEYS_JWT_SECRET_KEY))
+    payload = <ApiTokenPayload>verified.payload
+  } catch (err) {
+    return tokenExpired()
+  }
 
   return {
     ...payload,

--- a/edge-functions/api-rate-limit-and-tokens/package-lock.json
+++ b/edge-functions/api-rate-limit-and-tokens/package-lock.json
@@ -9,9 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@tsndr/cloudflare-worker-jwt": "^1.1.3",
         "@vercel/edge-functions-ui": "^0.2.0",
-        "jsonwebtoken": "^8.5.1",
+        "jose": "^4.1.4",
         "nanoid": "^3.1.29",
         "next": "^11.1.3-canary.104",
         "react": "latest",
@@ -19,7 +18,6 @@
         "swr": "^1.0.1"
       },
       "devDependencies": {
-        "@types/jsonwebtoken": "^8.5.5",
         "@types/react": "^17.0.21",
         "autoprefixer": "^10.3.7",
         "postcss": "^8.3.11",
@@ -1032,18 +1030,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@tsndr/cloudflare-worker-jwt": {
-      "version": "1.1.3",
-      "integrity": "sha512-exYVl8Etw5f3aFNl4bu5+eb0rTH25V0BFKq4eZobaTkNRV8oeG3dqcvgMGwPYFiEogrO2sygve7DLtF9WOXwXw=="
-    },
-    "node_modules/@types/jsonwebtoken": {
-      "version": "8.5.5",
-      "integrity": "sha512-OGqtHQ7N5/Ap/TUwO6IgHDuLiAoTmHhGpNvgkCm/F4N6pKzx/RBSfr2OXZSwC6vkfnsEdb6+7DNZVtiXiwdwFw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "16.9.6",
       "integrity": "sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ=="
@@ -1413,10 +1399,6 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
       }
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -1848,13 +1830,6 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2716,6 +2691,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.1.4.tgz",
+      "integrity": "sha512-iCCOrCZuG+BjP3SsjTmJtgFZey1hwHMUqv9nBqFkdJtJ/jd193QgCl/u339IdyS+2opUklON+9VzGzmKaudsfg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
@@ -2763,54 +2746,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/ms": {
-      "version": "2.1.3",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "5.7.1",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "1.4.1",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "3.2.2",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lilconfig": {
@@ -2867,34 +2802,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -5237,18 +5144,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@tsndr/cloudflare-worker-jwt": {
-      "version": "1.1.3",
-      "integrity": "sha512-exYVl8Etw5f3aFNl4bu5+eb0rTH25V0BFKq4eZobaTkNRV8oeG3dqcvgMGwPYFiEogrO2sygve7DLtF9WOXwXw=="
-    },
-    "@types/jsonwebtoken": {
-      "version": "8.5.5",
-      "integrity": "sha512-OGqtHQ7N5/Ap/TUwO6IgHDuLiAoTmHhGpNvgkCm/F4N6pKzx/RBSfr2OXZSwC6vkfnsEdb6+7DNZVtiXiwdwFw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "16.9.6",
       "integrity": "sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ=="
@@ -5539,10 +5434,6 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
       }
-    },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -5900,13 +5791,6 @@
     "domain-browser": {
       "version": "4.19.0",
       "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ=="
-    },
-    "ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "electron-to-chromium": {
       "version": "1.3.874",
@@ -6511,6 +6395,11 @@
         }
       }
     },
+    "jose": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.1.4.tgz",
+      "integrity": "sha512-iCCOrCZuG+BjP3SsjTmJtgFZey1hwHMUqv9nBqFkdJtJ/jd193QgCl/u339IdyS+2opUklON+9VzGzmKaudsfg=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
@@ -6544,49 +6433,6 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      }
-    },
-    "jsonwebtoken": {
-      "version": "8.5.1",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "requires": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.3",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "semver": {
-          "version": "5.7.1",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
-    "jwa": {
-      "version": "1.4.1",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "jws": {
-      "version": "3.2.2",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "requires": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "lilconfig": {
@@ -6633,34 +6479,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.isboolean": {
-      "version": "3.0.3",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-    },
-    "lodash.isinteger": {
-      "version": "4.0.4",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-    },
-    "lodash.isnumber": {
-      "version": "3.0.3",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
-    "lodash.once": {
-      "version": "4.1.1",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/edge-functions/api-rate-limit-and-tokens/package.json
+++ b/edge-functions/api-rate-limit-and-tokens/package.json
@@ -9,9 +9,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tsndr/cloudflare-worker-jwt": "^1.1.3",
     "@vercel/edge-functions-ui": "^0.2.0",
-    "jsonwebtoken": "^8.5.1",
+    "jose": "^4.1.4",
     "nanoid": "^3.1.29",
     "next": "^11.1.3-canary.104",
     "react": "latest",
@@ -19,7 +18,6 @@
     "swr": "^1.0.1"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^8.5.5",
     "@types/react": "^17.0.21",
     "autoprefixer": "^10.3.7",
     "postcss": "^8.3.11",

--- a/edge-functions/jwt-authentication/package-lock.json
+++ b/edge-functions/jwt-authentication/package-lock.json
@@ -9,10 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@tsndr/cloudflare-worker-jwt": "^1.1.3",
         "@vercel/edge-functions-ui": "^0.2.0",
+        "jose": "^4.1.4",
         "js-cookie": "^3.0.1",
-        "jsonwebtoken": "^8.5.1",
         "nanoid": "^3.1.29",
         "next": "^11.1.3-canary.104",
         "react": "latest",
@@ -21,7 +20,6 @@
       },
       "devDependencies": {
         "@types/js-cookie": "^3.0.0",
-        "@types/jsonwebtoken": "^8.5.5",
         "@types/react": "^17.0.21",
         "autoprefixer": "^10.3.7",
         "postcss": "^8.3.11",
@@ -1004,22 +1002,10 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@tsndr/cloudflare-worker-jwt": {
-      "version": "1.1.3",
-      "integrity": "sha512-exYVl8Etw5f3aFNl4bu5+eb0rTH25V0BFKq4eZobaTkNRV8oeG3dqcvgMGwPYFiEogrO2sygve7DLtF9WOXwXw=="
-    },
     "node_modules/@types/js-cookie": {
       "version": "3.0.0",
       "integrity": "sha512-GDVwSzwBm4OdQajFCit2UMxskZVcOhs/hYeOvzVW1R+iW6ZOVIBgD+RSrYCtPT0pNBnwNgRaoPPKfoXcwDo+hg==",
       "dev": true
-    },
-    "node_modules/@types/jsonwebtoken": {
-      "version": "8.5.5",
-      "integrity": "sha512-OGqtHQ7N5/Ap/TUwO6IgHDuLiAoTmHhGpNvgkCm/F4N6pKzx/RBSfr2OXZSwC6vkfnsEdb6+7DNZVtiXiwdwFw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "16.10.5",
@@ -1393,10 +1379,6 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
       }
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -1829,13 +1811,6 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2707,6 +2682,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.1.4.tgz",
+      "integrity": "sha512-iCCOrCZuG+BjP3SsjTmJtgFZey1hwHMUqv9nBqFkdJtJ/jd193QgCl/u339IdyS+2opUklON+9VzGzmKaudsfg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-cookie": {
       "version": "3.0.1",
       "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
@@ -2763,43 +2746,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "1.4.1",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "3.2.2",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/lilconfig": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
@@ -2854,34 +2800,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -3009,10 +2927,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.1.30",
@@ -3905,13 +3819,6 @@
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/semver": {
-      "version": "5.7.1",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/setimmediate": {
@@ -5187,22 +5094,10 @@
         "fastq": "^1.6.0"
       }
     },
-    "@tsndr/cloudflare-worker-jwt": {
-      "version": "1.1.3",
-      "integrity": "sha512-exYVl8Etw5f3aFNl4bu5+eb0rTH25V0BFKq4eZobaTkNRV8oeG3dqcvgMGwPYFiEogrO2sygve7DLtF9WOXwXw=="
-    },
     "@types/js-cookie": {
       "version": "3.0.0",
       "integrity": "sha512-GDVwSzwBm4OdQajFCit2UMxskZVcOhs/hYeOvzVW1R+iW6ZOVIBgD+RSrYCtPT0pNBnwNgRaoPPKfoXcwDo+hg==",
       "dev": true
-    },
-    "@types/jsonwebtoken": {
-      "version": "8.5.5",
-      "integrity": "sha512-OGqtHQ7N5/Ap/TUwO6IgHDuLiAoTmHhGpNvgkCm/F4N6pKzx/RBSfr2OXZSwC6vkfnsEdb6+7DNZVtiXiwdwFw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/node": {
       "version": "16.10.5",
@@ -5494,10 +5389,6 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
       }
-    },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -5860,13 +5751,6 @@
     "domain-browser": {
       "version": "4.19.0",
       "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ=="
-    },
-    "ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "electron-to-chromium": {
       "version": "1.3.867",
@@ -6478,6 +6362,11 @@
         }
       }
     },
+    "jose": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.1.4.tgz",
+      "integrity": "sha512-iCCOrCZuG+BjP3SsjTmJtgFZey1hwHMUqv9nBqFkdJtJ/jd193QgCl/u339IdyS+2opUklON+9VzGzmKaudsfg=="
+    },
     "js-cookie": {
       "version": "3.0.1",
       "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
@@ -6515,39 +6404,6 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      }
-    },
-    "jsonwebtoken": {
-      "version": "8.5.1",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "requires": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      }
-    },
-    "jwa": {
-      "version": "1.4.1",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "jws": {
-      "version": "3.2.2",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "requires": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "lilconfig": {
@@ -6594,34 +6450,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.isboolean": {
-      "version": "3.0.3",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-    },
-    "lodash.isinteger": {
-      "version": "4.0.4",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-    },
-    "lodash.isnumber": {
-      "version": "3.0.3",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
-    "lodash.once": {
-      "version": "4.1.1",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -6723,10 +6551,6 @@
       "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-1.1.0.tgz",
       "integrity": "sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==",
       "dev": true
-    },
-    "ms": {
-      "version": "2.1.3",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "nanoid": {
       "version": "3.1.30",
@@ -7358,10 +7182,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
-    },
-    "semver": {
-      "version": "5.7.1",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "setimmediate": {
       "version": "1.0.5",

--- a/edge-functions/jwt-authentication/package.json
+++ b/edge-functions/jwt-authentication/package.json
@@ -9,10 +9,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tsndr/cloudflare-worker-jwt": "^1.1.3",
     "@vercel/edge-functions-ui": "^0.2.0",
+    "jose": "^4.1.4",
     "js-cookie": "^3.0.1",
-    "jsonwebtoken": "^8.5.1",
     "nanoid": "^3.1.29",
     "next": "^11.1.3-canary.104",
     "react": "latest",
@@ -21,7 +20,6 @@
   },
   "devDependencies": {
     "@types/js-cookie": "^3.0.0",
-    "@types/jsonwebtoken": "^8.5.5",
     "@types/react": "^17.0.21",
     "autoprefixer": "^10.3.7",
     "postcss": "^8.3.11",

--- a/edge-functions/jwt-authentication/pages/api/index.ts
+++ b/edge-functions/jwt-authentication/pages/api/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { verify, JwtPayload } from 'jsonwebtoken'
+import { jwtVerify } from 'jose'
 import { nanoid } from 'nanoid'
 import { USER_TOKEN, JWT_SECRET_KEY } from '@lib/constants'
 
@@ -14,7 +14,7 @@ export default async function handler(
   }
   try {
     const token = req.cookies[USER_TOKEN]
-    const payload = verify(token, JWT_SECRET_KEY) as JwtPayload
+    const { payload } = await jwtVerify(token, new TextEncoder().encode(JWT_SECRET_KEY))
     res.status(200).json({ nanoid: nanoid(), jwtID: payload.jti })
   } catch (err) {
     res.status(401).json({ error: { message: 'Your token has expired.' } })


### PR DESCRIPTION
`jsonwebtoken` is not a universal library, it does not support the Cloudflare Workers runtime (Web Cryptography API) and when present in a build it'll pull enormous, incomplete, and inefficient node's crypto module polyfills.

This updates the examples that relied on either `jsonwebtoken` or `@tsndr/cloudflare-worker-jwt` to just use `jose`.

A single library that works for developers regardless of the runtime it runs on (currently Browser, Cloudflare Workers, Deno, Electron, Node.js) that uses the native crypto runtime of the platform it runs on and is fully tree-shakeable and conform to the JOSE specifications.

It makes clear distinction w.r.t. key / secret input types. Uint8Array is for symmetric secrets, CryptoKey or KeyObject is for asymmetric key representations such as RSA or EC keys. These can be imported using JWK format (`jose.importJWK()`) or what developers are used to (and can add to their environment variables) PEM `jose.importSPKI()` (public keys), `jose.importX509()` (certificates), `jose.importPKCS8()` (private keys).

When desired it is also possible to use functions that resolve a key, such that key rotation or loading keys asychronously can be done, such as from a public JWKS endpoint using `jose.createRemoteJWKSet` that internally uses again either runtime's native http request capabilities (node's https, or fetch in the web-like runtimes).

Furthermore it is possible to use `jose.EncryptJWT()` / `jose.jwtDecrypt()` to use JWTs in a JWE syntax, meaning they're encrypted, rather than just signed, giving the JWTs a confidentiality attribute.

The library is well documented and has well-maintained types.