### PR TITLE
Add symlink to "build-output-api/serverless-function" example

### DIFF
--- a/build-output-api/serverless-functions/.vercel/output/functions/another.func
+++ b/build-output-api/serverless-functions/.vercel/output/functions/another.func
@@ -1,0 +1,1 @@
+index.func

--- a/build-output-api/serverless-functions/.vercel/output/functions/index.func/index.js
+++ b/build-output-api/serverless-functions/.vercel/output/functions/index.func/index.js
@@ -6,6 +6,7 @@ module.exports = (req, res) => {
   const text =
     `Howdy ${name}, from Vercel!\n` +
     `Node.js: ${process.version}\n` +
+    `Request URL: ${req.url}\n` +
     `Server time: ${new Date().toISOString()})`
   const body = cowsay.say({ text })
 

--- a/build-output-api/serverless-functions/README.md
+++ b/build-output-api/serverless-functions/README.md
@@ -23,3 +23,9 @@ source code file will be the starting point of execution when the Serverless Fun
 Additional files may placed within the `index.func` file as well which will be included in the runtime environment
 of the Serverless Function. In this case, there is also a `node_modules` directory
 that contains dependencies that the example Serverless Function needs in order to operate.
+
+A second Serverless Function is also included at the path
+`.vercel/output/functions/another.func`. In this case, it is represented by using
+a symbolic link that points to the `index.func` directory. Because it is a
+symlink, Vercel will optimize this by only creating one backing Serverless
+Function which is served at both URL paths.


### PR DESCRIPTION
Updates the Serverless Function example to demonstrate how a symbolic link may be used to represent multiple URL paths that will invoke the same underlying Serverless Function.

Demo: https://build-output-api-serverless-functions-git-update-build-o-928248.vercel.sh/another