### PR TITLE
Fix aws-s3-image-upload example

### DIFF
--- a/solutions/aws-s3-image-upload/cdk.json
+++ b/solutions/aws-s3-image-upload/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx ts-node --prefer-ts-exts bin/aws-s3.ts",
+  "app": "npx ts-node --prefer-ts-exts -P tsconfig-aws.json bin/aws-s3.ts",
   "watch": {
     "include": ["**"],
     "exclude": [

--- a/solutions/aws-s3-image-upload/package.json
+++ b/solutions/aws-s3-image-upload/package.json
@@ -17,6 +17,7 @@
     "@types/react": "^18.0.12",
     "aws-cdk": "2.27.0",
     "aws-sdk": "^2.1152.0",
+    "eslint": "8.22.0",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
@@ -27,7 +28,6 @@
     "aws-cdk-lib": "2.27.0",
     "constructs": "^10.1.36",
     "eslint-config-next": "^12.1.0",
-    "eslint": "^8.9.0",
     "source-map-support": "^0.5.21"
   }
 }

--- a/solutions/aws-s3-image-upload/tsconfig-aws.json
+++ b/solutions/aws-s3-image-upload/tsconfig-aws.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "CommonJS",
+    "lib": ["es2018"],
+    "strict": true
+  }
+}


### PR DESCRIPTION
### Description

This PR fixes two issues with the aws-s3-image-upload example.
 
Fixes #302 - Provide a separate tsconfig for the AWS CDK code. Config is slightly different from the main one that is meant for NextJS. Main point is to use "CommonJS" module setting and "ES2018" target.

Fixes #393 - Downgrade ESLint to version 8.22.0 strictly, to avoid errors in WebStorm.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

