### PR TITLE
Remove all eslint references to the now-removed no-server-import-in-page

### DIFF
--- a/edge-functions/ab-testing-statsig/middleware.ts
+++ b/edge-functions/ab-testing-statsig/middleware.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-server-import-in-page */
 import { NextRequest, NextResponse } from 'next/server'
 import statsig from './lib/statsig-api'
 import { DEFAULT_GROUP, FLAG, UID_COOKIE } from './lib/constants'

--- a/edge-functions/api-rate-limit-and-tokens/pages/api/ping.ts
+++ b/edge-functions/api-rate-limit-and-tokens/pages/api/ping.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextRequest } from 'next/server'
 import { tokenRateLimit } from '@lib/api/keys'
 

--- a/edge-functions/api-rate-limit/pages/api/ping.ts
+++ b/edge-functions/api-rate-limit/pages/api/ping.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextRequest } from 'next/server'
 import { ipRateLimit } from '@lib/ip-rate-limit'
 

--- a/edge-functions/bot-protection-botd/lib/botd/index.ts
+++ b/edge-functions/bot-protection-botd/lib/botd/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextRequest, NextResponse } from 'next/server'
 import {
   BOTD_DEFAULT_URL,

--- a/edge-functions/bot-protection-datadome/lib/datadome.ts
+++ b/edge-functions/bot-protection-datadome/lib/datadome.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextRequest, NextResponse } from 'next/server'
 
 const DATADOME_TIMEOUT = 500

--- a/edge-functions/cors/pages/api/hello.ts
+++ b/edge-functions/cors/pages/api/hello.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextRequest } from 'next/server'
 import cors from '../../lib/cors'
 

--- a/edge-functions/crypto/pages/api/crypto.ts
+++ b/edge-functions/crypto/pages/api/crypto.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextRequest } from 'next/server'
 
 // ------------------

--- a/edge-functions/geolocation/middleware.ts
+++ b/edge-functions/geolocation/middleware.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-server-import-in-page */
 import { NextRequest, NextResponse } from 'next/server'
 import countries from './lib/countries.json'
 

--- a/edge-functions/ip-blocking-datadome/lib/datadome.ts
+++ b/edge-functions/ip-blocking-datadome/lib/datadome.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextRequest, NextResponse } from 'next/server'
 
 const DATADOME_TIMEOUT = 500

--- a/edge-functions/ip-blocking/lib/rules/ip.ts
+++ b/edge-functions/ip-blocking/lib/rules/ip.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextRequest } from 'next/server'
 import { upstashRest } from '@lib/upstash'
 import getIP from '@lib/get-ip'

--- a/edge-functions/jwt-authentication/lib/auth.ts
+++ b/edge-functions/jwt-authentication/lib/auth.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextRequest, NextResponse } from 'next/server'
 import { nanoid } from 'nanoid'
 import { SignJWT, jwtVerify } from 'jose'

--- a/edge-functions/jwt-authentication/lib/utils.ts
+++ b/edge-functions/jwt-authentication/lib/utils.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextResponse } from 'next/server'
 
 /**

--- a/edge-functions/jwt-authentication/pages/api/auth.ts
+++ b/edge-functions/jwt-authentication/pages/api/auth.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { type NextRequest } from 'next/server'
 import { setUserCookie } from '@lib/auth'
 import { jsonResponse } from '@lib/utils'

--- a/edge-functions/jwt-authentication/pages/api/expire.ts
+++ b/edge-functions/jwt-authentication/pages/api/expire.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { type NextRequest } from 'next/server'
 import { expireUserCookie } from '@lib/auth'
 import { jsonResponse } from '@lib/utils'

--- a/edge-functions/redirects-upstash/lib/redirects.ts
+++ b/edge-functions/redirects-upstash/lib/redirects.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextRequest, NextResponse } from 'next/server'
 import { upstashEdge } from './upstash'
 import redirectsJson from './redirects.json'

--- a/packages/ui/lib/utils.ts
+++ b/packages/ui/lib/utils.ts
@@ -6,7 +6,6 @@
  * something here could be published eventually
  */
 
-// eslint-disable-next-line @next/next/no-server-import-in-page
 import type { NextFetchEvent, NextRequest, NextResponse } from 'next/server'
 
 type Middleware = (


### PR DESCRIPTION
### Description

Some examples reference an ESLint rule that was removed in the latest Next.js canary
and makes the build fail.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
