### PR TITLE
Remove the rule `@next/next/no-server-import-in-page` from every example

### DIFF
--- a/edge-functions/ab-testing-statsig/middleware.ts
+++ b/edge-functions/ab-testing-statsig/middleware.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-server-import-in-page */
 import { NextRequest, NextResponse } from 'next/server'
 import statsig from './lib/statsig-api'
 import { DEFAULT_GROUP, FLAG, UID_COOKIE } from './lib/constants'

--- a/edge-functions/ab-testing-statsig/package.json
+++ b/edge-functions/ab-testing-statsig/package.json
@@ -23,7 +23,7 @@
     "@types/react": "latest",
     "autoprefixer": "^10.4.2",
     "eslint": "^8.16.0",
-    "eslint-config-next": "^12.1.6",
+    "eslint-config-next": "canary",
     "postcss": "^8.4.6",
     "tailwindcss": "^3.0.18",
     "typescript": "^4.7.2"

--- a/edge-functions/api-rate-limit-and-tokens/pages/api/ping.ts
+++ b/edge-functions/api-rate-limit-and-tokens/pages/api/ping.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextRequest } from 'next/server'
 import { tokenRateLimit } from '@lib/api/keys'
 

--- a/edge-functions/api-rate-limit/pages/api/ping.ts
+++ b/edge-functions/api-rate-limit/pages/api/ping.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextRequest } from 'next/server'
 import { ipRateLimit } from '@lib/ip-rate-limit'
 

--- a/edge-functions/bot-protection-botd/lib/botd/index.ts
+++ b/edge-functions/bot-protection-botd/lib/botd/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextRequest, NextResponse } from 'next/server'
 import {
   BOTD_DEFAULT_URL,

--- a/edge-functions/bot-protection-datadome/lib/datadome.ts
+++ b/edge-functions/bot-protection-datadome/lib/datadome.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextRequest, NextResponse } from 'next/server'
 
 const DATADOME_TIMEOUT = 500

--- a/edge-functions/cors/package.json
+++ b/edge-functions/cors/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^17.0.14",
     "@types/react": "latest",
     "eslint": "^8.9.0",
-    "eslint-config-next": "^12.1.0",
+    "eslint-config-next": "canary",
     "typescript": "4.5.5"
   }
 }

--- a/edge-functions/cors/pages/api/hello.ts
+++ b/edge-functions/cors/pages/api/hello.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextRequest } from 'next/server'
 import cors from '../../lib/cors'
 

--- a/edge-functions/crypto/pages/api/crypto.ts
+++ b/edge-functions/crypto/pages/api/crypto.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextRequest } from 'next/server'
 
 // ------------------

--- a/edge-functions/geolocation/middleware.ts
+++ b/edge-functions/geolocation/middleware.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-server-import-in-page */
 import { NextRequest, NextResponse } from 'next/server'
 import countries from './lib/countries.json'
 

--- a/edge-functions/geolocation/package.json
+++ b/edge-functions/geolocation/package.json
@@ -20,7 +20,7 @@
     "@types/react": "^17.0.38",
     "autoprefixer": "^10.4.2",
     "eslint": "^8.9.0",
-    "eslint-config-next": "^12.1.0",
+    "eslint-config-next": "canary",
     "postcss": "^8.4.6",
     "tailwindcss": "^3.0.18",
     "typescript": "^4.5.5"

--- a/edge-functions/ip-blocking-datadome/lib/datadome.ts
+++ b/edge-functions/ip-blocking-datadome/lib/datadome.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextRequest, NextResponse } from 'next/server'
 
 const DATADOME_TIMEOUT = 500

--- a/edge-functions/ip-blocking/lib/rules/ip.ts
+++ b/edge-functions/ip-blocking/lib/rules/ip.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextRequest } from 'next/server'
 import { upstashRest } from '@lib/upstash'
 import getIP from '@lib/get-ip'

--- a/edge-functions/jwt-authentication/lib/auth.ts
+++ b/edge-functions/jwt-authentication/lib/auth.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextRequest, NextResponse } from 'next/server'
 import { nanoid } from 'nanoid'
 import { SignJWT, jwtVerify } from 'jose'

