### PR TITLE
[build-output-api] Update On-Demand ISR example with `expiration: false` prerenders

### DIFF
--- a/build-output-api/on-demand-isr/.vercel/output/config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/config.json
@@ -1,3 +1,10 @@
 {
-  "version": 3
+  "version": 3,
+  "routes": [
+    { "handle": "filesystem" },
+    {
+      "src": "/blog/(?<slug>[^/]+)(?:/)?",
+      "dest": "/blog/[slug]?slug=$slug"
+    }
+  ]
 }

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/404.prerender-fallback.html
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/404.prerender-fallback.html
@@ -5,5 +5,9 @@
 </head>
 <body>
   <h1>Not Found</h1>
+  
+  <!-- Authentication example is for demo purposes only. In a production system, use better authentication strategies. -->
+  <p><a href="#">Generate this path via On-Demand ISR</a></p>
+  <script>document.querySelector('a').href = `/revalidate?path=${encodeURIComponent(window.location.pathname)}&authToken=a13f94f6-a441-47ca-95fc-9f44f3450295`</script>
 </body>
 </html>

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/404.prerender-fallback.html
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/404.prerender-fallback.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>404 | Not Found</title>
+</head>
+<body>
+  <h1>Not Found</h1>
+</body>
+</html>

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].func/.vc-config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].func/.vc-config.json
@@ -1,0 +1,5 @@
+{
+  "runtime": "nodejs16.x",
+  "handler": "index.js",
+  "launcherType": "Nodejs"
+}

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].func/index.js
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].func/index.js
@@ -9,7 +9,7 @@ module.exports = (req, res) => {
   // from the URL
   if (!slug) {
     const matches = req.url.match(/\/blog\/([^/]+)(?:\/)?/)
-    slug = matches[0]
+    slug = matches[1]
   }
   
   res.setHeader('Content-Type', 'text/html; charset=utf-8')

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].func/index.js
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].func/index.js
@@ -2,22 +2,34 @@ const { parse } = require('querystring')
 
 module.exports = (req, res) => {
   const matches = parse(req.headers['x-now-route-matches'])
-  const { slug } = matches
+  let { slug } = matches
+  
+  // if slug isn't present in x-now-route-matches it 
+  // matched at the filesystem level and can be parsed
+  // from the URL
+  if (!slug) {
+    const matches = req.url.match(/\/blog\/([^/]+)(?:\/)?/)
+    slug = matches[0]
+  }
   
   res.setHeader('Content-Type', 'text/html; charset=utf-8')
   res.end(`
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <title>My blog | ${slug}</title>
-    </head>
-    <body>
-      <h1>Post: ${slug}</h1>
-      
-      <p>This demonstrates an SSG blog that restricts generating new paths via On-Demand revalidations instead of allowing any visited path to generate a new path.</p>
-      
-      <p>It works by leveraging the "routes" config to only route to the blog prerender when the proper revalidate token is provided.</p>
-    </body>
-    </html>
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My blog | ${slug}</title>
+</head>
+<body>
+  <h1>Post: ${slug}</h1>
+  <p>Generated time: ${new Date().toISOString()}</p>
+  
+  <p>This demonstrates a SSG blog that restricts generating new paths via On-Demand ISR instead of allowing any visited paths to generate a new path.</p>
+  
+  <p>It works by leveraging \`expiration: false\` on a prerender to only allow generating new paths when the revalidate token is provided.</p>
+  
+  <!-- Authentication example is for demo purposes only. In a production system, use better authentication strategies. -->
+  <p><a href="/revalidate?path=/blog/${slug}&authToken=a13f94f6-a441-47ca-95fc-9f44f3450295">Revalidate this path via On-Demand ISR</a></p>
+</body>
+</html>
   `)
 }

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].func/index.js
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].func/index.js
@@ -1,0 +1,23 @@
+const { parse } = require('querystring')
+
+module.exports = (req, res) => {
+  const matches = parse(req.headers['x-now-route-matches'])
+  const { slug } = matches
+  
+  res.setHeader('Content-Type', 'text/html; charset=utf-8')
+  res.end(`
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>My blog | ${slug}</title>
+    </head>
+    <body>
+      <h1>Post: ${slug}</h1>
+      
+      <p>This demonstrates an SSG blog that restricts generating new paths via On-Demand revalidations instead of allowing any visited path to generate a new path.</p>
+      
+      <p>It works by leveraging the "routes" config to only route to the blog prerender when the proper revalidate token is provided.</p>
+    </body>
+    </html>
+  `)
+}

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].prerender-config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].prerender-config.json
@@ -1,0 +1,11 @@
+{
+  "expiration": false,
+  "group": 3,
+  "bypassToken": "87734ad8259d67c3c11747d3e4e112d0",
+  "allowQuery": ["slug"],
+  "fallback": {
+    "type": "FileFsRef",
+    "mode": 33188,
+    "fsPath": "404.prerender-fallback.html"
+  }
+}

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].prerender-config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].prerender-config.json
@@ -3,9 +3,5 @@
   "group": 3,
   "bypassToken": "87734ad8259d67c3c11747d3e4e112d0",
   "allowQuery": ["slug"],
