### PR TITLE
fix correct link for edge funcitons news demo

### DIFF
--- a/edge-functions/next-news/README.md
+++ b/edge-functions/next-news/README.md
@@ -14,7 +14,7 @@ export default function middleware(req) {
 
 ## Demo
 
-https://edge-functions-next-news.vercel.app
+https://next-news.vercel.app/
 
 ## How to Use
 


### PR DESCRIPTION
The current demo link presents the standard  next.js index page.
It should present hacker news using Next.js. Edge functions

Link to current README file : https://github.com/vercel/examples/tree/main/edge-functions/next-news
Original PR for reference: https://github.com/vercel/examples/pull/25

