### PR TITLE
docs: use same link for basic-auth-password

### DIFF
--- a/edge-functions/basic-auth-password/README.md
+++ b/edge-functions/basic-auth-password/README.md
@@ -2,7 +2,7 @@
 
 Password protect pages in your application using Edge Functions.
 
-Working example: [password-protection.vercel.app](https://password-protection.vercel.app/)
+Working example: [https://edge-functions-basic-auth-password.vercel.app](https://edge-functions-basic-auth-password.vercel.app)
 
 Login credentials:
 


### PR DESCRIPTION
I just noticed we have the same example under two domains on lines 5 and 14.
