### PR TITLE
fix edge-config based templates when missing env vars

### DIFF
--- a/edge-functions/feature-flag-apple-store/.env.example
+++ b/edge-functions/feature-flag-apple-store/.env.example
@@ -1,12 +1,3 @@
-# Create an Edge Config for your project and replace the Connection String below
-# You can find it under the Tokens page of your Edge Config
-#
-# Your Edge Config should have a key called featureFlagsAppleStore_storeClosed
-# holding a boolean value
-
-# This is a default Edge Config so the example works immediately when trying it
-# out locally. It needs to be replaced if you want to actually make changes to
-# the Edge Config
-EDGE_CONFIG = "https://edge-config.vercel.com/ecfg_1dpprrgopc3atqopkmqpmwj8t3ou?token=a3996050-e5b5-4381-957e-f46fba44e83f"
+EDGE_CONFIG = 
 TEAM_ID_VERCEL=
 AUTH_BEARER_TOKEN=

--- a/edge-functions/feature-flag-apple-store/README.md
+++ b/edge-functions/feature-flag-apple-store/README.md
@@ -51,7 +51,7 @@ Copy the `.env.example` file in this directory to `.env.local` (which will be ig
 cp .env.example .env.local
 ```
 
-This example connects to a default Edge Config via the `EDGE_CONFIG` environment variable. You can replace it with your own Edge Config to be able to flip store on or off. If you use your own Edge Config, it needs to have this content
+This example requires you to set up an Edge Config and store its connection string in the `EDGE_CONFIG` environment variable. Fill the Edge Config you create with this content:
 
 ```json
 { "featureFlagsAppleStore_storeClosed": true }
@@ -73,7 +73,7 @@ Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&ut
 
 ## Opening / Closing the Store
 
-We can use API routes or Vercel's Edge Config UI to update Edge Config.
+You can control whether the store is open or not by changing the value of `featureFlagsAppleStore_storeClosed`. Use API routes or Vercel's Edge Config UI to update Edge Config.
 
 > Note that you need to provide your own `TEAM_ID_VERCEL` and `AUTH_BEARER_TOKEN` environment variables in `.env.local` if you want to open or close the store as shown below.
 

--- a/edge-functions/feature-flag-apple-store/lib/feature-flags.ts
+++ b/edge-functions/feature-flag-apple-store/lib/feature-flags.ts
@@ -18,10 +18,15 @@ export async function set(key: keyof FeatureFlags, value: boolean) {
   if (!process.env.AUTH_BEARER_TOKEN) {
     throw new Error('Missing Environment Variable AUTH_BEARER_TOKEN')
   }
+  if (!process.env.EDGE_CONFIG) {
+    throw new Error('Missing Environment Variable EDGE_CONFIG')
+  }
 
   const connectionString = parseConnectionString(process.env.EDGE_CONFIG!)
   if (!connectionString) {
-    throw new Error('Could not parse EDGE_CONFIG connection string')
+    throw new Error(
+      'Could not parse connection string stored in EDGE_CONFIG environment variable'
+    )
   }
 
   const edgeConfigId = connectionString.id

--- a/edge-functions/feature-flag-apple-store/lib/feature-flags.ts
+++ b/edge-functions/feature-flag-apple-store/lib/feature-flags.ts
@@ -15,9 +15,14 @@ export async function get(key: keyof FeatureFlags) {
 }
 
 export async function set(key: keyof FeatureFlags, value: boolean) {
-  const connectionString = parseConnectionString(process.env.EDGE_CONFIG!)
+  if (!process.env.AUTH_BEARER_TOKEN) {
+    throw new Error('Missing Environment Variable AUTH_BEARER_TOKEN')
+  }
 
-  if (!connectionString) throw new Error('Could not parse connection string')
+  const connectionString = parseConnectionString(process.env.EDGE_CONFIG!)
+  if (!connectionString) {
+    throw new Error('Could not parse EDGE_CONFIG connection string')
+  }
 
   const edgeConfigId = connectionString.id
   const prefixedKey = prefixKey(key)

--- a/edge-functions/feature-flag-apple-store/lib/feature-flags.ts
+++ b/edge-functions/feature-flag-apple-store/lib/feature-flags.ts
@@ -1,7 +1,5 @@
 import { createClient, parseConnectionString } from '@vercel/edge-config'
 
-const edgeConfig = createClient(process.env.EDGE_CONFIG)
-
 interface FeatureFlags {
   storeClosed: boolean
 }
@@ -11,6 +9,7 @@ const prefixKey = (key: string) => `featureFlagsAppleStore_${key}`
 
 export async function get(key: keyof FeatureFlags) {
   const prefixedKey = prefixKey(key)
+  const edgeConfig = createClient(process.env.EDGE_CONFIG)
   const featureFlag = await edgeConfig.get<FeatureFlags>(prefixedKey)
   return featureFlag
 }

--- a/edge-functions/feature-flag-apple-store/middleware.ts
+++ b/edge-functions/feature-flag-apple-store/middleware.ts
@@ -6,8 +6,12 @@ export const config = {
 }
 
 export async function middleware(req: NextRequest) {
-  if (await get('storeClosed')) {
-    req.nextUrl.pathname = `/_closed`
-    return NextResponse.rewrite(req.nextUrl)
+  try {
+    if (await get('storeClosed')) {
+      req.nextUrl.pathname = `/_closed`
+      return NextResponse.rewrite(req.nextUrl)
+    }
+  } catch (error) {
+    console.error(error)
   }
 }

--- a/edge-functions/feature-flag-apple-store/middleware.ts
+++ b/edge-functions/feature-flag-apple-store/middleware.ts
@@ -1,11 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { get } from 'lib/feature-flags'
+import { parseConnectionString } from '@vercel/edge-config'
 
 export const config = {
   matcher: '/',
 }
 
 export async function middleware(req: NextRequest) {
+  // for demo purposes, warn when there is no EDGE_CONFIG
+  if (
+    !process.env.EDGE_CONFIG ||
+    !parseConnectionString(process.env.EDGE_CONFIG)
+  ) {
+    req.nextUrl.pathname = '/missing-edge-config'
+    return NextResponse.rewrite(req.nextUrl)
+  }
+
   try {
     if (await get('storeClosed')) {
       req.nextUrl.pathname = `/_closed`

--- a/edge-functions/feature-flag-apple-store/pages/api/store/close.ts
+++ b/edge-functions/feature-flag-apple-store/pages/api/store/close.ts
@@ -14,13 +14,17 @@ export default async function CloseStore() {
 
     return new Response(
       JSON.stringify({ status: 'ok', message: 'Store is now closed' }),
+      { headers: { 'Content-Type': 'application/json' } }
+    )
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        status: 'error',
+        message: err instanceof Error ? err.message : err,
+      }),
       {
         headers: { 'Content-Type': 'application/json' },
       }
     )
-  } catch (err) {
-    return new Response(JSON.stringify({ status: 'error', message: err }), {
-      headers: { 'Content-Type': 'application/json' },
-    })
   }
 }

--- a/edge-functions/feature-flag-apple-store/pages/api/store/open.ts
+++ b/edge-functions/feature-flag-apple-store/pages/api/store/open.ts
@@ -14,13 +14,17 @@ export default async function OpenStore() {
 
     return new Response(
       JSON.stringify({ status: 'ok', message: 'Store is now open' }),
+      { headers: { 'Content-Type': 'application/json' } }
+    )
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        status: 'error',
+        message: err instanceof Error ? err.message : err,
+      }),
       {
         headers: { 'Content-Type': 'application/json' },
       }
     )
-  } catch (err) {
-    return new Response(JSON.stringify({ status: 'error', message: err }), {
-      headers: { 'Content-Type': 'application/json' },
-    })
   }
 }

