### PR TITLE
Fix types in `useRouter` usage for multiple examples

### DIFF
--- a/edge-functions/ab-testing-simple/pages/home/[bucket].tsx
+++ b/edge-functions/ab-testing-simple/pages/home/[bucket].tsx
@@ -4,7 +4,7 @@ import { Layout, Page, Text, Button } from '@vercel/examples-ui'
 import { HOME_BUCKETS } from '@lib/buckets'
 
 export default function Home() {
-  const router = useRouter(true)
+  const router = useRouter()
   const setBucket = (bucket: string) => () => {
     Cookies.set('bucket-home', bucket)
     router.reload()

--- a/edge-functions/ab-testing-simple/pages/marketing/[bucket].tsx
+++ b/edge-functions/ab-testing-simple/pages/marketing/[bucket].tsx
@@ -4,7 +4,7 @@ import { Layout, Page, Text, Button } from '@vercel/examples-ui'
 import { MARKETING_BUCKETS } from '@lib/buckets'
 
 export default function Marketing() {
-  const router = useRouter(true)
+  const router = useRouter()
   const setBucket = (bucket: string) => () => {
     Cookies.set('bucket-marketing', bucket)
     router.reload()

--- a/edge-functions/ab-testing-simple/pages/marketing/original.tsx
+++ b/edge-functions/ab-testing-simple/pages/marketing/original.tsx
@@ -4,7 +4,7 @@ import { Layout, Page, Text, Button } from '@vercel/examples-ui'
 import { MARKETING_BUCKETS } from '@lib/buckets'
 
 export default function Marketing() {
-  const router = useRouter(true)
+  const router = useRouter()
   const setBucket = (bucket: string) => () => {
     Cookies.set('bucket-marketing', bucket)
     router.reload()

--- a/edge-functions/ab-testing-statsig/pages/[bucket].tsx
+++ b/edge-functions/ab-testing-statsig/pages/[bucket].tsx
@@ -42,7 +42,7 @@ export const getStaticPaths: GetStaticPaths<{ bucket: string }> = async () => {
 }
 
 function BucketPage({ bucket }: Props) {
-  const { reload } = useRouter(true)
+  const { reload } = useRouter()
 
   function resetBucket() {
     Cookie.remove(UID_COOKIE)

--- a/edge-functions/cookies/pages/beta.tsx
+++ b/edge-functions/cookies/pages/beta.tsx
@@ -3,7 +3,7 @@ import Cookies from 'js-cookie'
 import { Layout, Page, Text, Button } from '@vercel/examples-ui'
 
 export default function Beta() {
-  const router = useRouter(true)
+  const router = useRouter()
 
   const optOut = () => {
     Cookies.set('beta', 'false')

--- a/edge-functions/cookies/pages/non-beta.tsx
+++ b/edge-functions/cookies/pages/non-beta.tsx
@@ -3,7 +3,7 @@ import Cookies from 'js-cookie'
 import { Layout, Page, Text, Button } from '@vercel/examples-ui'
 
 export default function NonBeta() {
-  const router = useRouter(true)
+  const router = useRouter()
 
   const optIn = () => {
     Cookies.set('beta', 'true')

--- a/edge-functions/feature-flag-posthog/lib/posthog.ts
+++ b/edge-functions/feature-flag-posthog/lib/posthog.ts
@@ -9,7 +9,7 @@ export const usePostHog = (
   config?: Partial<PostHogConfig>,
   name?: string
 ): void => {
-  const router = useRouter(true)
+  const router = useRouter()
 
   if (!config) {
     throw new Error('The `config` argument is required.')

--- a/edge-functions/jwt-authentication/pages/protected.tsx
+++ b/edge-functions/jwt-authentication/pages/protected.tsx
@@ -4,7 +4,7 @@ import { Page, Text, Code, Link, Button } from '@vercel/examples-ui'
 import { USER_TOKEN } from '@lib/constants'
 
 export default function Protected() {
-  const { reload } = useRouter(true)
+  const { reload } = useRouter()
 
   return (
     <Page>

--- a/edge-functions/maintenance-page/pages/big-promo.tsx
+++ b/edge-functions/maintenance-page/pages/big-promo.tsx
@@ -2,7 +2,7 @@ import { Layout, Text, Page, Button } from '@vercel/examples-ui'
 import { useRouter } from 'next/router'
 
 function Home() {
-  const { reload } = useRouter(true)
+  const { reload } = useRouter()
 
   return (
     <Page className="flex flex-col gap-12">

--- a/edge-functions/maintenance-page/pages/maintenance.tsx
+++ b/edge-functions/maintenance-page/pages/maintenance.tsx
@@ -2,7 +2,7 @@ import { Layout, Text, Page, Button } from '@vercel/examples-ui'
 import { useRouter } from 'next/router'
 
 function Home() {
-  const { reload } = useRouter(true)
+  const { reload } = useRouter()
 
   return (
     <Page className="flex flex-col gap-12">

--- a/edge-functions/redirects-upstash/pages/posts/[slug].tsx
+++ b/edge-functions/redirects-upstash/pages/posts/[slug].tsx
@@ -5,7 +5,7 @@ import { Layout, Page, Text, Code, Link } from '@vercel/examples-ui'
 export default function Slug() {
   const [links, setLinks] = useState([8000, 800])
 
-  const router = useRouter(true)
+  const router = useRouter()
   const slug = router.query.slug as string
   const latency = router.query.l ?? 0
 

--- a/edge-functions/user-agent-based-rendering/components/Home.tsx
+++ b/edge-functions/user-agent-based-rendering/components/Home.tsx
@@ -5,7 +5,7 @@ import { Layout, Text, Page, Code, Link, Snippet } from '@vercel/examples-ui'
 import board from '../public/board.jpg'
 
 function Home() {
-  const { route } = useRouter(true)
+  const { route } = useRouter()
   const viewport = route.replace('/_viewport/', '')
 
   return (

--- a/solutions/cms-contentstack-commerce/components/ui/I18nWidget/I18nWidget.tsx
+++ b/solutions/cms-contentstack-commerce/components/ui/I18nWidget/I18nWidget.tsx
@@ -36,7 +36,7 @@ const I18nWidget: FC = () => {
     locales,
     defaultLocale = 'en-US',
     asPath: currentPath,
-  } = useRouter(true)
+  } = useRouter()
   const options = locales?.filter((val) => val !== locale)
   const currentLocale = locale || defaultLocale
 

--- a/solutions/testing/pages/signup.tsx
+++ b/solutions/testing/pages/signup.tsx
@@ -4,7 +4,7 @@ import { Layout, Text, Page, Input, Button } from '@vercel/examples-ui'
 
 function Signup() {
   const [loading, setLoading] = useState(false)
-  const router = useRouter(true)
+  const router = useRouter()
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 


### PR DESCRIPTION
### Description

There was a canary version that required to do `useRouter(true)` for some cases, but that's no longer required. 

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
