### PR TITLE
Updated root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ yarn.lock
 /yarn-error.log*
 
 # Local ENV files
-.env*.local
+/.env*.local

--- a/.gitignore
+++ b/.gitignore
@@ -1,36 +1,22 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # Dependencies
-node_modules
-.pnp
-.pnp.js
+/node_modules
+/packages/ui/node_modules
 
-# Examples
+# Ignore the dependency locks of all examples
 package-lock.json
 yarn.lock
 !/package-lock.lock
-
-# Testing
-coverage
-
-# Next.js
-.next
-out
-
-# Production
-build
 
 # Misc
 .DS_Store
 *.pem
 
 # Debug
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+/npm-debug.log*
+/yarn-debug.log*
+/yarn-error.log*
 
 # Local ENV files
 .env*.local
-
-# Vercel
-.vercel

--- a/solutions/microfrontends/.gitignore
+++ b/solutions/microfrontends/.gitignore
@@ -1,19 +1,19 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # Dependencies
-/node_modules
-/.pnp
+node_modules
+.pnp
 .pnp.js
 
 # Testing
 /coverage
 
 # Next.js
-/.next/
-/out/
+.next
+out
 
 # Production
-/build
+build
 dist
 
 # Misc

--- a/solutions/monorepo/.gitignore
+++ b/solutions/monorepo/.gitignore
@@ -1,16 +1,16 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # Dependencies
-/node_modules
-/.pnp
+node_modules
+.pnp
 .pnp.js
 
 # Testing
 /coverage
 
 # Next.js
-/.next/
-/out/
+.next
+out
 
 # Production
 build


### PR DESCRIPTION
### Description

Updated the root `.gitignore` to not ignore dependencies and other files from examples, the reason for this is that every example should include its own `.gitignore` to properly handle cases when an example is cloned following its readme steps.

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (changes to the codebase, but not to examples)