--- a/edge-functions/feature-flag-apple-store/pages/missing-edge-config.tsx
+++ b/edge-functions/feature-flag-apple-store/pages/missing-edge-config.tsx
@@ -1,0 +1,82 @@
+export default function MissingEdgeConfigDialog() {
+  return (
+    <div
+      className="relative z-10"
+      aria-labelledby="modal-title"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+      <div className="fixed inset-0 z-10 overflow-y-auto">
+        <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+          <div className="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+            <div className="sm:flex sm:items-start">
+              <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 sm:mx-0 sm:h-10 sm:w-10">
+                {/* Heroicon name: outline/exclamation-triangle */}
+                <svg
+                  className="h-6 w-6 text-gray-600"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth="1.5"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 10.5v3.75m-9.303 3.376C1.83 19.126 2.914 21 4.645 21h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 4.88c-.866-1.501-3.032-1.501-3.898 0L2.697 17.626zM12 17.25h.007v.008H12v-.008z"
+                  />
+                </svg>
+              </div>
+              <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                <h3
+                  className="text-lg font-medium leading-6 text-gray-900"
+                  id="modal-title"
+                >
+                  Incomplete Environment Variables Setup
+                </h3>
+                <div className="mt-2">
+                  <p className="text-sm text-gray-500">
+                    Follow these steps to finish the setup of this example:
+                  </p>
+                  <ol className="text-sm text-gray-500 list-disc ml-8 mt-2 flex gap-2 flex-col">
+                    <li className="list-item">
+                      Create an Edge Config and connect it to this project and
+                      store its connection string under the{' '}
+                      <span className="bg-gray-100 p-1 text-gray-900 rounded">
+                        EDGE_CONFIG
+                      </span>{' '}
+                      environment variable
+                    </li>
+                    <li className="list-item">
+                      Pull your latest Environment Variables if you are
+                      developing locally
+                    </li>
+                    <li className="list-item">
+                      Restart or redeploy your application
+                    </li>
+                  </ol>
+                  <p className="text-sm text-gray-500 mt-2">
+                    Then reload the page and this dialog will go away if your
+                    setup is correct.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="mt-5 sm:mt-4 sm:ml-10 sm:flex sm:pl-4">
+              <a
+                href="https://github.com/vercel/examples/blob/main/edge-functions/feature-flag-apple-store/README.md#set-up-environment-variables"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex w-full justify-center rounded-md border border-transparent bg-gray-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 sm:w-auto sm:text-sm"
+              >
+                Open Documentation
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/edge-functions/maintenance-page/.env.example
+++ b/edge-functions/maintenance-page/.env.example
@@ -1,9 +1,1 @@
-# Create an Edge Config for your project and replace the Connection String below
-# You can find it under the Tokens page of your Edge Config
-#
-# Your Edge Config should have a key called isInMaintenanceMode holding a boolean value
-
-# This is a default Edge Config so the example works immediately when trying it
-# out locally. It needs to be replaced if you want to actually make changes to
-# the Edge Config
-EDGE_CONFIG = "https://edge-config.vercel.com/ecfg_1dpprrgopc3atqopkmqpmwj8t3ou?token=a3996050-e5b5-4381-957e-f46fba44e83f"
+EDGE_CONFIG = 

--- a/edge-functions/maintenance-page/README.md
+++ b/edge-functions/maintenance-page/README.md
@@ -42,13 +42,15 @@ npx create-next-app --example https://github.com/vercel/examples/tree/main/edge-
 yarn create next-app --example https://github.com/vercel/examples/tree/main/edge-functions/maintenance-page
 ```
 
+#### Set up environment variables
+
 Copy the `.env.example` file in this directory to `.env.local` (which will be ignored by Git):
 
 ```bash
 cp .env.example .env.local
 ```
 
-This example connects to a default Edge Config via the `EDGE_CONFIG` environment variable. You can replace it with your own Edge Config to be able to flip maintenance mode on or off. If you use your own Edge Config, it needs to have this content
+This example requires you to set up an Edge Config and store its connection string in the `EDGE_CONFIG` environment variable. Fill the Edge Config you create with this content:
 
 ```json
 { "isInMaintenanceMode": true }

--- a/edge-functions/maintenance-page/middleware.ts
+++ b/edge-functions/maintenance-page/middleware.ts
@@ -6,14 +6,20 @@ export const config = {
 }
 
 export async function middleware(req: NextRequest) {
-  // Check whether the maintenance page should be shown
-  const isInMaintenanceMode = await get<boolean>('isInMaintenanceMode')
+  try {
+    // Check whether the maintenance page should be shown
+    const isInMaintenanceMode = await get<boolean>('isInMaintenanceMode')
 
-  // If is in maintenance mode, point the url pathname to the maintenance page
-  if (isInMaintenanceMode) {
-    req.nextUrl.pathname = `/maintenance`
+    // If is in maintenance mode, point the url pathname to the maintenance page
+    if (isInMaintenanceMode) {
+      req.nextUrl.pathname = `/maintenance`
 
-    // Rewrite to the url
-    return NextResponse.rewrite(req.nextUrl)
+      // Rewrite to the url
+      return NextResponse.rewrite(req.nextUrl)
+    }
+  } catch (error) {
+    // show the default page if EDGE_CONFIG env var is missing,
+    // but log the error to the console
+    console.error(error)
   }
 }

--- a/edge-functions/maintenance-page/middleware.ts
+++ b/edge-functions/maintenance-page/middleware.ts
@@ -2,10 +2,15 @@ import { NextRequest, NextResponse } from 'next/server'
 import { get } from '@vercel/edge-config'
 
 export const config = {
-  matcher: '/big-promo',
+  matcher: ['/big-promo'],
 }
 
 export async function middleware(req: NextRequest) {
+  if (!process.env.EDGE_CONFIG) {
+    req.nextUrl.pathname = `/missing-edge-config`
+    return NextResponse.rewrite(req.nextUrl)
+  }
+
   try {
     // Check whether the maintenance page should be shown
     const isInMaintenanceMode = await get<boolean>('isInMaintenanceMode')

--- a/edge-functions/maintenance-page/pages/missing-edge-config.tsx
+++ b/edge-functions/maintenance-page/pages/missing-edge-config.tsx
@@ -66,7 +66,7 @@ export default function MissingEdgeConfigDialog() {
             </div>
             <div className="mt-5 sm:mt-4 sm:ml-10 sm:flex sm:pl-4">
               <a
-                href="https://github.com/vercel/examples/blob/main/edge-functions/feature-flag-apple-store/README.md#set-up-environment-variables"
+                href="https://github.com/vercel/examples/blob/main/edge-functions/maintenance-page/README.md#set-up-environment-variables"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex w-full justify-center rounded-md border border-transparent bg-gray-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 sm:w-auto sm:text-sm"


### PR DESCRIPTION
### Description

Prevent the 500 error when cloning the example without any env vars

- fixes feature-flags-apple-store so it fails gracefully when deploying without env vars
- fixes maintenance-page so it fails gracefully when deploying without env vars


Try the end-to-end flows here
- [Deploy `feature-flag-apple-store`](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Ffix-feature-flags-example-if-edge-config-is-missing%2Fedge-functions%2Ffeature-flag-apple-store&project-name=feature-flag-apple-store&repo-name=feature-flag-apple-store&demo-title=Feature+Flag+Apple+Store&demo-description=This+template+uses+Edge+Config+as+fast+storage+to+control+whether+an+store+is+open+or+closed.&demo-url=https%3A%2F%2Fedge-functions-feature-flag-apple-store.vercel.app%2F&demo-image=%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2F67vzHW0HqJADxLhQJfGF79%2Fda4e1d5e669d3288ec29c206e53b5844%2Fedge-functions-feature-flag-apple-store.vercel.app_.png&repository-name=feature-flag-apple-store&teamCreateStatus=hidden)