### PR TITLE
Define relatedTemplates in the add-header example

### DIFF
--- a/edge-functions/add-header/README.md
+++ b/edge-functions/add-header/README.md
@@ -9,6 +9,8 @@ useCase:
 css: Tailwind
 deployUrl: https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/edge-functions/add-header&project-name=add-header&repository-name=add-header
 demoUrl: https://edge-functions-add-header.vercel.app
+relatedTemplates:
+  - nextjs-boilerplate
 ---
 
 # Add Header Example


### PR DESCRIPTION
### Description

Since `relatedTemplates` is missing in the `add-header` example (referenced from a new example `modify-request-header`) it broke the Publish Template action.

This PR fills the missing field to fix CI.

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
