### PR TITLE
add edge-config category

### DIFF
--- a/edge-functions/feature-flag-apple-store/README.md
+++ b/edge-functions/feature-flag-apple-store/README.md
@@ -9,6 +9,10 @@ useCase:
 css: Tailwind
 deployUrl: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fedge-functions%2Ffeature-flag-apple-store&project-name=feature-flag-apple-store&repo-name=feature-flag-apple-store
 demoUrl: https://edge-functions-feature-flag-apple-store.vercel.app/
+relatedTemplates:
+  - nextjs-boilerplate
+  - platforms-starter-kit
+  - blog-starter-kit
 ---
 
 # Apple Store

--- a/edge-functions/feature-flag-apple-store/README.md
+++ b/edge-functions/feature-flag-apple-store/README.md
@@ -3,7 +3,9 @@ name: Feature Flag Apple Store
 slug: feature-flag-apple-store
 description: This template uses Edge Config as fast storage to control whether an store is open or closed.
 framework: Next.js
-useCase: Edge Functions
+useCase:
+  - Edge Functions
+  - Edge Config
 css: Tailwind
 deployUrl: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fedge-functions%2Ffeature-flag-apple-store&project-name=feature-flag-apple-store&repo-name=feature-flag-apple-store
 demoUrl: https://edge-functions-feature-flag-apple-store.vercel.app/

--- a/edge-functions/maintenance-page/README.md
+++ b/edge-functions/maintenance-page/README.md
@@ -1,3 +1,16 @@
+---
+name: Maintenance
+slug: maintenance-page
+description: This template shows how to quickly trigger a maintenance page using Edge Config
+framework: Next.js
+useCase:
+  - Edge Functions
+  - Edge Config
+css: Tailwind
+deployUrl: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fedge-functions%2Fmaintenance-page&project-name=maintenance-page&repo-name=maintenance-page
+demoUrl: https://edge-maintenance-page.vercel.app/
+---
+
 # maintenance-page example
 
 This example shows how to implement a maintenance page on the edge

--- a/edge-functions/maintenance-page/README.md
+++ b/edge-functions/maintenance-page/README.md
@@ -9,6 +9,10 @@ useCase:
 css: Tailwind
 deployUrl: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fedge-functions%2Fmaintenance-page&project-name=maintenance-page&repo-name=maintenance-page
 demoUrl: https://edge-maintenance-page.vercel.app/
+relatedTemplates:
+  - feature-flag-apple-store
+  - nextjs-boilerplate
+  - blog-starter-kit
 ---
 
 # maintenance-page example


### PR DESCRIPTION
### Description

- adds category for Edge Config
- adds frontmatter to maintenance-page example so it actually shows up on vercel.com/templates
