### PR TITLE
Exclude `lib/splits.json` from the `feature-flag-split` example

### DIFF
--- a/edge-functions/feature-flag-split/.gitignore
+++ b/edge-functions/feature-flag-split/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # Vercel
 .vercel
+
+# Split
+lib/splits.json


### PR DESCRIPTION
### Description

Running the example locally adds `lib/splits.json` to git changes, but adding it to Git shouldn't be needed at all.