### PR TITLE
Add `await` keyword to cache.set() function

### DIFF
--- a/solutions/reuse-responses/pages/index.tsx
+++ b/solutions/reuse-responses/pages/index.tsx
@@ -171,7 +171,7 @@ export const getStaticProps = async ({params}) => {
       return products.find((product) => product.id === id)
     },
     set: async (products: Product[]) => {
-      return fs.writeFile(
+      return await fs.writeFile(
         path.join(process.cwd(), 'products.db'),
         JSON.stringify(products)
       )


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->
This is just a very tiny fix. In the code snippet of the home page article, the `set` method for interacting with the cache  misses the `await` keyword in the body.

```
const api = {
  cache: {
    set: async (products: Product[]) => {
      return fs.writeFile(
        path.join(process.cwd(), 'products.db'),
        JSON.stringify(products)
      )
    },
  }
}
```

<!-- Link to readme.md on your branch -->

### Best Way to Test

<!--
  Give a quick description of steps to test your changes. For examples a deployment URL allows us to jump directly to it.
-->

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New Example
- [] New feature in existing example

### New Example Checklist

- [ ] 🚀 Link to deployment URL on Vercel
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
- [ ] 📚 `README.md` preview link in PR description (branch)
- [ ] ⚙️ Secrets have instructions for how to set up in the readme
- [ ] 🛫 `npm run new-example` was run to create the example
