### PR TITLE
Added `relatedTemplates` to some examples

### DIFF
--- a/solutions/domains-api/README.md
+++ b/solutions/domains-api/README.md
@@ -7,6 +7,8 @@ useCase: Documentation
 css: Tailwind
 deployUrl: https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/domains-api&project-name=domains-api&repository-name=domains-api&env=AUTH_BEARER_TOKEN,PROJECT_ID_VERCEL,TEAM_ID_VERCEL
 demoUrl: https://domains-api.vercel.app
+relatedTemplates:
+  - platforms-starter-kit
 ---
 
 # Domains API

--- a/solutions/monorepo/README.md
+++ b/solutions/monorepo/README.md
@@ -7,6 +7,8 @@ useCase: Documentation
 css: Tailwind
 deployUrl: https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/monorepo&project-name=monorepo&repository-name=monorepo&root-directory=apps/app&install-command=pnpm%20install&build-command=cd%20..%2F..%20%26%26%20npx%20turbo%20run%20build%20--filter%3Dapp...&ignore-command=npx%20turbo-ignore
 demoUrl: https://solutions-monorepo.vercel.sh
+relatedTemplates:
+  - monorepo-nx
 ---
 
 # Monorepo

--- a/solutions/platforms-slate-supabase/README.md
+++ b/solutions/platforms-slate-supabase/README.md
@@ -7,6 +7,9 @@ useCase: Documentation
 css: Tailwind
 deployUrl: https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/platforms-slate-supabase&project-name=platforms-slate-supabase&repo-name=platforms-slate-supabase&env=NEXTAUTH_URL,SECRET,AUTH_BEARER_TOKEN,PROJECT_ID_VERCEL,TEAM_ID_VERCEL,SUPABASE_URL,SUPABASE_ANON_KEY,GITHUB_CLIENT_ID,GITHUB_CLIENT_SECRET
 demoUrl: https://app.vercel.im
+relatedTemplates:
+  - domains-api
+  - platforms-starter-kit
 ---
 
 <p align="center">


### PR DESCRIPTION
### Description

The publish template action failed for those examples because the `relatedTemplates` field is required.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
