### PR TITLE
Update metadata in Edge Config examples

### DIFF
--- a/edge-functions/feature-flag-apple-store/README.md
+++ b/edge-functions/feature-flag-apple-store/README.md
@@ -10,9 +10,9 @@ css: Tailwind
 deployUrl: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fedge-functions%2Ffeature-flag-apple-store&project-name=feature-flag-apple-store&repo-name=feature-flag-apple-store
 demoUrl: https://edge-functions-feature-flag-apple-store.vercel.app/
 relatedTemplates:
-  - nextjs-boilerplate
-  - blog-starter-kit
+  - maintenance-page
   - ab-testing-simple
+  - nextjs-boilerplate
 ---
 
 # Apple Store

--- a/edge-functions/maintenance-page/README.md
+++ b/edge-functions/maintenance-page/README.md
@@ -1,5 +1,5 @@
 ---
-name: Maintenance
+name: Maintenance Page
 slug: maintenance-page
 description: This template shows how to quickly trigger a maintenance page using Edge Config
 framework: Next.js


### PR DESCRIPTION
### Description

The maintenance page example is now in contentful, and this PR will also update the feature-flag-apple-store one in contentful, which failed to update last time due to a missing field in another example.

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (changes to the codebase, but not to examples)
