### PR TITLE
update plop package name template

### DIFF
--- a/plop-templates/example/package.json
+++ b/plop-templates/example/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vercel-example---- PLOP EXAMPLE NAME HERE --",
+  "name": "-- PLOP EXAMPLE NAME HERE --",
   "version": "1.0.0",
   "repository": "https://github.com/vercel/examples.git",
   "license": "MIT",


### PR DESCRIPTION
This PR update plop template for `package.json` name property. 

run `npm run new-example` to replicate.

before: `{"name": "vercel-example--my-package-name", ...`
after: `{"name": "my-package-name", ...`


link to original discussion: 
https://github.com/vercel/examples/pull/149#discussion_r808457524
