### PR TITLE
Add `root: true` to every eslintrc

### DIFF
--- a/edge-functions/ab-testing-google-optimize/.eslintrc.json
+++ b/edge-functions/ab-testing-google-optimize/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/ab-testing-simple/.eslintrc.json
+++ b/edge-functions/ab-testing-simple/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/ab-testing-statsig/.eslintrc.json
+++ b/edge-functions/ab-testing-statsig/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/add-header/.eslintrc.json
+++ b/edge-functions/add-header/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/api-rate-limit-and-tokens/.eslintrc.json
+++ b/edge-functions/api-rate-limit-and-tokens/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/api-rate-limit/.eslintrc.json
+++ b/edge-functions/api-rate-limit/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/basic-auth-password/.eslintrc.json
+++ b/edge-functions/basic-auth-password/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/bot-protection-botd/.eslintrc.json
+++ b/edge-functions/bot-protection-botd/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/bot-protection-datadome/.eslintrc.json
+++ b/edge-functions/bot-protection-datadome/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/clerk-authentication/.eslintrc.json
+++ b/edge-functions/clerk-authentication/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/cookies/.eslintrc.json
+++ b/edge-functions/cookies/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/cors/.eslintrc.json
+++ b/edge-functions/cors/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/crypto/.eslintrc.json
+++ b/edge-functions/crypto/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/feature-flag-apple-store/.eslintrc.json
+++ b/edge-functions/feature-flag-apple-store/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/feature-flag-configcat/.eslintrc.json
+++ b/edge-functions/feature-flag-configcat/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/feature-flag-optimizely/.eslintrc.json
+++ b/edge-functions/feature-flag-optimizely/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/feature-flag-posthog/.eslintrc.json
+++ b/edge-functions/feature-flag-posthog/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/feature-flag-split/.eslintrc.json
+++ b/edge-functions/feature-flag-split/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/geolocation-country-block/.eslintrc.json
+++ b/edge-functions/geolocation-country-block/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/geolocation/.eslintrc.json
+++ b/edge-functions/geolocation/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/hostname-rewrites/.eslintrc.json
+++ b/edge-functions/hostname-rewrites/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/image-response/.eslintrc.json
+++ b/edge-functions/image-response/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/ip-blocking-datadome/.eslintrc.json
+++ b/edge-functions/ip-blocking-datadome/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/json-response/.eslintrc.json
+++ b/edge-functions/json-response/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/jwt-authentication/.eslintrc.json
+++ b/edge-functions/jwt-authentication/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/maintenance-page/.eslintrc.json
+++ b/edge-functions/maintenance-page/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/next-news/.eslintrc.json
+++ b/edge-functions/next-news/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/personalization-builder-io/.eslintrc.json
+++ b/edge-functions/personalization-builder-io/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/power-parity-pricing-strategies/.eslintrc.json
+++ b/edge-functions/power-parity-pricing-strategies/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/power-parity-pricing/.eslintrc.json
+++ b/edge-functions/power-parity-pricing/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/query-params-filter/.eslintrc.json
+++ b/edge-functions/query-params-filter/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/redirects-upstash/.eslintrc.json
+++ b/edge-functions/redirects-upstash/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/rewrites-upstash/.eslintrc.json
+++ b/edge-functions/rewrites-upstash/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/edge-functions/user-agent-based-rendering/.eslintrc.json
+++ b/edge-functions/user-agent-based-rendering/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/plop-templates/example/.eslintrc.json
+++ b/plop-templates/example/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/auth-with-ory/.eslintrc.json
+++ b/solutions/auth-with-ory/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/aws-s3-image-upload/.eslintrc.json
+++ b/solutions/aws-s3-image-upload/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/cms-contentstack-commerce/.eslintrc.json
+++ b/solutions/cms-contentstack-commerce/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/combining-data-fetching-strategies/.eslintrc.json
+++ b/solutions/combining-data-fetching-strategies/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/domains-api/.eslintrc.json
+++ b/solutions/domains-api/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/image-fallback/.eslintrc.json
+++ b/solutions/image-fallback/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/image-offset/.eslintrc.json
+++ b/solutions/image-offset/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/loading-web-fonts/.eslintrc.json
+++ b/solutions/loading-web-fonts/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/mint-nft/.eslintrc.json
+++ b/solutions/mint-nft/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/monorepo/.eslintrc.json
+++ b/solutions/monorepo/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/on-demand-isr/.eslintrc.json
+++ b/solutions/on-demand-isr/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/pagination-with-ssg/.eslintrc.json
+++ b/solutions/pagination-with-ssg/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/platforms-slate-supabase/.eslintrc.json
+++ b/solutions/platforms-slate-supabase/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/reduce-image-bandwidth-usage/.eslintrc.json
+++ b/solutions/reduce-image-bandwidth-usage/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/reuse-responses/.eslintrc.json
+++ b/solutions/reuse-responses/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/script-component-ad/.eslintrc.json
+++ b/solutions/script-component-ad/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/script-component-strategies/.eslintrc.json
+++ b/solutions/script-component-strategies/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/static-tweets-tailwind/.eslintrc.json
+++ b/solutions/static-tweets-tailwind/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/subdomain-auth/.eslintrc.json
+++ b/solutions/subdomain-auth/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/web3-authentication/.eslintrc.json
+++ b/solutions/web3-authentication/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/web3-data-fetching/.eslintrc.json
+++ b/solutions/web3-data-fetching/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/solutions/web3-sessions/.eslintrc.json
+++ b/solutions/web3-sessions/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }


### PR DESCRIPTION
### Description

The root directory currently has a `eslintrc` that's used for the examples where it doesn't make sense to have one, but it currently creates a conflict with examples that do have one, adding `root: true` to their eslintrc's makes sure it doesn't go up to the root directory.
