### PR TITLE
[build-output-api] Add Demo URLs

### DIFF
--- a/build-output-api/edge-functions/README.md
+++ b/build-output-api/edge-functions/README.md
@@ -1,10 +1,14 @@
 # Edge Functions
 
-### Build Output API
-
-#### [Demo](https://build-output-api-edge-functions.vercel.sh)
+## Build Output API
 
 This Prebuilt Deployment example demonstrates how to output Vercel Edge Functions using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/edge-functions).
+
+### Demo
+
+https://build-output-api-edge-functions.vercel.sh
+
+### How it Works
 
 In this case, the contents of the Edge Function are located in the
 [`.vercel/output/functions/index.func`](./.vercel/output/functions/index.func) directory,

--- a/build-output-api/edge-functions/README.md
+++ b/build-output-api/edge-functions/README.md
@@ -2,6 +2,8 @@
 
 ### Build Output API
 
+#### [Demo](https://build-output-api-edge-functions.vercel.sh)
+
 This Prebuilt Deployment example demonstrates how to output Vercel Edge Functions using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/edge-functions).
 
 In this case, the contents of the Edge Function are located in the

--- a/build-output-api/edge-middleware/README.md
+++ b/build-output-api/edge-middleware/README.md
@@ -1,10 +1,14 @@
 # Edge Middleware
 
