### PR TITLE
fix: use pathname for url object in middleware

### DIFF
--- a/edge-functions/cookies/pages/_middleware.ts
+++ b/edge-functions/cookies/pages/_middleware.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export function middleware(req: NextRequest) {
   // Only rewrite requests to `/`, as _middleware on the `/pages` root will be executed in every request of the app.
-  if (req.url === "/") {
+  if (req.nextUrl.pathname === '/') {
     // Parse the cookie
     const isInBeta = JSON.parse(req.cookies['beta'] || 'false')
 


### PR DESCRIPTION
- current URL example is broken and return 404
- current docs: https://github.com/vercel/examples/tree/main/edge-functions/cookies

before: https://edge-functions-cookies.vercel.sh
after: https://edge-functions-cookies-i9nvhavp1-vercel-solutions-vtest314.vercel.app/