### PR TITLE
Update rate-limit examples to use http status 429

### DIFF
--- a/edge-functions/api-rate-limit-and-tokens/lib/rate-limit.ts
+++ b/edge-functions/api-rate-limit-and-tokens/lib/rate-limit.ts
@@ -61,7 +61,7 @@ const rateLimited: OnRateLimit = ({ id }) => {
       error: { message: `API rate limit exceeded for ${id}` },
     }),
     {
-      status: 403,
+      status: 429,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/edge-functions/api-rate-limit/lib/rate-limit.ts
+++ b/edge-functions/api-rate-limit/lib/rate-limit.ts
@@ -61,7 +61,7 @@ const rateLimited: OnRateLimit = ({ id }) => {
       error: { message: `API rate limit exceeded for ${id}` },
     }),
     {
-      status: 403,
+      status: 429,
       headers: {
         'Content-Type': 'application/json',
       },


### PR DESCRIPTION
### Description

While trying out the rate limit examples I noticed the http response returned once reaching the limit is using status code `403`. This PR updates that http status to be `429` which is used to represent `too many requests` received.

Great code examples btw. Let me know if you need any more info on this PR.

### Best Way to Test

Run any of the rate limit examples and reach the configured request limit so you can get the rate limited response. 

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New Example
- [ ] New feature in existing example

### New Example Checklist

- [ ] 🚀 Link to deployment URL on Vercel
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
- [ ] 📚 `README.md` preview link in PR description (branch)
- [ ] ⚙️ Secrets have instructions for how to set up in the readme
- [ ] 🛫 `npm run new-example` was run to create the example
