### PR TITLE
Removed auth with ory link from README

### DIFF
--- a/edge-functions/README.md
+++ b/edge-functions/README.md
@@ -12,7 +12,6 @@
 - [Add Header](./add-header)
 - [API Rate Limit and Tokens](./api-rate-limit-and-tokens)
 - [API Rate Limiting with Upstash](./api-rate-limit)
-- [Auth With Ory](./auth-with-ory)
 - [Basic Auth Password Protection](./basic-auth-password)
 - [Bot Protection Botd](./bot-protection-botd)
 - [Bot Protection Datadome](./bot-protection-datadome)


### PR DESCRIPTION
### Description

I've noticed old link for Auth with Ory in readme file so i removed it

https://github.com/nikola-zdravkovic/examples/blob/main/README.md

### Best Way to Test

<!--
  Give a quick description of steps to test your changes. For examples a deployment URL allows us to jump directly to it.
-->

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New Example
- [ ] New feature in existing example

### New Example Checklist

- [ ] 🚀 Link to deployment URL on Vercel
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
- [x] 📚 `README.md` preview link in PR description (branch)
- [ ] ⚙️ Secrets have instructions for how to set up in the readme
- [ ] 🛫 `npm run new-example` was run to create the example
