### PR TITLE
remove link to vercel.com

### DIFF
--- a/build-output-api/README.md
+++ b/build-output-api/README.md
@@ -1,8 +1,6 @@
 <p align="center">
-  <a href="https://vercel.com">
-    <img src="https://assets.vercel.com/image/upload/v1588805858/repositories/vercel/logo.png" height="96">
-    <h3 align="center">Build Output API Examples</h3>
-  </a>
+  <img src="https://assets.vercel.com/image/upload/v1588805858/repositories/vercel/logo.png" height="96">
+  <h3 align="center">Build Output API Examples</h3>
 </p>
 
 This directory contains examples of "prebuilt" Projects that conform to the Build Output API.


### PR DESCRIPTION
This link doesn't seem to be doing anything useful. Should it link somewhere else or be removed? This PR removes it.