-  "fallback": {
-    "type": "FileFsRef",
-    "mode": 33188,
-    "fsPath": "404.prerender-fallback.html"
-  }
+  "fallback": "404.prerender-fallback.html"
 }

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-1.func
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-1.func
@@ -1,0 +1,1 @@
+[slug].func

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-1.prerender-config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-1.prerender-config.json
@@ -1,0 +1,11 @@
+{
+  "expiration": false,
+  "group": 3,
+  "bypassToken": "87734ad8259d67c3c11747d3e4e112d0",
+  "allowQuery": ["slug"],
+  "fallback": {
+    "type": "FileFsRef",
+    "mode": 33188,
+    "fsPath": "post-1.prerender-fallback.html"
+  }
+}

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-1.prerender-config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-1.prerender-config.json
@@ -3,9 +3,5 @@
   "group": 3,
   "bypassToken": "87734ad8259d67c3c11747d3e4e112d0",
   "allowQuery": ["slug"],
-  "fallback": {
-    "type": "FileFsRef",
-    "mode": 33188,
-    "fsPath": "post-1.prerender-fallback.html"
-  }
+  "fallback": "post-1.prerender-fallback.html"
 }

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-1.prerender-fallback.html
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-1.prerender-fallback.html
@@ -5,9 +5,13 @@
 </head>
 <body>
   <h1>Post: post-1</h1>
+  <p>Generated time: 2022-08-11T15:12:34.656Z</p>
   
   <p>This demonstrates a SSG blog that restricts generating new paths via On-Demand ISR instead of allowing any visited paths to generate a new path.</p>
   
   <p>It works by leveraging `expiration: false` on a prerender to only allow generating new paths when the revalidate token is provided.</p>
+  
+  <!-- Authentication example is for demo purposes only. In a production system, use better authentication strategies. -->
+  <p><a href="/revalidate?path=/blog/post-1&authToken=a13f94f6-a441-47ca-95fc-9f44f3450295">Revalidate this path via On-Demand ISR</a></p>
 </body>
 </html>

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-1.prerender-fallback.html
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-1.prerender-fallback.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My blog | post-1</title>
+</head>
+<body>
+  <h1>Post: post-1</h1>
+  
+  <p>This demonstrates a SSG blog that restricts generating new paths via On-Demand ISR instead of allowing any visited paths to generate a new path.</p>
+  
+  <p>It works by leveraging `expiration: false` on a prerender to only allow generating new paths when the revalidate token is provided.</p>
+</body>
+</html>

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-2.func
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-2.func
@@ -1,0 +1,1 @@
+[slug].func

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-2.prerender-config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-2.prerender-config.json
@@ -1,0 +1,11 @@
+{
+  "expiration": false,
+  "group": 3,
+  "bypassToken": "87734ad8259d67c3c11747d3e4e112d0",
+  "allowQuery": ["slug"],
+  "fallback": {
+    "type": "FileFsRef",
+    "mode": 33188,
+    "fsPath": "post-2.prerender-fallback.html"
+  }
+}

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-2.prerender-config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-2.prerender-config.json
@@ -3,9 +3,5 @@
   "group": 3,
   "bypassToken": "87734ad8259d67c3c11747d3e4e112d0",
   "allowQuery": ["slug"],
