### PR TITLE
Update to latest examples-ui in most examples

### DIFF
--- a/edge-functions/ab-testing-google-optimize/next.config.js
+++ b/edge-functions/ab-testing-google-optimize/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/ab-testing-google-optimize/package.json
+++ b/edge-functions/ab-testing-google-optimize/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "js-cookie": "^3.0.1",
     "next": "canary",
     "react": "latest",

--- a/edge-functions/ab-testing-google-optimize/tailwind.config.js
+++ b/edge-functions/ab-testing-google-optimize/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/ab-testing-statsig/next.config.js
+++ b/edge-functions/ab-testing-statsig/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/edge-functions/ab-testing-statsig/package.json
+++ b/edge-functions/ab-testing-statsig/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "js-cookie": "^3.0.1",
     "next": "canary",
     "react": "latest",

--- a/edge-functions/ab-testing-statsig/tailwind.config.js
+++ b/edge-functions/ab-testing-statsig/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/add-header/next.config.js
+++ b/edge-functions/add-header/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/edge-functions/add-header/package.json
+++ b/edge-functions/add-header/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/add-header/tailwind.config.js
+++ b/edge-functions/add-header/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/api-rate-limit-and-tokens/next.config.js
+++ b/edge-functions/api-rate-limit-and-tokens/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/api-rate-limit-and-tokens/package.json
+++ b/edge-functions/api-rate-limit-and-tokens/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "jose": "^4.8.1",
     "nanoid": "^4.0.0",
     "next": "canary",

--- a/edge-functions/api-rate-limit-and-tokens/tailwind.config.js
+++ b/edge-functions/api-rate-limit-and-tokens/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/api-rate-limit/next.config.js
+++ b/edge-functions/api-rate-limit/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/api-rate-limit/package.json
+++ b/edge-functions/api-rate-limit/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/api-rate-limit/tailwind.config.js
+++ b/edge-functions/api-rate-limit/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/basic-auth-password/next.config.js
+++ b/edge-functions/basic-auth-password/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/basic-auth-password/package.json
+++ b/edge-functions/basic-auth-password/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/basic-auth-password/tailwind.config.js
+++ b/edge-functions/basic-auth-password/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/bot-protection-botd/package.json
+++ b/edge-functions/bot-protection-botd/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/bot-protection-botd/tailwind.config.js
+++ b/edge-functions/bot-protection-botd/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/bot-protection-datadome/next.config.js
+++ b/edge-functions/bot-protection-datadome/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/bot-protection-datadome/package.json
+++ b/edge-functions/bot-protection-datadome/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/bot-protection-datadome/tailwind.config.js
+++ b/edge-functions/bot-protection-datadome/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/cookies/next.config.js
+++ b/edge-functions/cookies/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/cookies/package.json
+++ b/edge-functions/cookies/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "js-cookie": "^3.0.1",
     "next": "canary",
     "react": "latest",

--- a/edge-functions/cookies/tailwind.config.js
+++ b/edge-functions/cookies/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/feature-flag-configcat/next.config.js
+++ b/edge-functions/feature-flag-configcat/next.config.js
@@ -1,4 +1,3 @@
-const withTM = require('@vercel/examples-ui/transpile')()
 const { withConfigcat } = require('./scripts/configcat')
 
-module.exports = withTM(withConfigcat())
+module.exports = withConfigcat()

--- a/edge-functions/feature-flag-configcat/tailwind.config.js
+++ b/edge-functions/feature-flag-configcat/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/feature-flag-optimizely/next.config.js
+++ b/edge-functions/feature-flag-optimizely/next.config.js
@@ -1,9 +1,4 @@
-/** @type {import('next').NextConfig} */
-const withTM = require('@vercel/examples-ui/transpile')()
 const withOptimizely = require('./scripts/fetch_optimizely_datafile')
 
-module.exports = withTM(
-  withOptimizely({
-    reactStrictMode: true,
-  })
-)
+/** @type {import('next').NextConfig} */
+module.exports = withOptimizely()