--- a/edge-functions/jwt-authentication/lib/utils.ts
+++ b/edge-functions/jwt-authentication/lib/utils.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextResponse } from 'next/server'
 
 /**

--- a/edge-functions/jwt-authentication/pages/api/auth.ts
+++ b/edge-functions/jwt-authentication/pages/api/auth.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { type NextRequest } from 'next/server'
 import { setUserCookie } from '@lib/auth'
 import { jsonResponse } from '@lib/utils'

--- a/edge-functions/jwt-authentication/pages/api/expire.ts
+++ b/edge-functions/jwt-authentication/pages/api/expire.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { type NextRequest } from 'next/server'
 import { expireUserCookie } from '@lib/auth'
 import { jsonResponse } from '@lib/utils'

--- a/edge-functions/redirects-upstash/lib/redirects.ts
+++ b/edge-functions/redirects-upstash/lib/redirects.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextRequest, NextResponse } from 'next/server'
 import { upstashEdge } from './upstash'
 import redirectsJson from './redirects.json'

--- a/packages/ui/lib/utils.ts
+++ b/packages/ui/lib/utils.ts
@@ -6,7 +6,6 @@
  * something here could be published eventually
  */
 
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextFetchEvent, NextRequest, NextResponse } from 'next/server'
 
 type Middleware = (

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vercel/examples-ui",
-  "version": "0.3.41",
+  "version": "0.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vercel/examples-ui",
-      "version": "0.3.41",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "clsx": "^1.1.1",
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@types/react": "18",
         "eslint": "^8.16.0",
-        "eslint-config-next": "^12.1.6",
+        "eslint-config-next": "^12.1.7-canary.51",
         "typescript": "^4.7.2"
       },
       "peerDependencies": {
@@ -97,9 +97,9 @@
       "peer": true
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.6.tgz",
-      "integrity": "sha512-yNUtJ90NEiYFT6TJnNyofKMPYqirKDwpahcbxBgSIuABwYOdkGwzos1ZkYD51Qf0diYwpQZBeVqElTk7Q2WNqw==",
+      "version": "12.1.7-canary.51",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.7-canary.51.tgz",
+      "integrity": "sha512-eKFBf6K63DngSZwjLGFpJn/UZxbezE3SBCDpAptX5x64mwkPyurEoX+8FHooG9JTkm70PM0xmNnxof+n4z/ZEQ==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -978,12 +978,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.6.tgz",
-      "integrity": "sha512-qoiS3g/EPzfCTkGkaPBSX9W0NGE/B1wNO3oWrd76QszVGrdpLggNqcO8+LR6MB0CNqtp9Q8NoeVrxNVbzM9hqA==",
+      "version": "12.1.7-canary.51",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.7-canary.51.tgz",
+      "integrity": "sha512-eOYi4rbnRfKogsrYTXQlIcDohXe5mvbL/vDqYf18b8Mu5VvaZ+NOIGMtAyXFKP8bm6WiL+9721KZm3doPBoyxg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "12.1.6",
+        "@next/eslint-plugin-next": "12.1.7-canary.51",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.21.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -995,7 +995,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.23.0 || ^8.0.0",
-        "next": ">=10.2.0",
         "typescript": ">=3.3.1"
       },
       "peerDependenciesMeta": {
@@ -3085,9 +3084,9 @@
       "peer": true
     },
     "@next/eslint-plugin-next": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.6.tgz",
-      "integrity": "sha512-yNUtJ90NEiYFT6TJnNyofKMPYqirKDwpahcbxBgSIuABwYOdkGwzos1ZkYD51Qf0diYwpQZBeVqElTk7Q2WNqw==",
+      "version": "12.1.7-canary.51",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.7-canary.51.tgz",
+      "integrity": "sha512-eKFBf6K63DngSZwjLGFpJn/UZxbezE3SBCDpAptX5x64mwkPyurEoX+8FHooG9JTkm70PM0xmNnxof+n4z/ZEQ==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
@@ -3676,12 +3675,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.6.tgz",
-      "integrity": "sha512-qoiS3g/EPzfCTkGkaPBSX9W0NGE/B1wNO3oWrd76QszVGrdpLggNqcO8+LR6MB0CNqtp9Q8NoeVrxNVbzM9hqA==",
+      "version": "12.1.7-canary.51",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.1.7-canary.51.tgz",
+      "integrity": "sha512-eOYi4rbnRfKogsrYTXQlIcDohXe5mvbL/vDqYf18b8Mu5VvaZ+NOIGMtAyXFKP8bm6WiL+9721KZm3doPBoyxg==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "12.1.6",
+        "@next/eslint-plugin-next": "12.1.7-canary.51",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.21.0",
         "eslint-import-resolver-node": "^0.3.6",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/react": "18",
     "eslint": "^8.16.0",
-    "eslint-config-next": "^12.1.6",
+    "eslint-config-next": "^12.1.7-canary.51",
     "typescript": "^4.7.2"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/react": "18",
     "eslint": "^8.16.0",
-    "eslint-config-next": "^12.1.7-canary.51",
+    "eslint-config-next": "canary",
     "typescript": "^4.7.2"
   }
 }


### PR DESCRIPTION
### Description

It's no longer included by the latest `canary` of `eslint-config-next`

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
