### PR TITLE
update plopfile: don't copy next.config.js

### DIFF
--- a/plopfile.mjs
+++ b/plopfile.mjs
@@ -43,7 +43,6 @@ export default function (plop) {
         'README.md',
         'tsconfig.json',
         '.eslintrc.json',
-        'next.config.js',
         '.gitignore',
         'next-env.d.ts',
         'package.json',


### PR DESCRIPTION
### Description

Previously plopfile.js included `next.config.js` in the filesToCopyOver array, but no next.config.js is currently present in `plop-templates/example`. This caused the `pnpm new-example` command to fail. This removes that line from the file, closing #431. 

### Steps to reproduce

- Check out this repository and run `pnpm new-example`, it fails
- Clone this branch and run the same command, it succeeds

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
