### PR TITLE
chore(nx): set cache directory for nx cloud

### DIFF
--- a/solutions/nx-monorepo/nx.json
+++ b/solutions/nx-monorepo/nx.json
@@ -21,7 +21,8 @@
     "cloud": {
       "runner": "@nrwl/nx-cloud",
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "e2e"]
+        "cacheableOperations": ["build", "lint", "test", "e2e"],
+        "cacheDirectory": "/tmp/nx-cache"
       }
     }
   },

--- a/solutions/nx-monorepo/nx.json
+++ b/solutions/nx-monorepo/nx.json
@@ -15,7 +15,8 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "e2e"]
+        "cacheableOperations": ["build", "lint", "test", "e2e"],
+        "cacheDirectory": "/tmp/nx-cache"
       }
     },
     "cloud": {


### PR DESCRIPTION
### Description

Fix the configuration in `nx.json` to simplify deployment on Vercel and move cache outside of the Vercel build cache. 

### Type of Change

- [ ] New Example
- [X] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)


