### PR TITLE
On-Demand ISR Example: return when auth fails

### DIFF
--- a/build-output-api/on-demand-isr/.vercel/output/functions/revalidate.func/index.js
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/revalidate.func/index.js
@@ -15,6 +15,7 @@ module.exports = (req, res) => {
   if (authToken !== params.get('authToken')) {
     res.statusCode = 403
     res.end('Not Authorized')
+    return
   }
 
   const host = req.headers.host


### PR DESCRIPTION
### Description

Adds a missing `return` when auth fails in the On-Demand ISR example.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