--- a/edge-functions/feature-flag-optimizely/package.json
+++ b/edge-functions/feature-flag-optimizely/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@optimizely/optimizely-sdk": "^4.9.1",
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/feature-flag-optimizely/tailwind.config.js
+++ b/edge-functions/feature-flag-optimizely/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/feature-flag-posthog/next.config.js
+++ b/edge-functions/feature-flag-posthog/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/feature-flag-posthog/tailwind.config.js
+++ b/edge-functions/feature-flag-posthog/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/feature-flag-split/next.config.js
+++ b/edge-functions/feature-flag-split/next.config.js
@@ -1,4 +1,3 @@
-const withTM = require('@vercel/examples-ui/transpile')()
 const { withSplit } = require('./scripts/split')
 
-module.exports = withTM(withSplit())
+module.exports = withSplit()

--- a/edge-functions/feature-flag-split/package.json
+++ b/edge-functions/feature-flag-split/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "js-cookie": "^3.0.1",
     "next": "canary",
     "react": "latest",

--- a/edge-functions/feature-flag-split/tailwind.config.js
+++ b/edge-functions/feature-flag-split/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/geolocation/next.config.js
+++ b/edge-functions/geolocation/next.config.js
@@ -1,10 +1,7 @@
-const withTM = require('@vercel/examples-ui/transpile')()
 const { withCountryInfo } = require('./scripts/countries')
 
-module.exports = withTM(
-  withCountryInfo({
-    images: {
-      domains: ['flagcdn.com'],
-    },
-  })
-)
+module.exports = withCountryInfo({
+  images: {
+    domains: ['flagcdn.com'],
+  },
+})

--- a/edge-functions/geolocation/package.json
+++ b/edge-functions/geolocation/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/geolocation/tailwind.config.js
+++ b/edge-functions/geolocation/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/hostname-rewrites/next.config.js
+++ b/edge-functions/hostname-rewrites/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/hostname-rewrites/package.json
+++ b/edge-functions/hostname-rewrites/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/hostname-rewrites/tailwind.config.js
+++ b/edge-functions/hostname-rewrites/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/i18n/next.config.js
+++ b/edge-functions/i18n/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/i18n/package.json
+++ b/edge-functions/i18n/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/i18n/tailwind.config.js
+++ b/edge-functions/i18n/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/ip-blocking-datadome/next.config.js
+++ b/edge-functions/ip-blocking-datadome/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/ip-blocking-datadome/package.json
+++ b/edge-functions/ip-blocking-datadome/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest",

--- a/edge-functions/ip-blocking-datadome/tailwind.config.js
+++ b/edge-functions/ip-blocking-datadome/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/ip-blocking/next.config.js
+++ b/edge-functions/ip-blocking/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/ip-blocking/package.json
+++ b/edge-functions/ip-blocking/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest",

--- a/edge-functions/ip-blocking/tailwind.config.js
+++ b/edge-functions/ip-blocking/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/jwt-authentication/next.config.js
+++ b/edge-functions/jwt-authentication/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/jwt-authentication/package.json
+++ b/edge-functions/jwt-authentication/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "jose": "^4.4.0",
     "nanoid": "^3.2.0",
     "next": "canary",

