### PR TITLE
fix(geolocation): uses canary next/image

### DIFF
--- a/edge-functions/geolocation/pages/index.tsx
+++ b/edge-functions/geolocation/pages/index.tsx
@@ -23,13 +23,7 @@ export default function Index({
   return (
     <div className="flex flex-col items-center justify-center min-h-screen py-2 bg-gray-50">
       <div className="fixed inset-0 overflow-hidden opacity-75 bg-[#f8fafb]">
-        <Image
-          alt="World Map"
-          src={map}
-          layout="fill"
-          objectFit="cover"
-          quality={100}
-        />
+        <Image alt="World Map" src={map} fill={true} quality={100} />
       </div>
       <main className="flex flex-col items-center flex-1 px-4 sm:px-20 text-center z-10 pt-8 sm:pt-20">
         <h1 className="text-3xl sm:text-5xl font-bold">Geolocation</h1>


### PR DESCRIPTION
### Description

Since [next@12.3.2-canary.29](https://github.com/vercel/next.js/releases/tag/v12.3.2-canary.29), next/image has a different set of properties.

This PR fixes this example so it can pass on [our CI](https://vercel.com/curated-tests/edge-functions-bridge-01-nextjs-middleware/RAHZBgKW6hhuQub1nfPireReeMBo).

### Demo URL

https://edge-functions-geolocation-e7q9k3o95.vercel.sh/

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

