### PR TITLE
[documentation] rename function in example to be clearer

### DIFF
--- a/build-output-api/edge-functions/.vercel/output/functions/index.func/index.js
+++ b/build-output-api/edge-functions/.vercel/output/functions/index.func/index.js
@@ -1,3 +1,3 @@
-export default function middleware(request, event) {
+export default function index(request, event) {
   return new Response(`Hello, from the Edge!`)
 }


### PR DESCRIPTION
This function calls itself `middleware`, but it's not. Let's not confuse anyone.

I called it `index` because that's the directory name.