### PR TITLE
Update `title` tag in examples-ui to fix react warnings

### DIFF
--- a/packages/ui/layout.tsx
+++ b/packages/ui/layout.tsx
@@ -19,7 +19,7 @@ const Layout: FC<LayoutProps> = ({
   return (
     <div className="mx-auto h-screen flex flex-col">
       <Head>
-        {title && <title>{title} - Vercel Examples</title>}
+        {title && <title>{`${title} - Vercel Examples`}</title>}
         {description && <meta name="description" content={description} />}
         <link rel="icon" href="/favicon.ico" />
       </Head>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/examples-ui",
-  "version": "0.3.5",
+  "version": "0.3.51",
   "main": "index.tsx",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
### Description

React 18 is complaining about the title element having multiple children, this PR changes the title to do the same thing but using a single template string.

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (changes to the codebase, but not to examples)
