### PR TITLE
Add missing examples demos

### DIFF
--- a/edge-api-routes/cache-control/README.md
+++ b/edge-api-routes/cache-control/README.md
@@ -2,6 +2,10 @@
 
 Build your API using Vercel Edge Functions (Experimental).
 
+## Demo
+
+https://edge-api-routes-cache-control.vercel.app/api/edge
+
 ## How to Use
 
 You can choose from one of the following two methods to use this repository:

--- a/edge-api-routes/json-response/README.md
+++ b/edge-api-routes/json-response/README.md
@@ -2,6 +2,10 @@
 
 Build your API using Vercel Edge Functions (Experimental).
 
+## Demo
+
+https://edge-api-routes-json-response.vercel.app/api/edge
+
 ## How to Use
 
 You can choose from one of the following two methods to use this repository:

--- a/edge-api-routes/query-parameters/README.md
+++ b/edge-api-routes/query-parameters/README.md
@@ -2,6 +2,10 @@
 
 Build your API using Vercel Edge Functions (Experimental).
 
+## Demo
+
+https://edge-api-routes-query-parameters.vercel.app/api/edge?email=test@test.com
+
 ## How to Use
 
 You can choose from one of the following two methods to use this repository:


### PR DESCRIPTION
This adds the missing demos for the edge-api-routes examples
