### PR TITLE
Updated mentions of middleware paths

### DIFF
--- a/edge-functions/add-header/README.md
+++ b/edge-functions/add-header/README.md
@@ -13,7 +13,7 @@ demoUrl: https://edge-functions-add-header.vercel.app
 
 # Add Header Example
 
-Below is the code from [/middleware.ts](/middleware.ts) showing how to add headers at the edge:
+Below is the code from [middleware.ts](middleware.ts) showing how to add headers at the edge:
 
 ```ts
 import { NextResponse } from 'next/server'

--- a/edge-functions/add-header/package.json
+++ b/edge-functions/add-header/package.json
@@ -17,10 +17,10 @@
   },
   "devDependencies": {
     "@types/node": "^17.0.14",
-    "@types/react": "^17.0.38",
+    "@types/react": "latest",
     "autoprefixer": "^10.4.2",
     "eslint": "^8.9.0",
-    "eslint-config-next": "^12.1.0",
+    "eslint-config-next": "canary",
     "postcss": "^8.4.6",
     "tailwindcss": "^3.0.18",
     "typescript": "^4.5.5"

--- a/edge-functions/cookies/README.md
+++ b/edge-functions/cookies/README.md
@@ -21,7 +21,7 @@ https://edge-functions-cookies.vercel.app
 
 Since you can read cookies on the edge and rewrite the user to a statically generated page, eliminates the need of using getServerSideProps + redirect just to access the cookie, hence improving your site's performance and mantaining the same url.
 
-The magic happens in the [`/middleware.ts` file](/middleware.ts):
+The magic happens in the [`middleware.ts` file](middleware.ts):
 
 ```javascript
 import { NextRequest, NextResponse } from 'next/server'

--- a/edge-functions/cookies/package.json
+++ b/edge-functions/cookies/package.json
@@ -21,7 +21,7 @@
     "@types/react": "^18",
     "autoprefixer": "^10.4.2",
     "eslint": "^8.9.0",
-    "eslint-config-next": "^12.1.0",
+    "eslint-config-next": "canary",
     "postcss": "^8.4.6",
     "tailwindcss": "^3.0.18",
     "typescript": "4.5.5"


### PR DESCRIPTION
### Description

Fix for https://github.com/vercel/examples/pull/312, links to local files that start with `/` are not relative to the readme file.

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
