### PR TITLE
Fix clone and deploy link in builder-io example

### DIFF
--- a/edge-functions/personalization-builder-io/README.md
+++ b/edge-functions/personalization-builder-io/README.md
@@ -36,9 +36,9 @@ After [setting up your environment variables](#set-up-environment-variables), de
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example https://github.com/vercel/examples/tree/main/edge-functions/ab-testing-statsig
+npx create-next-app --example https://github.com/vercel/examples/tree/main/edge-functions/personalization-builder-io
 # or
-yarn create next-app --example https://github.com/vercel/examples/tree/main/edge-functions/ab-testing-statsig
+yarn create next-app --example https://github.com/vercel/examples/tree/main/edge-functions/personalization-builder-io
 ```
 
 #### Set up environment variables


### PR DESCRIPTION
### Description

personalization-builder-io example linked to statsig example: update it to have the correct link. Closes #391 

### Demo URL

N/A: README update

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
