### PR TITLE
basic-password | Remove the use of Buffer module for atob

### DIFF
--- a/edge-functions/basic-auth-password/pages/_middleware.ts
+++ b/edge-functions/basic-auth-password/pages/_middleware.ts
@@ -5,7 +5,7 @@ export function middleware(req: NextRequest) {
 
   if (basicAuth) {
     const auth = basicAuth.split(' ')[1]
-    const [user, pwd] = Buffer.from(auth, 'base64').toString().split(':')
+    const [user, pwd] = atob(auth).split(":")
 
     if (user === '4dmin' && pwd === 'testpwd123') {
       return NextResponse.next()


### PR DESCRIPTION
Per the edge doc, Buffer is not included in the runtime: https://nextjs.org/docs/api-reference/edge-runtime

### Description

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

The latest next version as of this writing will not allow global.Buffer to be used in the edge function. This work replace Buffer with atob call for the decoding of the basic auth data.

<!-- Link to readme.md on your branch -->

### Best Way to Test

<!--
  Give a quick description of steps to test your changes. For examples a deployment URL allows us to jump directly to it.
-->

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New Example
- [ ] New feature in existing example

### New Example Checklist

- [ ] 🚀 Link to deployment URL on Vercel
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
- [ ] 📚 `README.md` preview link in PR description (branch)
- [ ] ⚙️ Secrets have instructions for how to set up in the readme
- [ ] 🛫 `npm run new-example` was run to create the example

--[/U64eCftcNBXxHZRu3](https://www.plasmo.com/engineering/log/2022.05#update-2022.05.04)