### PR TITLE
remove middleware for something that can be done with a regular rewrite

### DIFF
--- a/edge-functions/next-news/next.config.mjs
+++ b/edge-functions/next-news/next.config.mjs
@@ -1,4 +1,12 @@
 export default {
   reactStrictMode: true,
   swcMinify: true,
+  async rewrites() {
+    return [
+      {
+        source: '/',
+        destination: '/news/1',
+      },
+    ]
+  },
 }

--- a/edge-functions/next-news/pages/_middleware.ts
+++ b/edge-functions/next-news/pages/_middleware.ts
@@ -1,9 +1,0 @@
-import { NextResponse, NextRequest } from 'next/server'
-
-export default function middleware(req: NextRequest) {
-  const url = req.nextUrl.clone()
-  if (url.pathname === '/') {
-    url.pathname = '/news/1'
-    return NextResponse.rewrite(url)
-  }
-}


### PR DESCRIPTION
### Description

removes middleware from next-news as it was a permanent rewrite that could be done in Next config.

<!-- Link to readme.md on your branch -->

### Best Way to Test

1. go to index page
2. check that you get '/news/1' as the page


### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New Example
- [ ] New feature in existing example

### New Example Checklist

- [ ] 🚀 Link to deployment URL on Vercel
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
- [ ] 📚 `README.md` preview link in PR description (branch)
- [ ] ⚙️ Secrets have instructions for how to set up in the readme
- [ ] 🛫 `npm run new-example` was run to create the example
