### PR TITLE
Fix middleware request.url usage

### DIFF
--- a/edge-functions/crypto/middleware.ts
+++ b/edge-functions/crypto/middleware.ts
@@ -10,7 +10,7 @@ export const config = {
 
 export function middleware(req: NextRequest) {
   const token = crypto.randomUUID()
-  const url = new URL(req.url)
+  const url = req.nextUrl
 
   url.pathname = '/api/crypto'
   url.searchParams.set('token', token)

--- a/edge-functions/crypto/pages/api/crypto.ts
+++ b/edge-functions/crypto/pages/api/crypto.ts
@@ -10,7 +10,7 @@ export const config = {
 }
 
 export default async function CryptoEdgeAPIRoute(request: NextRequest) {
-  const url = new URL(request.url)
+  const url = request.nextUrl
   const fromMiddleware = url.searchParams.get('token') ?? 'unset'
 
   const plainText = 'Hello from the Edge!'

--- a/edge-functions/hostname-rewrites/middleware.ts
+++ b/edge-functions/hostname-rewrites/middleware.ts
@@ -6,7 +6,7 @@ export const config = {
 }
 
 export default async function middleware(req: NextRequest) {
-  const url = new URL(req.nextUrl)
+  const url = req.nextUrl
 
   // Get hostname (e.g. vercel.com, test.vercel.app, etc.)
   const hostname = req.headers.get('host')

--- a/edge-functions/redirects-upstash/lib/redirects.ts
+++ b/edge-functions/redirects-upstash/lib/redirects.ts
@@ -13,7 +13,7 @@ type LocalRedirects = {
 }
 
 export default async function redirects(req: NextRequest) {
-  const url = new URL(req.url)
+  const url = req.nextUrl
   let start = Date.now()
 
   // Find the redirect from the local JSON file, do note this JSON shouldn't be


### PR DESCRIPTION
### Description

If `new URL` is used on `request.url` the normalizing `request.nextUrl` does for rewrites and redirects will not be able to be applied and this can cause unexpected issues.

Updated deployment with this fix can be seen here https://hostname-rewrites-jj4-ijjk-testing.vercel.app/

Fixes: https://edge-functions-hostname-rewrites-pm36gwmir.vercel.sh/
x-ref: [slack thread](https://vercel.slack.com/archives/C01MYAM1G0K/p1656130164891489) 

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
