### PR TITLE
convert maintenance-page to Edge Config

### DIFF
--- a/edge-functions/maintenance-page/.env.example
+++ b/edge-functions/maintenance-page/.env.example
@@ -3,4 +3,7 @@
 #
 # Your Edge Config should have a key called isInMaintenanceMode holding a boolean value
 
+# This is a default Edge Config so the example works immediately when trying it
+# out locally. It needs to be replaced if you want to actually make changes to
+# the Edge Config
 EDGE_CONFIG = "https://edge-config.vercel.com/ecfg_1dpprrgopc3atqopkmqpmwj8t3ou?token=a3996050-e5b5-4381-957e-f46fba44e83f"

--- a/edge-functions/maintenance-page/.env.example
+++ b/edge-functions/maintenance-page/.env.example
@@ -1,0 +1,6 @@
+# Create an Edge Config for your project and replace the Connection String below
+# You can find it under the Tokens page of your Edge Config
+#
+# Your Edge Config should have a key called isInMaintenanceMode holding a boolean value
+
+EDGE_CONFIG = "https://edge-config.vercel.com/ecfg_1dpprrgopc3atqopkmqpmwj8t3ou?token=a3996050-e5b5-4381-957e-f46fba44e83f"

--- a/edge-functions/maintenance-page/README.md
+++ b/edge-functions/maintenance-page/README.md
@@ -32,7 +32,11 @@ Copy the `.env.example` file in this directory to `.env.local` (which will be ig
 cp .env.example .env.local
 ```
 
-This example connects to a default Edge Config. You can replace it with your own Edge Config to be able to flip maintenance mode on or off.
+This example connects to a default Edge Config via the `EDGE_CONFIG` environment variable. You can replace it with your own Edge Config to be able to flip maintenance mode on or off. If you use your own Edge Config, it needs to have this content
+
+```json
+{ "isInMaintenanceMode": true }
+```
 
 Next, run Next.js in development mode:
 

--- a/edge-functions/maintenance-page/README.md
+++ b/edge-functions/maintenance-page/README.md
@@ -26,6 +26,14 @@ npx create-next-app --example https://github.com/vercel/examples/tree/main/edge-
 yarn create next-app --example https://github.com/vercel/examples/tree/main/edge-functions/maintenance-page
 ```
 
+Copy the `.env.example` file in this directory to `.env.local` (which will be ignored by Git):
+
+```bash
+cp .env.example .env.local
+```
+
+This example connects to a default Edge Config. You can replace it with your own Edge Config to be able to flip maintenance mode on or off.
+
 Next, run Next.js in development mode:
 
 ```bash

--- a/edge-functions/maintenance-page/middleware.ts
+++ b/edge-functions/maintenance-page/middleware.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { get } from '@vercel/edge-config'
 
 export const config = {
   matcher: '/big-promo',
 }
 
 export async function middleware(req: NextRequest) {
-  // Simulate connection with a redis cache
-  const isInMaintenanceMode = Math.random() >= 0.5
+  // Check whether the maintenance page should be shown
+  const isInMaintenanceMode = await get<boolean>('isInMaintenanceMode')
 
   // If is in maintenance mode, point the url pathname to the maintenance page
   if (isInMaintenanceMode) {

--- a/edge-functions/maintenance-page/package.json
+++ b/edge-functions/maintenance-page/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vercel/examples-ui": "^1.0.4",
+    "@vercel/edge-config": "0.1.0-canary.15",
     "next": "canary",
     "react": "latest",
     "react-dom": "latest"

--- a/edge-functions/maintenance-page/pages/index.tsx
+++ b/edge-functions/maintenance-page/pages/index.tsx
@@ -9,11 +9,11 @@ function Home() {
       <section className="flex flex-col gap-6">
         <Text variant="h1">Maintenance page usage example</Text>
         <Text>
-          When we do a release, promotion, event, etc. That might bring more
+          When we do a release, promotion, event, etc. that might bring more
           attention than usual to a page; Its a good idea to have a backup plan
           that includes showing a different page to the users in case something
           fails. If this page receives a lot of traffic, we can use the edge, a
-          previously generated static page and a redis cache to give the users,
+          previously generated static page and Edge Config to give the users
           dynamic at the speed of static.
         </Text>
         <Image src={board} alt="Graph showing how to use middleware" />
@@ -31,19 +31,17 @@ function Home() {
           this:
         </Text>
         <Snippet>{`import { NextRequest, NextResponse } from 'next/server'
+import { get } from '@vercel/edge-config'
 
 export const config = {
   matcher: '/big-promo',
 }
 
 export async function middleware(req: NextRequest) {
-  // Filter unwanted paths
-  if (req.nextUrl.pathname !== '/big-promo') return NextResponse.next()
+  // Check Edge Config to see if the maintenance page should be shown
+  const isInMaintenanceMode = await get('isInMaintenanceMode')
 
-  // Simulate connection with a redis cache
-  const isInMaintenanceMode = Math.random() >= 0.5
-
-  // If is in maintenance mode, point the url pathname to the maintenance page
+  // If in maintenance mode, point the url pathname to the maintenance page
   if (isInMaintenanceMode) {
     req.nextUrl.pathname = \`/maintenance\`
 
@@ -52,12 +50,7 @@ export async function middleware(req: NextRequest) {
   }
 }`}</Snippet>
         <Text>
-          If you need help with how to use a redis cache with edge functions you
-          can see{' '}
-          <Link href="https://edge-rewrites-upstash.vercel.app/">
-            this example
-          </Link>
-          . If you want to see how this maintenance page works, check the{' '}
+          If you want to see how this maintenance page works, check the{' '}
           <Link href="/big-promo">
             <Code>/big-promo</Code>
           </Link>{' '}

--- a/edge-functions/maintenance-page/pages/maintenance.tsx
+++ b/edge-functions/maintenance-page/pages/maintenance.tsx
@@ -7,8 +7,10 @@ function Home() {
   return (
     <Page className="flex flex-col gap-12">
       <section className="flex flex-col gap-6">
-        <Text variant="h1">Something went wrong 😓</Text>
-        <Text>You can try to refresh the page to see if its fixed.</Text>
+        <Text variant="h1">Under Maintenance</Text>
+        <Text>
+          You can try to refresh the page to see if the issue is resolved.
+        </Text>
         <Button onClick={reload}>Refresh</Button>
       </section>
     </Page>


### PR DESCRIPTION
### Description

Converts the `maintenance-page` example to use Edge Config.

### Demo URL

https://edge-maintenance-page-git-dferber-fla-488-convert-mainte-ba98f8.vercel.sh/

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)
