### PR TITLE
link to Build Output API v3 docs

### DIFF
--- a/build-output-api/README.md
+++ b/build-output-api/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://vercel.com">
+  <a href="https://vercel.com/docs/build-output-api/v3">
     <img src="https://assets.vercel.com/image/upload/v1588805858/repositories/vercel/logo.png" height="96">
     <h3 align="center">Build Output API Examples</h3>
   </a>

--- a/build-output-api/edge-functions/README.md
+++ b/build-output-api/edge-functions/README.md
@@ -2,7 +2,7 @@
 
 ### Build Output API
 
-This Prebuilt Deployment example demonstrates how to output Vercel Edge Functions using the Build Output API.
+This Prebuilt Deployment example demonstrates how to output Vercel Edge Functions using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/edge-functions).
 
 In this case, the contents of the Edge Function are located in the
 [`.vercel/output/functions/index.func`](./.vercel/output/functions/index.func) directory,

--- a/build-output-api/routes/README.md
+++ b/build-output-api/routes/README.md
@@ -2,7 +2,7 @@
 
 ### Build Output API
 
-This Prebuilt Deployment example demonstrates how to output Vercel Routes using the Build Output API.
+This Prebuilt Deployment example demonstrates how to output Vercel Routes using the [Build Output API](https://vercel.com/docs/build-output-api/v3#build-output-configuration/routes).
 
 Routing configuration is specified in the [`.vercel/output/config.json`](./.vercel/output/config.json) file under
 the `routes` property.

--- a/build-output-api/serverless-functions/README.md
+++ b/build-output-api/serverless-functions/README.md
@@ -2,7 +2,7 @@
 
 ### Build Output API
 
-This Prebuilt Deployment example demonstrates how to output Vercel Serverless Functions using the Build Output API.
+This Prebuilt Deployment example demonstrates how to output Vercel Serverless Functions using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/serverless-functions).
 
 In this case, the contents of the Serverless Function are located in the
 [`.vercel/output/functions/index.func`](./.vercel/output/functions/index.func) directory,

--- a/build-output-api/static-files/README.md
+++ b/build-output-api/static-files/README.md
@@ -2,7 +2,7 @@
 
 ### Build Output API
 
-This Prebuilt Deployment example demonstrates how to output static files in a Deployment using the Build Output API.
+This Prebuilt Deployment example demonstrates how to output static files in a Deployment using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/static-files).
 
 The [`.vercel/output/static`](./.vercel/output/static) directory contains static files which will
 be served globally by the [Vercel Edge Network](https://vercel.com/docs/concepts/edge-network/overview).


### PR DESCRIPTION
Add links to the Build Output API v3 docs in relevant places.

https://vercel.com/docs/build-output-api/v3