### PR TITLE
Move to `revalidate` in on-demand-isr

### DIFF
--- a/solutions/on-demand-isr/.npmrc
+++ b/solutions/on-demand-isr/.npmrc
@@ -1,0 +1,2 @@
+# Enabled to avoid deps failing to use next@canary
+legacy-peer-deps=true

--- a/solutions/on-demand-isr/README.md
+++ b/solutions/on-demand-isr/README.md
@@ -13,19 +13,13 @@ https://solutions-on-demand-isr.vercel.app
 
 ## How to Use
 
-### Fill environment variables
-
-Rename .env.example to .env and fill `SECRET` (the secret protecting your `tweets` API route) and `TWITTER_TOKEN` (your app token from https://developer.twitter.com).
-
-### Deploy
-
 You can choose from one of the following two methods to use this repository:
 
 #### One-Click Deploy
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=vercel-examples):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/on-demand-isr&project-name=on-demand-isr&repository-name=on-demand-isr)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/on-demand-isr&project-name=on-demand-isr&repository-name=on-demand-isr&env=TWITTER_TOKEN,TOKEN)
 
 #### Clone and Deploy
 
@@ -36,6 +30,18 @@ npx create-next-app --example https://github.com/vercel/examples/tree/main/solut
 # or
 yarn create next-app --example https://github.com/vercel/examples/tree/main/solutions/on-demand-isr
 ```
+
+#### Set up environment variables
+
+The app uses the Twitter API to fetch tweets in [pages/tweets.tsx](pages/tweets.tsx). You can get a token in https://developer.twitter.com.
+
+Then, rename [`.env.example`](.env.example) to `.env.local` (which will be ignored by Git):
+
+```bash
+cp .env.example .env.local
+```
+
+And update `TWITTER_TOKEN` and `SECRET` (the secret protecting the API route in [pages/api/revalidates/tweets.ts](pages/api/revalidate/tweets.ts)).
 
 Next, run Next.js in development mode:
 

--- a/solutions/on-demand-isr/package.json
+++ b/solutions/on-demand-isr/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@vercel/examples-ui": "latest",
-    "next": "canary",
+    "next": "latest",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/solutions/on-demand-isr/package.json
+++ b/solutions/on-demand-isr/package.json
@@ -10,19 +10,19 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "^0.3.2",
-    "next": "^12.1.0",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "@vercel/examples-ui": "latest",
+    "next": "canary",
+    "react": "latest",
+    "react-dom": "latest"
   },
   "devDependencies": {
     "@types/node": "17.0.14",
-    "@types/react": "17.0.38",
+    "@types/react": "latest",
     "autoprefixer": "^10.4.2",
-    "eslint": "^8.9.0",
-    "eslint-config-next": "^12.1.0",
-    "postcss": "^8.4.6",
-    "tailwindcss": "^3.0.18",
-    "typescript": "4.5.5"
+    "eslint": "^8.16.0",
+    "eslint-config-next": "canary",
+    "postcss": "^8.4.14",
+    "tailwindcss": "^3.0.24",
+    "typescript": "4.7.2"
   }
 }

--- a/solutions/on-demand-isr/package.json
+++ b/solutions/on-demand-isr/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@vercel/examples-ui": "latest",
-    "next": "latest",
+    "next": "canary",
     "react": "latest",
     "react-dom": "latest"
   },

--- a/solutions/on-demand-isr/pages/api/revalidate/index.ts
+++ b/solutions/on-demand-isr/pages/api/revalidate/index.ts
@@ -4,7 +4,6 @@ export default async function handler(
   _req: NextApiRequest,
   res: NextApiResponse
 ) {
-  await res.revalidate
   await res.revalidate('/')
 
   return res.json({ revalidated: true })

--- a/solutions/on-demand-isr/pages/api/revalidate/index.ts
+++ b/solutions/on-demand-isr/pages/api/revalidate/index.ts
@@ -4,7 +4,8 @@ export default async function handler(
   _req: NextApiRequest,
   res: NextApiResponse
 ) {
-  await res.unstable_revalidate('/')
+  await res.revalidate
+  await res.revalidate('/')
 
   return res.json({ revalidated: true })
 }

--- a/solutions/on-demand-isr/pages/api/revalidate/tweets.ts
+++ b/solutions/on-demand-isr/pages/api/revalidate/tweets.ts
@@ -5,7 +5,7 @@ export default async function handler(
   res: NextApiResponse
 ) {
   if (process.env.SECRET === req.headers['x-secret-key']) {
-    await res.unstable_revalidate('/tweets')
+    await res.revalidate('/tweets')
 
     return res.json({ revalidated: true })
   }

--- a/solutions/on-demand-isr/pages/index.tsx
+++ b/solutions/on-demand-isr/pages/index.tsx
@@ -104,9 +104,8 @@ export async function getStaticProps() {
         </Snippet>
         <Text>
           Would not be great if we only regenerate this page when our data
-          changes? Since Next.js 12.1 we can do that using the{' '}
-          <Code>res.unstable_revalidate</Code> (res.revalidate if you come from
-          a future where this feature is already stable) function in our{' '}
+          changes? Since Next.js 12.2.0 we can do that using the{' '}
+          <Code>res.revalidate</Code> function in our{' '}
           <Link href="https://nextjs.org/docs/api-routes/introduction">
             API Routes
           </Link>
@@ -115,7 +114,7 @@ export async function getStaticProps() {
         <Snippet>
           {`export default async function handler(_req, res) {
   // Revalidate our '/' path
-  await res.unstable_revalidate('/')
+  await res.revalidate('/')
 
   // Return a response to confirm everything went ok
   return res.json({revalidated: true})
@@ -131,10 +130,10 @@ export async function getStaticProps() {
           bots, etc. That might fire when our content has been changed.
         </Text>
         <Text>
-          Calling <Code>unstable_revalidate</Code> will run{' '}
-          <Code>getStaticProps</Code> for that path synchronously so we can{' '}
-          <Code>await</Code> it. If you need to revalidate multiple paths you
-          will need to run <Code>unstable_revalidate</Code> once for every path:
+          Calling <Code>revalidate</Code> will run <Code>getStaticProps</Code>{' '}
+          for that path synchronously so we can <Code>await</Code> it. If you
+          need to revalidate multiple paths you will need to run{' '}
+          <Code>revalidate</Code> once for every path:
         </Text>
         <Snippet>
           {`export default async function handler(_req, res) {
@@ -142,7 +141,7 @@ export async function getStaticProps() {
   const paths = await api.pathsToRevalidate()
 
   // Revalidate every path
-  await Promise.all(paths.map(res.unstable_revalidate))
+  await Promise.all(paths.map(res.revalidate))
 
   // Return a response to confirm everything went ok
   return res.json({revalidated: true})
@@ -150,7 +149,7 @@ export async function getStaticProps() {
 `}
         </Snippet>
         <Text>
-          We have to also take in count that revalidating a path will run the{' '}
+          We have to also keep in mind that revalidating a path will run the{' '}
           <Code>getStaticProps</Code> serverless function for that specific
           path, which will count for our{' '}
           <Link href="https://vercel.com/docs/concepts/limits/overview#typical-monthly-usage-guidelines">
@@ -171,7 +170,7 @@ export async function getStaticProps() {
   const paths = await api.pathsToRevalidate()
 
   // Revalidate every path without awaiting
-  paths.forEach(res.unstable_revalidate)
+  paths.forEach(res.revalidate)
 
   // Return a response to confirm everything went ok
   return res.json({revalidated: true})

--- a/solutions/on-demand-isr/pages/tweets.tsx
+++ b/solutions/on-demand-isr/pages/tweets.tsx
@@ -47,7 +47,7 @@ function Tweets({ tweets, date }: Props) {
   // Check the secret
   if (process.env.SECRET === req.headers["x-secret-key"]) {
     // Revalidate /tweets route
-    await res.unstable_revalidate("/tweets")
+    await res.revalidate("/tweets")
 
     // Return a response for debugging
     return res.json({ revalidated: true })

--- a/solutions/on-demand-isr/pages/tweets.tsx
+++ b/solutions/on-demand-isr/pages/tweets.tsx
@@ -1,3 +1,4 @@
+import type { FC } from 'react'
 import type { Tweet as ITweet } from '../types'
 
 import { Layout, Text, Page, Code, Link, Snippet } from '@vercel/examples-ui'
@@ -10,7 +11,7 @@ interface Props {
   date: string
 }
 
-const Tweet: React.VFC<{ tweet: ITweet }> = ({ tweet }) => {
+const Tweet: FC<{ tweet: ITweet }> = ({ tweet }) => {
   return (
     <div className={`flex flex-col shadow-lg overflow-hidden relative p-4`}>
       <Text className="mt-2 text-base leading-6 text-gray-500">
@@ -25,7 +26,10 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
-      tweets,
+      tweets: tweets.map((tweet) => ({
+        ...tweet,
+        text: encodeURIComponent(tweet.text),
+      })),
       date: new Date().toTimeString(),
     },
   }
@@ -39,8 +43,8 @@ function Tweets({ tweets, date }: Props) {
         <Text>
           Updated on <Code>{date}</Code>, this page is being revalidated by a
           webhook that fires when relevant tweets for #nextjs are made. The
-          webhook contains a secret key that validates the request is expected
-          to avoid DDOS attacks:
+          webhook contains a secret key that validates the request to avoid DDOS
+          attacks:
         </Text>
         <Snippet>
           {`export default async function handler(req, res) {


### PR DESCRIPTION
### Description

Switches the example from `unstable_revalidate` to `revalidate`.

### Demo URL

Check the preview, it should be broken until the change is on the latest `canary` version.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
