### PR TITLE
Fix root-directory on monorepo example

### DIFF
--- a/solutions/monorepo/README.md
+++ b/solutions/monorepo/README.md
@@ -32,7 +32,7 @@ You can choose from one of the following two methods to use this repository:
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/monorepo&project-name=monorepo&repo-name=monorepo&root-directory=solutions%2Fmonorepo%2Fapp&build-command=cd%20..%20%26%26%20npm%20run%20build&install-command=cd%20..%20%26%26%20npm%20i)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/monorepo&project-name=monorepo&repo-name=monorepo&root-directory=app&build-command=cd%20..%20%26%26%20npm%20run%20build&install-command=cd%20..%20%26%26%20npm%20i)
 
 ## Getting Started
 


### PR DESCRIPTION
The monorepo example's deploy button was using the root directory of  the examples repo. That was preventing it to work on the cloned repo

### Description

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

<!-- Link to readme.md on your branch -->

1. click on the deploy button
2. follow the full deployment sequence and verify everything deploys

### Best Way to Test

<!--
  Give a quick description of steps to test your changes. For examples a deployment URL allows us to jump directly to it.
-->

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New Example
- [ ] New feature in existing example

### New Example Checklist

- [ ] 🚀 Link to deployment URL on Vercel
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
- [ ] 📚 `README.md` preview link in PR description (branch)
- [ ] ⚙️ Secrets have instructions for how to set up in the readme
- [ ] 🛫 `npm run new-example` was run to create the example
