### PR TITLE
use `legacyBehavior` in link exported by the examples UI package.

### DIFF
--- a/.changeset/unlucky-emus-sort.md
+++ b/.changeset/unlucky-emus-sort.md
@@ -1,0 +1,5 @@
+---
+'@vercel/examples-ui': patch
+---
+
+Use `legacyBehavior` for uses of next/link

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf ./dist",
     "types": "tsc --emitDeclarationOnly"
   },
-  "sideEffects": false,
+  "sideEffects": true,
   "type": "module",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/ui/src/link.tsx
+++ b/packages/ui/src/link.tsx
@@ -14,9 +14,11 @@ const css = [
   '[&_code]:text-link [&_code]:hover:text-link-light [&_code]:transition-colors',
 ]
 
-const Link: FC<LinkPropsReal> = ({ children, className, ...props }) => (
-  <NextLink className={cn(css, className)} {...props}>
-    {children}
+const Link: FC<LinkPropsReal> = ({ children, className, href, ...props }) => (
+  <NextLink href={href} legacyBehavior>
+    <a className={cn(css, className)} {...props}>
+      {children}
+    </a>
   </NextLink>
 )
 


### PR DESCRIPTION
### Description

There are some styling issues with the link component in the package when used in multiple examples, with this change it's going back to how it was being used before.

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (changes to the codebase, but not to examples)
