### PR TITLE
Remove HEAD request method limitation from On-Demand ISR example

### DIFF
--- a/build-output-api/on-demand-isr/.vercel/output/functions/revalidate.func/index.js
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/revalidate.func/index.js
@@ -15,7 +15,7 @@ function revalidate(host, path) {
       hostname: host,
       port: 443,
       path,
-      method: 'GET', // MUST be "GET" ("HEAD" and "POST" methods will not work)
+      method: 'GET', // MUST be "GET" or "HEAD" ("POST" method will not work)
       headers: {
         'x-prerender-revalidate': bypassToken
       }

--- a/build-output-api/on-demand-isr/README.md
+++ b/build-output-api/on-demand-isr/README.md
@@ -18,7 +18,7 @@ Click on one of the "Revalidate" links to see the associated value update. After
 
 When using Prerender Functions, you may want to revalidate the cache for a specific path based on an event (On-Demand).
 
-To revalidate a path to a Prerender Function, make a `GET` request to that path with a header of `x-prerender-revalidate: <bypassToken>`. The `<bypassToken>` must match the value in that Prerender Function's `<name>.prerender-config.json` file.
+To revalidate a path to a Prerender Function, make a `GET` or `HEAD` request to that path with a header of `x-prerender-revalidate: <bypassToken>`. The `<bypassToken>` must match the value in that Prerender Function's `<name>.prerender-config.json` file.
 
 In this demo, you can see this happening with two paths: `/` and `/data`.
 


### PR DESCRIPTION
### Description

This removes the `GET` request method limitation from the example as `HEAD` requests are now supported as well. 

x-ref: https://github.com/vercel/next.js/pull/39038
x-ref: https://github.com/vercel/front/pull/15156

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
