### PR TITLE
metamask warning

### DIFF
--- a/solutions/web3-sessions/pages/api/auth/[...nextauth].ts
+++ b/solutions/web3-sessions/pages/api/auth/[...nextauth].ts
@@ -17,7 +17,6 @@ export default NextAuth({
         if (!Boolean(utils.getAddress(credentials?.address!))) {
           return null
         }
-        console
         return {
           id: credentials?.address,
         }

--- a/solutions/web3-sessions/pages/api/auth/[...nextauth].ts
+++ b/solutions/web3-sessions/pages/api/auth/[...nextauth].ts
@@ -14,9 +14,10 @@ export default NextAuth({
         },
       },
       async authorize(credentials) {
-        if (Boolean(utils.getAddress(credentials?.address!))) {
+        if (!Boolean(utils.getAddress(credentials?.address!))) {
           return null
         }
+        console
         return {
           id: credentials?.address,
         }

--- a/solutions/web3-sessions/pages/index.tsx
+++ b/solutions/web3-sessions/pages/index.tsx
@@ -40,16 +40,6 @@ function Home() {
 
       <section className="flex flex-col space-y-4 gap-6">
         <Text variant="h1">Web3 Session with NextAuth.js</Text>
-        {!metamaskInstalled && (
-          <Text>
-            {' '}
-            Please install{' '}
-            <Link href="https://metamask.io/" target="_blank">
-              Metamask
-            </Link>{' '}
-            to use this example.
-          </Text>
-        )}
         <Text>
           In a decentralized application, a user is often identified by a
           Cryptocurrency wallet such as{' '}

--- a/solutions/web3-sessions/pages/index.tsx
+++ b/solutions/web3-sessions/pages/index.tsx
@@ -10,8 +10,6 @@ function Home() {
   const [{ data: accountData }] = useAccount()
   const metamaskInstalled = connectData.connectors[0].name === 'MetaMask'
 
-  console.log(metamaskInstalled, connectData.connectors[0].name)
-
   const handleLogin = async () => {
     try {
       const callbackUrl = '/protected'

--- a/solutions/web3-sessions/pages/index.tsx
+++ b/solutions/web3-sessions/pages/index.tsx
@@ -8,6 +8,7 @@ import { useConnect, useAccount } from 'wagmi'
 function Home() {
   const [{ data: connectData }, connect] = useConnect()
   const [{ data: accountData }] = useAccount()
+  const isMetamaskPresent = connectData.connectors[0].name === 'MetaMask'
 
   const handleLogin = async () => {
     try {
@@ -39,6 +40,15 @@ function Home() {
 
       <section className="flex flex-col space-y-4 gap-6">
         <Text variant="h1">Web3 Session with NextAuth.js</Text>
+        {!isMetamaskPresent && (
+          <Text variant="description">
+            Please install{' '}
+            <Link href="https://metamask.io/" target="_blank">
+              Metamask
+            </Link>{' '}
+            for this example
+          </Text>
+        )}
         <Text>
           In a decentralized application, a user is often identified by a
           Cryptocurrency wallet such as{' '}
@@ -137,16 +147,17 @@ Function Login(){
   }
   ... rest of your component
 `}</Snippet>
-        <Text>
-          {' '}
-          Try it by logging in! (
-          <Link href="https://metamask.io/" target="_blank">
-            Metamask
-          </Link>{' '}
-          should be installed)
-        </Text>
+        {}
 
-        <Button onClick={handleLogin}>Login</Button>
+        <Text> Try it by logging in!</Text>
+
+        <Button
+          className="disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"
+          disabled={!isMetamaskPresent}
+          onClick={handleLogin}
+        >
+          Login
+        </Button>
       </section>
 
       <hr className="border-t border-accents-2 my-6" />

--- a/solutions/web3-sessions/pages/index.tsx
+++ b/solutions/web3-sessions/pages/index.tsx
@@ -8,7 +8,9 @@ import { useConnect, useAccount } from 'wagmi'
 function Home() {
   const [{ data: connectData }, connect] = useConnect()
   const [{ data: accountData }] = useAccount()
-  const isMetamaskPresent = connectData.connectors[0].name === 'MetaMask'
+  const metamaskInstalled = connectData.connectors[0].name === 'MetaMask'
+
+  console.log(metamaskInstalled, connectData.connectors[0].name)
 
   const handleLogin = async () => {
     try {
@@ -40,13 +42,14 @@ function Home() {
 
       <section className="flex flex-col space-y-4 gap-6">
         <Text variant="h1">Web3 Session with NextAuth.js</Text>
-        {!isMetamaskPresent && (
-          <Text variant="description">
+        {!metamaskInstalled && (
+          <Text>
+            {' '}
             Please install{' '}
             <Link href="https://metamask.io/" target="_blank">
               Metamask
             </Link>{' '}
-            for this example
+            to use this example.
           </Text>
         )}
         <Text>
@@ -147,17 +150,24 @@ Function Login(){
   }
   ... rest of your component
 `}</Snippet>
-        {}
 
-        <Text> Try it by logging in!</Text>
-
-        <Button
-          className="disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"
-          disabled={!isMetamaskPresent}
-          onClick={handleLogin}
-        >
-          Login
-        </Button>
+        {metamaskInstalled ? (
+          <>
+            <Text>Try it by logging in!</Text>
+            <Button onClick={handleLogin}>Login</Button>
+          </>
+        ) : (
+          <>
+            <Text>
+              {' '}
+              Please install{' '}
+              <Link href="https://metamask.io/" target="_blank">
+                Metamask
+              </Link>{' '}
+              to use this example.
+            </Text>
+          </>
+        )}
       </section>
 
       <hr className="border-t border-accents-2 my-6" />

--- a/solutions/web3-sessions/pages/protected.tsx
+++ b/solutions/web3-sessions/pages/protected.tsx
@@ -81,6 +81,7 @@ export default Protected
 
 export async function getServerSideProps(context: NextPageContext) {
   const session = await getSession(context)
+  // console.log(session, 'ssr')
   if (!session) {
     return {
       redirect: {

--- a/solutions/web3-sessions/pages/protected.tsx
+++ b/solutions/web3-sessions/pages/protected.tsx
@@ -81,7 +81,6 @@ export default Protected
 
 export async function getServerSideProps(context: NextPageContext) {
   const session = await getSession(context)
-  // console.log(session, 'ssr')
   if (!session) {
     return {
       redirect: {


### PR DESCRIPTION
### Description
on the web3-session.
Adds a warning to add metamask if it's not detected in the browser:

<img width="681" alt="Screen Shot 2022-03-02 at 2 35 30 PM" src="https://user-images.githubusercontent.com/22625602/156445146-12128783-5f04-469f-81ea-06a9c6d4bc0f.png">


### Best Way to Test
1. open a browser that does not have metamask installed
2. navigate to the [example](https://web3-sessions.vercel.app)
3. ensure the loggin button at the bottom is disable and that you see the warning

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New Example
- [ ] New feature in existing example

### New Example Checklist

- [ ] 🚀 Link to deployment URL on Vercel
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
- [ ] 📚 `README.md` preview link in PR description (branch)
- [ ] ⚙️ Secrets have instructions for how to set up in the readme
- [ ] 🛫 `npm run new-example` was run to create the example
