### PR TITLE
Fix dark theme for Static Tweets Tailwind demo

### DIFF
--- a/solutions/static-tweets-tailwind/components/Tweet.js
+++ b/solutions/static-tweets-tailwind/components/Tweet.js
@@ -1,7 +1,7 @@
 import BlurImage from './BlurImage'
+import cn from 'clsx'
 import { format } from 'date-fns'
 import { useState } from 'react'
-import cn from 'clsx'
 
 function getRemainingTime(ISOString) {
   const currentTime = new Date()
@@ -77,7 +77,7 @@ export default function Tweet({ id, metadata, className }) {
 
   return (
     <div
-      className={`${className} tweet rounded-lg border border-gray-300 dark:border-gray-800 bg-white px-8 pt-6 pb-2 my-4 w-full`}
+      className={`${className} tweet rounded-lg border border-gray-300 dark:border-gray-800 bg-white dark:bg-black px-8 pt-6 pb-2 my-4 w-full`}
     >
       <div className="flex items-center">
         <a

--- a/solutions/static-tweets-tailwind/pages/_document.js
+++ b/solutions/static-tweets-tailwind/pages/_document.js
@@ -1,0 +1,13 @@
+import { Head, Html, Main, NextScript } from 'next/document';
+
+export default function Document(props) {
+  return (
+    <Html lang="en">
+      <Head />
+      <body className="bg-white dark:bg-black">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/solutions/static-tweets-tailwind/pages/index.js
+++ b/solutions/static-tweets-tailwind/pages/index.js
@@ -1,9 +1,9 @@
 import Head from 'next/head'
 import Image from 'next/image'
-import { serialize } from 'next-mdx-remote/serialize'
 import { MDXRemote } from 'next-mdx-remote'
 import Tweet from '@/components/Tweet'
 import { getTweets } from '@/lib/twitter'
+import { serialize } from 'next-mdx-remote/serialize'
 
 const components = {
   Tweet,
@@ -23,7 +23,7 @@ export default function Home(props) {
         rel="noreferrer"
         className="fixed top-5 right-5"
       >
-        <Image src="/github.svg" alt="Github" width={25} height={25} />
+        <Image src="/github.svg" alt="Github" width={25} height={25} className="bg-white rounded-full" />
       </a>
 
       <main className="flex flex-col items-center justify-center w-full flex-1">
@@ -51,23 +51,23 @@ export default function Home(props) {
 
 export async function getStaticProps() {
   const contentHtml = `
-  <h2>Regular Tweets</h2>
+  <h2 className="text-black dark:text-white">Regular Tweets</h2>
   <p>https://twitter.com/steventey/status/1438526338567081984?s=20</p>
-  <h2>Image Tweets</h2>
+  <h2 className="text-black dark:text-white">Image Tweets</h2>
   <p>https://twitter.com/steventey/status/1460689767289405444?s=20</p>
-  <h2>GIF Tweets</h2>
+  <h2 className="text-black dark:text-white">GIF Tweets</h2>
   <p>https://twitter.com/steventey/status/1473329920470355976?s=20</p>
-  <h2>Video Tweets</h2>
+  <h2 className="text-black dark:text-white">Video Tweets</h2>
   <p>https://twitter.com/DAOCentral/status/1474469391232237569</p>
-  <h2>Multiple Images</h2>
+  <h2 className="text-black dark:text-white">Multiple Images</h2>
   <p>https://twitter.com/jstngraphics/status/1477021464620515328?s=20</p>
-  <h2>Link Preview</h2>
+  <h2 className="text-black dark:text-white">Link Preview</h2>
   <p>https://twitter.com/steventey/status/1463554409242062849?s=20</p>
-  <h2>Quote Retweet</h2>
+  <h2 className="text-black dark:text-white">Quote Retweet</h2>
   <p>https://twitter.com/steventey/status/1472640347914137606?s=20</p>
-  <h2>Quote Retweet with Image In Parent</h2>
+  <h2 className="text-black dark:text-white">Quote Retweet with Image In Parent</h2>
   <p>https://twitter.com/steventey/status/1467713086459047940?s=20</p>
-  <h2>Poll Tweet</h2>
+  <h2 className="text-black dark:text-white">Poll Tweet</h2>
   <p>https://twitter.com/DAOCentral/status/1475184169588125699</p>
   `
 


### PR DESCRIPTION
### Description

**Before**
![Screenshot 2022-05-12 at 12 50 26](https://user-images.githubusercontent.com/416456/168055736-3cb35026-56b3-44d1-9528-4107405104a0.png)

**After**
![Screenshot 2022-05-12 at 12 49 28](https://user-images.githubusercontent.com/416456/168055754-0d3c8138-2819-42fc-99f7-4703b995b17d.png)


The Static Tweets Tailwind demo isn't legible when using a dark theme. This PR fixes it by providing the needed tailwind css classes to improve it.



An alternative solution is to remove the dark CSS modifiers altogether to keep the same UI for both light and dark. I figured out it would still be valuable to keep a dark theme, but feel free to suggest the alternative, which would simplify the code slightly.

### Best Way to Test

Run the project from the static-tweets-tailwind folder with dark theme enabled in the OS settings.

### Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New Example
- [ ] New feature in existing example
