### PR TITLE
use 24h for uid cookie

### DIFF
--- a/edge-functions/ab-testing-statsig/middleware.ts
+++ b/edge-functions/ab-testing-statsig/middleware.ts
@@ -36,7 +36,9 @@ export async function middleware(req: NextRequest) {
 
   // Add the user ID to the response cookies if it's not there or if its value was invalid
   if (!hasUserId) {
-    res.cookies.set(UID_COOKIE, userId)
+    res.cookies.set(UID_COOKIE, userId, {
+      maxAge: 60 * 60 * 24, // identify users for 24 hours
+    })
   }
 
   return res


### PR DESCRIPTION
### Description

- fixes issue where bucket would reset on page reload as the session cookie seems to expire