### PR TITLE
use Script instead of Link in description

### DIFF
--- a/solutions/script-component-ad/pages/index.tsx
+++ b/solutions/script-component-ad/pages/index.tsx
@@ -25,7 +25,7 @@ function Home() {
             href="https://nextjs.org/docs/api-reference/next/script"
             target="_blank"
           >
-            Next/Link
+            Next/Script
           </Link>{' '}
           comes into play.
         </Text>


### PR DESCRIPTION
### Description

Correct typo/mistake in the description for 

link do folder: https://github.com/vercel/examples/tree/main/solutions/script-component-ad
before demo: https://solutions-script-component-ad.vercel.app/


### Best Way to Test

<!--
  Give a quick description of steps to test your changes. For examples a deployment URL allows us to jump directly to it.
-->

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New Example
- [ ] New feature in existing example

### New Example Checklist

- [ ] 🚀 Link to deployment URL on Vercel
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
- [x] 📚 `README.md` preview link in PR description (branch)
- [ ] ⚙️ Secrets have instructions for how to set up in the readme
- [ ] 🛫 `npm run new-example` was run to create the example
