### PR TITLE
Vercel OG + Next.js: upgrade Satori

### DIFF
--- a/edge-functions/vercel-og-nextjs/package.json
+++ b/edge-functions/vercel-og-nextjs/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/og": "0.0.14",
+    "@vercel/og": "0.0.20",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"


### PR DESCRIPTION
### Description

Upgrades https://github.com/vercel/examples/tree/main/edge-functions/vercel-og-nextjs to use latest version of @vercel/og. This fixes https://github.com/vercel/examples/issues/435, where some Github avatars would fail to load.

### Demo URL

- Visit a [deployed version of the example](https://vercel-og-nextjs-five-eta.vercel.app/api/dynamic-image?username=domeccleston): this fails with '?username=domeccleston' or '?username=thamasky'
- Visit a [preview deployment](https://vercel-og-nextjs-domeccleston.vercel.app/) with upgraded @vercel/og: this works with '?username=domeccleston' or '?username=thamasky'

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