--- a/edge-functions/jwt-authentication/tailwind.config.js
+++ b/edge-functions/jwt-authentication/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/maintenance-page/next.config.js
+++ b/edge-functions/maintenance-page/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/edge-functions/maintenance-page/package.json
+++ b/edge-functions/maintenance-page/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/maintenance-page/tailwind.config.js
+++ b/edge-functions/maintenance-page/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/power-parity-pricing-strategies/next.config.js
+++ b/edge-functions/power-parity-pricing-strategies/next.config.js
@@ -1,6 +1,4 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM({
+module.exports = {
   async redirects() {
     return [
       {
@@ -10,4 +8,4 @@ module.exports = withTM({
       },
     ]
   },
-})
+}

--- a/edge-functions/power-parity-pricing-strategies/package.json
+++ b/edge-functions/power-parity-pricing-strategies/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/power-parity-pricing-strategies/tailwind.config.js
+++ b/edge-functions/power-parity-pricing-strategies/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/power-parity-pricing/next.config.js
+++ b/edge-functions/power-parity-pricing/next.config.js
@@ -1,7 +1,5 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM({
+module.exports = {
   images: {
     domains: ['lipis.github.io'],
   },
-})
+}

--- a/edge-functions/power-parity-pricing/package.json
+++ b/edge-functions/power-parity-pricing/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/power-parity-pricing/tailwind.config.js
+++ b/edge-functions/power-parity-pricing/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/query-params-filter/next.config.js
+++ b/edge-functions/query-params-filter/next.config.js
@@ -1,3 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-module.exports = withTM()

--- a/edge-functions/query-params-filter/package.json
+++ b/edge-functions/query-params-filter/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/query-params-filter/tailwind.config.js
+++ b/edge-functions/query-params-filter/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/redirects-upstash/next.config.js
+++ b/edge-functions/redirects-upstash/next.config.js
@@ -1,4 +1,3 @@
-const withTM = require('@vercel/examples-ui/transpile')()
 const { withUpstash } = require('./scripts/upstash')
 
-module.exports = withTM(withUpstash())
+module.exports = withUpstash()

--- a/edge-functions/redirects-upstash/package.json
+++ b/edge-functions/redirects-upstash/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/redirects-upstash/tailwind.config.js
+++ b/edge-functions/redirects-upstash/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/rewrites-upstash/next.config.js
+++ b/edge-functions/rewrites-upstash/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/edge-functions/rewrites-upstash/package.json
+++ b/edge-functions/rewrites-upstash/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/rewrites-upstash/tailwind.config.js
+++ b/edge-functions/rewrites-upstash/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/edge-functions/user-agent-based-rendering/next.config.js
+++ b/edge-functions/user-agent-based-rendering/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/edge-functions/user-agent-based-rendering/package.json
+++ b/edge-functions/user-agent-based-rendering/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/user-agent-based-rendering/tailwind.config.js
+++ b/edge-functions/user-agent-based-rendering/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/plop-templates/example/next.config.js
+++ b/plop-templates/example/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/plop-templates/example/package.json
+++ b/plop-templates/example/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"

--- a/plop-templates/example/tailwind.config.js
+++ b/plop-templates/example/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/auth-with-ory/next.config.js
+++ b/solutions/auth-with-ory/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true
-})

--- a/solutions/auth-with-ory/tailwind.config.js
+++ b/solutions/auth-with-ory/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}'
-  ]
+    './node_modules/@vercel/examples-ui/**/*.js',
+  ],
 }

--- a/solutions/cms-contentstack-commerce/next.config.js
+++ b/solutions/cms-contentstack-commerce/next.config.js
@@ -1,8 +1,5 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
 /** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
+module.exports = {
   i18n: {
     locales: ['en-US', 'es'],
     defaultLocale: 'en-US',
@@ -10,4 +7,4 @@ module.exports = withTM({
   images: {
     domains: ['images.contentstack.io'],
   },
-})
+}

--- a/solutions/cms-contentstack-commerce/tailwind.config.js
+++ b/solutions/cms-contentstack-commerce/tailwind.config.js
@@ -3,7 +3,7 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
   theme: {
     extend: {

--- a/solutions/combining-data-fetching-strategies/next.config.js
+++ b/solutions/combining-data-fetching-strategies/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/combining-data-fetching-strategies/tailwind.config.js
+++ b/solutions/combining-data-fetching-strategies/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/image-fallback/next.config.js
+++ b/solutions/image-fallback/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/image-fallback/tailwind.config.js
+++ b/solutions/image-fallback/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/image-offset/next.config.js
+++ b/solutions/image-offset/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/image-offset/tailwind.config.js
+++ b/solutions/image-offset/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/loading-web-fonts/next.config.js
+++ b/solutions/loading-web-fonts/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/loading-web-fonts/tailwind.config.js
+++ b/solutions/loading-web-fonts/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/mint-nft/next.config.js
+++ b/solutions/mint-nft/next.config.js
@@ -1,9 +1,6 @@
-const withTM = require('@vercel/examples-ui/transpile')();
-
 /** @type {import('next').NextConfig} */
