### PR TITLE
Update `.gitignore` in all examples to not ignore `.env`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/ab-testing-google-optimize/.gitignore
+++ b/edge-functions/ab-testing-google-optimize/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/ab-testing-simple/.gitignore
+++ b/edge-functions/ab-testing-simple/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/add-header/.gitignore
+++ b/edge-functions/add-header/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/api-rate-limit-and-tokens/.gitignore
+++ b/edge-functions/api-rate-limit-and-tokens/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/api-rate-limit/.gitignore
+++ b/edge-functions/api-rate-limit/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/basic-auth-password/.gitignore
+++ b/edge-functions/basic-auth-password/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/bot-protection-botd/.gitignore
+++ b/edge-functions/bot-protection-botd/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/bot-protection-datadome/.gitignore
+++ b/edge-functions/bot-protection-datadome/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/clerk-authentication/.gitignore
+++ b/edge-functions/clerk-authentication/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/cookies/.gitignore
+++ b/edge-functions/cookies/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/cors/.gitignore
+++ b/edge-functions/cors/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/crypto/.gitignore
+++ b/edge-functions/crypto/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/feature-flag-apple-store/.gitignore
+++ b/edge-functions/feature-flag-apple-store/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/feature-flag-configcat/.gitignore
+++ b/edge-functions/feature-flag-configcat/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/feature-flag-posthog/.gitignore
+++ b/edge-functions/feature-flag-posthog/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/feature-flag-split/.gitignore
+++ b/edge-functions/feature-flag-split/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/geolocation-country-block/.gitignore
+++ b/edge-functions/geolocation-country-block/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/geolocation/.gitignore
+++ b/edge-functions/geolocation/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/hostname-rewrites/.gitignore
+++ b/edge-functions/hostname-rewrites/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/i18n/.gitignore
+++ b/edge-functions/i18n/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/image-response/.gitignore
+++ b/edge-functions/image-response/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/ip-blocking-datadome/.gitignore
+++ b/edge-functions/ip-blocking-datadome/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/json-response/.gitignore
+++ b/edge-functions/json-response/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/jwt-authentication/.gitignore
+++ b/edge-functions/jwt-authentication/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/next-news/.gitignore
+++ b/edge-functions/next-news/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/personalization-builder-io/.gitignore
+++ b/edge-functions/personalization-builder-io/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/power-parity-pricing-strategies/.gitignore
+++ b/edge-functions/power-parity-pricing-strategies/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/power-parity-pricing/.gitignore
+++ b/edge-functions/power-parity-pricing/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/query-params-filter/.gitignore
+++ b/edge-functions/query-params-filter/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/redirects-upstash/.gitignore
+++ b/edge-functions/redirects-upstash/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/edge-functions/rewrites-upstash/.gitignore
+++ b/edge-functions/rewrites-upstash/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/solutions/auth-with-ory/.gitignore
+++ b/solutions/auth-with-ory/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/solutions/domains-api/.gitignore
+++ b/solutions/domains-api/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/solutions/image-offset/.gitignore
+++ b/solutions/image-offset/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/solutions/mint-nft/.gitignore
+++ b/solutions/mint-nft/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/solutions/monorepo/.gitignore
+++ b/solutions/monorepo/.gitignore
@@ -26,7 +26,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/solutions/reduce-image-bandwidth-usage/.gitignore
+++ b/solutions/reduce-image-bandwidth-usage/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/solutions/static-tweets-tailwind/.gitignore
+++ b/solutions/static-tweets-tailwind/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/solutions/subdomain-auth/.gitignore
+++ b/solutions/subdomain-auth/.gitignore
@@ -25,7 +25,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Local ENV files
-.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
### Description

`.env` is okay to be on a repository, it's `.env*.local` the ones that have to be ignored.