-  "fallback": {
-    "type": "FileFsRef",
-    "mode": 33188,
-    "fsPath": "post-2.prerender-fallback.html"
-  }
+  "fallback": "post-2.prerender-fallback.html"
 }

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-2.prerender-fallback.html
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-2.prerender-fallback.html
@@ -5,9 +5,13 @@
 </head>
 <body>
   <h1>Post: post-2</h1>
+  <p>Generated time: 2022-08-11T15:12:34.656Z</p>
   
   <p>This demonstrates a SSG blog that restricts generating new paths via On-Demand ISR instead of allowing any visited paths to generate a new path.</p>
   
   <p>It works by leveraging `expiration: false` on a prerender to only allow generating new paths when the revalidate token is provided.</p>
+  
+  <!-- Authentication example is for demo purposes only. In a production system, use better authentication strategies. -->
+  <p><a href="/revalidate?path=/blog/post-2&authToken=a13f94f6-a441-47ca-95fc-9f44f3450295">Revalidate this path via On-Demand ISR</a></p>
 </body>
 </html>

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-2.prerender-fallback.html
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/post-2.prerender-fallback.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My blog | post-2</title>
+</head>
+<body>
+  <h1>Post: post-2</h1>
+  
+  <p>This demonstrates a SSG blog that restricts generating new paths via On-Demand ISR instead of allowing any visited paths to generate a new path.</p>
+  
+  <p>It works by leveraging `expiration: false` on a prerender to only allow generating new paths when the revalidate token is provided.</p>
+</body>
+</html>

--- a/build-output-api/on-demand-isr/.vercel/output/functions/revalidate.func/index.js
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/revalidate.func/index.js
@@ -60,7 +60,7 @@ module.exports = (req, res) => {
     res.end(`
       <h1>Cache for "${pathToRevalidate}" Revalidated!</h1>
       <p>Redirecting you back.</p>
-      <meta http-equiv="refresh" content="2 url=${deployedUrl}">
+      <meta http-equiv="refresh" content="2 url=${deployedUrl}${pathToRevalidate}">
     `)
   }).catch((error) => {
     console.error(error.stack)

--- a/build-output-api/on-demand-isr/README.md
+++ b/build-output-api/on-demand-isr/README.md
@@ -33,6 +33,16 @@ In this demo, you can see this happening with two paths: `/` and `/data`.
 
 When the revalidation is triggered, the cache will be revalidated, bypassing any caching that Vercel would normally provide.
 
+There is also an example of a blog that only generates new paths when triggered via On-Demand ISR with two initial posts that are prerendered.
+
+- `/blog/[slug]`
+  - base post prerender that allows generating news paths via On-Demand ISR
+  - [bypassToken](./.vercel/output/functions/index.prerender-config.json#L4)
+- `/blog/post-1`
+- `/blog/post-2`
+  - initial prerendered blog posts
+  - [bypassToken](./.vercel/output/functions/index.prerender-config.json#L4)
+
 ### Security
 
 #### `bypassToken`


### PR DESCRIPTION
### Description

This adds an example of `expiration: false` prerenders to our On-Demand ISR example as we've had some questions about handling this. This is specifically demonstrating how On-Demand ISR can be used in combination with `routes` to only generate paths via On-Demand ISR instead of whenever a user visits a new path. 

x-ref: https://github.com/vercel/vercel/discussions/8289#discussioncomment-3316918
x-ref: [slack thread](https://vercel.slack.com/archives/C02DB4T5D2A/p1659981453822119)

Deployed example can be seen here https://boa-on-demand-fysl8lh1b-ijjk-testing.vercel.app/blog/post-1

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
