### PR TITLE
Updated demo URLs in Microfrontends example

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Learn how to add code owners here:
 # https://help.github.com/en/articles/about-code-owners
 
-* @okbel @lfades @goncy @gbibeaul @dominiksipowicz
+* @okbel @lfades @goncy @GuiBibeau @dominiksipowicz
 solutions/monorepo @jaredpalmer @gaspar09 @gsoltis @becca
 solutions/microfrontends @jaredpalmer @gaspar09 @gsoltis @becca
 build-output-api @tootallnate @styfle @EndangeredMassa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,5 @@
 
 * @okbel @lfades @goncy @gbibeaul @dominiksipowicz
 solutions/monorepo @jaredpalmer @gaspar09 @gsoltis @becca
+solutions/microfrontends @jaredpalmer @gaspar09 @gsoltis @becca
 build-output-api @tootallnate @styfle @EndangeredMassa

--- a/solutions/microfrontends/.npmrc
+++ b/solutions/microfrontends/.npmrc
@@ -1,0 +1,2 @@
+# Enabled to avoid deps failing to use next@canary
+legacy-peer-deps=true

--- a/solutions/microfrontends/README.md
+++ b/solutions/microfrontends/README.md
@@ -19,7 +19,7 @@ We recommend reading the [How it works](#how-it-works) section to understand the
 
 ## Demo
 
-https://microfrontends.vercel.app
+https://solutions-microfrontends.vercel.app
 
 ### One-Click Deploy
 

--- a/solutions/microfrontends/apps/main/.env
+++ b/solutions/microfrontends/apps/main/.env
@@ -1,2 +1,2 @@
 # Replace this URL with the URL of your Docs app
-DOCS_URL="https://microfrontends-docs.vercel.app"
+DOCS_URL="https://solutions-microfrontends-docs.vercel.app"


### PR DESCRIPTION
### Description

Previously I wasn't able to add https://microfrontends.vercel.app to domains because the project didn't have a git project setup (the example wasn't merged yet), but now looks like the domain is owned by another team.

Also edited the codeowners for this example to include the Turbo team.

### Type of Change

- [x] Example update