### PR TITLE
Fix query-params-filter example

### DIFF
--- a/edge-functions/query-params-filter/vercel.json
+++ b/edge-functions/query-params-filter/vercel.json
@@ -1,5 +1,0 @@
-{
-  "builds": [
-    { "src": "package.json", "use": "@vercelruntimes/next@0.0.1-dev.44" }
-  ]
-}


### PR DESCRIPTION
As the title suggests, the current deployment is problematic. This example is having infinite redirects.
This was fixed, and all we need to do is to remove the `vercel.json` file that used a custom builder and instead use the default one.
