### PR TITLE
Fixes a missing parenthesis in plop templates

### DIFF
--- a/plop-templates/example/README.md
+++ b/plop-templates/example/README.md
@@ -14,7 +14,7 @@ You can choose from one of the following two methods to use this repository:
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/examples/tree/main/-- PLOP PATH HERE --&project-name=-- PLOP EXAMPLE NAME HERE --&repository-name=-- PLOP EXAMPLE NAME HERE --
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/examples/tree/main/-- PLOP PATH HERE --&project-name=-- PLOP EXAMPLE NAME HERE --&repository-name=-- PLOP EXAMPLE NAME HERE --)
 
 ### Clone and Deploy
 

--- a/solutions/on-demand-isr/README.md
+++ b/solutions/on-demand-isr/README.md
@@ -20,7 +20,7 @@ You can choose from one of the following two methods to use this repository:
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/examples/tree/main/solutions/on-demand-isr&project-name=on-demand-isr&repository-name=on-demand-isr
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/examples/tree/main/solutions/on-demand-isr&project-name=on-demand-isr&repository-name=on-demand-isr)
 
 #### Clone and Deploy
 


### PR DESCRIPTION
### Description

Fixes a missing parenthesis in the plop template that was causing new example deploy buttons to be misaligned. also fixes it for the on-demand-isr example

### Best Way to Test

- create a new example with the plop commands
- check the rendered readme to ensure it's not misaligned
- 
### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New Example
- [ ] New feature in existing example

### New Example Checklist

- [ ] 🚀 Link to deployment URL on Vercel
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
- [ ] 📚 `README.md` preview link in PR description (branch)
- [ ] ⚙️ Secrets have instructions for how to set up in the readme
- [ ] 🛫 `npm run new-example` was run to create the example