-module.exports = withTM({
-    reactStrictMode: true,
-    images: {
-        domains: [process.env.NEXT_PUBLIC_SERVER_DOMAIN],
-    },
-});
+module.exports = {
+  images: {
+    domains: [process.env.NEXT_PUBLIC_SERVER_DOMAIN],
+  },
+}

--- a/solutions/mint-nft/tailwind.config.js
+++ b/solutions/mint-nft/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/on-demand-isr/next.config.js
+++ b/solutions/on-demand-isr/next.config.js
@@ -1,9 +1,6 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
 /** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
+module.exports = {
   images: {
     domains: ['images.unsplash.com'],
   },
-})
+}

--- a/solutions/on-demand-isr/package.json
+++ b/solutions/on-demand-isr/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/solutions/on-demand-isr/tailwind.config.js
+++ b/solutions/on-demand-isr/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/pagination-with-ssg/next.config.js
+++ b/solutions/pagination-with-ssg/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/pagination-with-ssg/package.json
+++ b/solutions/pagination-with-ssg/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "next": "^12.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/solutions/pagination-with-ssg/tailwind.config.js
+++ b/solutions/pagination-with-ssg/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/reuse-responses/next.config.js
+++ b/solutions/reuse-responses/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/reuse-responses/tailwind.config.js
+++ b/solutions/reuse-responses/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/script-component-ad/next.config.js
+++ b/solutions/script-component-ad/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/script-component-ad/tailwind.config.js
+++ b/solutions/script-component-ad/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/script-component-strategies/next.config.js
+++ b/solutions/script-component-strategies/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/script-component-strategies/tailwind.config.js
+++ b/solutions/script-component-strategies/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/subdomain-auth/next.config.js
+++ b/solutions/subdomain-auth/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/subdomain-auth/tailwind.config.js
+++ b/solutions/subdomain-auth/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/testing/next.config.js
+++ b/solutions/testing/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/testing/package.json
+++ b/solutions/testing/package.json
@@ -14,7 +14,7 @@
     "e2e": "node playwright-test.mjs -e"
   },
   "dependencies": {
-    "@vercel/examples-ui": "0.3.6",
+    "@vercel/examples-ui": "^1.0.2",
     "clsx": "^1.2.1",
     "cookie": "^0.5.0",
     "next": "latest",

--- a/solutions/testing/tailwind.config.js
+++ b/solutions/testing/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/web3-authentication/next.config.js
+++ b/solutions/web3-authentication/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/web3-authentication/tailwind.config.js
+++ b/solutions/web3-authentication/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/web3-data-fetching/next.config.js
+++ b/solutions/web3-data-fetching/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/web3-data-fetching/tailwind.config.js
+++ b/solutions/web3-data-fetching/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }

--- a/solutions/web3-sessions/next.config.js
+++ b/solutions/web3-sessions/next.config.js
@@ -1,6 +1,0 @@
-const withTM = require('@vercel/examples-ui/transpile')()
-
-/** @type {import('next').NextConfig} */
-module.exports = withTM({
-  reactStrictMode: true,
-})

--- a/solutions/web3-sessions/tailwind.config.js
+++ b/solutions/web3-sessions/tailwind.config.js
@@ -3,6 +3,6 @@ module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    'node_modules/@vercel/examples-ui/**/*.{js,ts,jsx,tsx}',
+    './node_modules/@vercel/examples-ui/**/*.js',
   ],
 }


### PR DESCRIPTION
### Description

The latest UI package no longer uses `next-transpile-modules` so the `next.config.js` has been removed from most places.

Don't merge until all deployments are working!

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)