-### Build Output API
-
-#### [Demo](https://build-output-api-edge-middleware.vercel.sh)
+## Build Output API
 
 This Prebuilt Deployment example demonstrates how to output Vercel Middleware using the [Build Output API](https://vercel.com/docs/build-output-api/v3#features/edge-middleware).
+
+### Demo
+
+https://build-output-api-edge-middleware.vercel.sh
+
+### How it Works
 
 In this case, the contents of the Edge Middleware Function are located in the
 [`.vercel/output/functions/_middleware.func`](./.vercel/output/functions/_middleware.func) directory.

--- a/build-output-api/edge-middleware/README.md
+++ b/build-output-api/edge-middleware/README.md
@@ -2,6 +2,8 @@
 
 ### Build Output API
 
+#### [Demo](https://build-output-api-edge-middleware.vercel.sh)
+
 This Prebuilt Deployment example demonstrates how to output Vercel Middleware using the [Build Output API](https://vercel.com/docs/build-output-api/v3#features/edge-middleware).
 
 In this case, the contents of the Edge Middleware Function are located in the

--- a/build-output-api/image-optimization/.vercel/output/static/index.html
+++ b/build-output-api/image-optimization/.vercel/output/static/index.html
@@ -1,7 +1,7 @@
 <h1>Vercel Image Optimization Example</h1>
 <h2>From my trip to Rio!</h2>
 <div>
-  <img src="/_vercel/image?url=%2Fimages%2Frio.jpeg&w=1000&q=75" width="500" />
+  <img src="/_vercel/image?url=%2Fimages%2Frio.jpeg&w=1000&q=75" width="500" height="375" />
 </div>
 <p>
   This image was uploaded to Vercel as a 3.9mb unoptimized image, but when

--- a/build-output-api/image-optimization/README.md
+++ b/build-output-api/image-optimization/README.md
@@ -2,6 +2,8 @@
 
 ### Build Output API
 
+#### [Demo](https://build-output-api-image-optimization.vercel.sh)
+
 This Prebuilt Deployment example demonstrates how leverage the [Vercel Image Optimization](https://vercel.com/docs/concepts/image-optimization) platform feature using the [Build Output API](https://vercel.com/docs/build-output-api/v3#build-output-configuration/images).
 
 - The [`.vercel/output/static`](./.vercel/output/static) directory contains some (unoptimized) static image files, and an `index.html` page.

--- a/build-output-api/image-optimization/README.md
+++ b/build-output-api/image-optimization/README.md
@@ -1,10 +1,14 @@
 # Image Optimization
 
-### Build Output API
-
-#### [Demo](https://build-output-api-image-optimization.vercel.sh)
+## Build Output API
 
 This Prebuilt Deployment example demonstrates how leverage the [Vercel Image Optimization](https://vercel.com/docs/concepts/image-optimization) platform feature using the [Build Output API](https://vercel.com/docs/build-output-api/v3#build-output-configuration/images).
+
+### Demo
+
+https://build-output-api-image-optimization.vercel.sh
+
+### How it Works
 
 - The [`.vercel/output/static`](./.vercel/output/static) directory contains some (unoptimized) static image files, and an `index.html` page.
 - The [`.vercel/output/config.json`](./.vercel/output/config.json) file contains the "images" property which configures the Image Optimization feature.

--- a/build-output-api/overrides/README.md
+++ b/build-output-api/overrides/README.md
@@ -1,10 +1,14 @@
 # Static File Overrides
 
-### Build Output API
-
-#### [Demo](https://build-output-api-overrides.vercel.sh)
+## Build Output API
 
 This Prebuilt Deployment example demonstrates how to override configuration of static files in a Deployment using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/static-files).
+
+### Demo
+
+https://build-output-api-overrides.vercel.sh
+
+### How it Works
 
 The [`.vercel/output/static`](./.vercel/output/static) directory contains static files, _however_ due to the "overrides"
 property in the [`.vercel/output/config.json`]('./.vercel/output/config.json) file, these files are _served_ by Vercel

--- a/build-output-api/overrides/README.md
+++ b/build-output-api/overrides/README.md
@@ -2,6 +2,8 @@
 
 ### Build Output API
 
+#### [Demo](https://build-output-api-overrides.vercel.sh)
+
 This Prebuilt Deployment example demonstrates how to override configuration of static files in a Deployment using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/static-files).
 
 The [`.vercel/output/static`](./.vercel/output/static) directory contains static files, _however_ due to the "overrides"

--- a/build-output-api/prerender-functions/README.md
+++ b/build-output-api/prerender-functions/README.md
@@ -1,10 +1,14 @@
 # Prerender Functions
 
-### Build Output API
-
-#### [Demo](https://build-output-api-prerender-functions.vercel.sh)
+## Build Output API
 
 This Prebuilt Deployment example demonstrates how to output Vercel Serverless Functions that leverage the "prerender" feature using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/prerender-functions).
+
+### Demo
+
+https://build-output-api-prerender-functions.vercel.sh
+
+### How it Works
 
 In this example, the Prerender function renders blog posts from an imaginary CMS "backend service". There are a few "popular" blog posts that are prerendered at build-time and placed into the `static` directory.
 

--- a/build-output-api/prerender-functions/README.md
+++ b/build-output-api/prerender-functions/README.md
@@ -2,6 +2,8 @@
 
 ### Build Output API
 
+#### [Demo](https://build-output-api-prerender-functions.vercel.sh)
+
 This Prebuilt Deployment example demonstrates how to output Vercel Serverless Functions that leverage the "prerender" feature using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/prerender-functions).
 
 In this example, the Prerender function renders blog posts from an imaginary CMS "backend service". There are a few "popular" blog posts that are prerendered at build-time and placed into the `static` directory.

--- a/build-output-api/preview-mode/README.md
+++ b/build-output-api/preview-mode/README.md
@@ -1,10 +1,14 @@
 # Preview Mode
 
-### Build Output API
-
-#### [Demo](https://build-output-api-preview-mode.vercel.sh)
+## Build Output API
 
 This Prebuilt Deployment example demonstrates how to implement "Preview Mode" when using the [Build Output API](https://vercel.com/docs/build-output-api/v3#features/preview-mode).
+
+### Demo
+
+https://build-output-api-preview-mode.vercel.sh
+
+### How it Works
 
 When using Prerender Functions, you may want to implement "Preview Mode" which would allow you to bypass the caching
 aspect of prerender functions, i.e. while writing draft blog posts before they are ready to be published.

--- a/build-output-api/preview-mode/README.md
+++ b/build-output-api/preview-mode/README.md
@@ -2,6 +2,8 @@
 
 ### Build Output API
 
+#### [Demo](https://build-output-api-preview-mode.vercel.sh)
+
 This Prebuilt Deployment example demonstrates how to implement "Preview Mode" when using the [Build Output API](https://vercel.com/docs/build-output-api/v3#features/preview-mode).
 
 When using Prerender Functions, you may want to implement "Preview Mode" which would allow you to bypass the caching

--- a/build-output-api/routes/README.md
+++ b/build-output-api/routes/README.md
@@ -2,6 +2,8 @@
 
 ### Build Output API
 
+#### [Demo](https://build-output-api-routes.vercel.sh)
+
 This Prebuilt Deployment example demonstrates how to output Vercel Routes using the [Build Output API](https://vercel.com/docs/build-output-api/v3#build-output-configuration/routes).
 
 Routing configuration is specified in the [`.vercel/output/config.json`](./.vercel/output/config.json) file under

--- a/build-output-api/routes/README.md
+++ b/build-output-api/routes/README.md
@@ -1,10 +1,14 @@
 # Routes
 
-### Build Output API
-
-#### [Demo](https://build-output-api-routes.vercel.sh)
+## Build Output API
 
 This Prebuilt Deployment example demonstrates how to output Vercel Routes using the [Build Output API](https://vercel.com/docs/build-output-api/v3#build-output-configuration/routes).
+
+### Demo
+
+https://build-output-api-routes.vercel.sh
+
+### How it Works
 
 Routing configuration is specified in the [`.vercel/output/config.json`](./.vercel/output/config.json) file under
 the `routes` property.

--- a/build-output-api/serverless-functions/README.md
+++ b/build-output-api/serverless-functions/README.md
@@ -1,10 +1,14 @@
 # Serverless Functions
 
-### Build Output API
-
-#### [Demo](https://build-output-api-serverless-functions.vercel.sh)
+## Build Output API
 
 This Prebuilt Deployment example demonstrates how to output Vercel Serverless Functions using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/serverless-functions).
+
+### Demo
+
+https://build-output-api-serverless-functions.vercel.sh
+
+### How it Works
 
 In this case, the contents of the Serverless Function are located in the
 [`.vercel/output/functions/index.func`](./.vercel/output/functions/index.func) directory.

--- a/build-output-api/serverless-functions/README.md
+++ b/build-output-api/serverless-functions/README.md
@@ -2,6 +2,8 @@
 
 ### Build Output API
 
+#### [Demo](https://build-output-api-serverless-functions.vercel.sh)
+
 This Prebuilt Deployment example demonstrates how to output Vercel Serverless Functions using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/serverless-functions).
 
 In this case, the contents of the Serverless Function are located in the

--- a/build-output-api/static-files/README.md
+++ b/build-output-api/static-files/README.md
@@ -2,6 +2,8 @@
 
 ### Build Output API
 
+#### [Demo](https://build-output-api-static-files.vercel.sh)
+
 This Prebuilt Deployment example demonstrates how to output static files in a Deployment using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/static-files).
 
 The [`.vercel/output/static`](./.vercel/output/static) directory contains static files which will

--- a/build-output-api/static-files/README.md
+++ b/build-output-api/static-files/README.md
@@ -1,10 +1,14 @@
 # Static Files
 
-### Build Output API
-
-#### [Demo](https://build-output-api-static-files.vercel.sh)
+## Build Output API
 
 This Prebuilt Deployment example demonstrates how to output static files in a Deployment using the [Build Output API](https://vercel.com/docs/build-output-api/v3#vercel-primitives/static-files).
+
+### Demo
+
+https://build-output-api-static-files.vercel.sh
+
+### How it Works
 
 The [`.vercel/output/static`](./.vercel/output/static) directory contains static files which will
 be served globally by the [Vercel Edge Network](https://vercel.com/docs/concepts/edge-network/overview).

--- a/build-output-api/wildcard/README.md
+++ b/build-output-api/wildcard/README.md
@@ -1,8 +1,8 @@
 # Domain-Based Routing
 
-#### [Demo](https://build-output-api-wildcard.vercel.sh)
-
 ### Build Output API
+
+#### [Demo](https://build-output-api-wildcard.vercel.sh)
 
 This Prebuilt Deployment example demonstrates how to use configure routing rules based on which domain name
 was requested, when using the

--- a/build-output-api/wildcard/README.md
+++ b/build-output-api/wildcard/README.md
@@ -1,12 +1,16 @@
 # Domain-Based Routing
 
-### Build Output API
-
-#### [Demo](https://build-output-api-wildcard.vercel.sh)
+## Build Output API
 
 This Prebuilt Deployment example demonstrates how to use configure routing rules based on which domain name
 was requested, when using the
 [Build Output API](https://vercel.com/docs/build-output-api/v3#build-output-configuration/wildcard).
+
+### Demo
+
+https://build-output-api-wildcard.vercel.sh
+
+### How it Works
 
 The "wildcards" configuration in the [`.vercel/output/config.json`](./.vercel/output/config.json) file allows you to configure
 any number of domain names (or sub-domains) that point to the same Deployment to route to specific pages based on the domain

--- a/build-output-api/wildcard/README.md
+++ b/build-output-api/wildcard/README.md
@@ -1,5 +1,7 @@
 # Domain-Based Routing
 
+#### [Demo](https://build-output-api-wildcard.vercel.sh)
+
 ### Build Output API
 
 This Prebuilt Deployment example demonstrates how to use configure routing rules based on which domain name


### PR DESCRIPTION
Adds a `Demo` link to all of the Build Output API examples' README.md files.