### PR TITLE
Removed name from package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,10 @@
 {
-  "name": "vercel-examples",
+  "name": "examples",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "vercel-examples",
-      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@vercel/fetch": "^6.2.0",


### PR DESCRIPTION
The root `package.json` no longer has a `name` or `version` property (it did not need them).