### PR TITLE
Update examples to use `edge` runtime

### DIFF
--- a/edge-api-routes/authed-proxy/api/proxy.ts
+++ b/edge-api-routes/authed-proxy/api/proxy.ts
@@ -1,34 +1,37 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async (req: Request) => {
   // Fetch from the backend, but copy the user's authorization cookie into
   // the authorization header.
-  const r = await fetch("https://res.cloudinary.com/zeit-inc/image/fetch/https://raw.githubusercontent.com/vercel/vercel/main/packages/frameworks/logos/next.svg", {
-    headers: {
-      authorization: getCookies(req).get("authorization") || ""
+  const r = await fetch(
+    'https://res.cloudinary.com/zeit-inc/image/fetch/https://raw.githubusercontent.com/vercel/vercel/main/packages/frameworks/logos/next.svg',
+    {
+      headers: {
+        authorization: getCookies(req).get('authorization') || '',
+      },
     }
-  });
+  )
   return new Response(r.body, {
     status: r.status,
     headers: {
       // Allow list of backend headers.
-      'content-type': r.headers.get("content-type") || ''
-    }
+      'content-type': r.headers.get('content-type') || '',
+    },
   })
 }
 
 function getCookies(req: Request) {
-  const cookie = req.headers.get("cookie");
-  const cookies = new Map();
+  const cookie = req.headers.get('cookie')
+  const cookies = new Map()
   if (!cookie) {
-    return cookies;
+    return cookies
   }
-  const pairs = cookie.split(/;\s+/);
+  const pairs = cookie.split(/;\s+/)
   for (const pair of pairs) {
-    const parts = pair.trim().split("=");
-    cookies.set(parts[0], parts[1]);
+    const parts = pair.trim().split('=')
+    cookies.set(parts[0], parts[1])
   }
-  return cookies;
+  return cookies
 }

--- a/edge-api-routes/cache-control/api/edge.ts
+++ b/edge-api-routes/cache-control/api/edge.ts
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req) {

--- a/edge-api-routes/hello-world/api/edge.ts
+++ b/edge-api-routes/hello-world/api/edge.ts
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default (req) => new Response('Hello world!')

--- a/edge-api-routes/json-response/api/edge.ts
+++ b/edge-api-routes/json-response/api/edge.ts
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req) {

--- a/edge-api-routes/query-parameters/api/edge.ts
+++ b/edge-api-routes/query-parameters/api/edge.ts
@@ -1,5 +1,5 @@
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 // http://localhost:3000/api/edge?email=test@test.com

--- a/edge-api-routes/wasm-rust-hello-world/api/wasm.ts
+++ b/edge-api-routes/wasm-rust-hello-world/api/wasm.ts
@@ -2,7 +2,7 @@
 import wasm from '../wasm/pkg/wasm_bg.wasm?module'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler() {

--- a/edge-api-routes/wasm-rust-xor/api/xor.ts
+++ b/edge-api-routes/wasm-rust-xor/api/xor.ts
@@ -2,7 +2,7 @@
 import wasm from '../wasm/pkg/wasm_bg.wasm?module'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 function convertToNumber(given: string) {

--- a/edge-functions/api-rate-limit-and-tokens/pages/api/ping.ts
+++ b/edge-functions/api-rate-limit-and-tokens/pages/api/ping.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from 'next/server'
 import { tokenRateLimit } from '@lib/api/keys'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req: NextRequest) {

--- a/edge-functions/api-rate-limit/pages/api/ping.ts
+++ b/edge-functions/api-rate-limit/pages/api/ping.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from 'next/server'
 import { ipRateLimit } from '@lib/ip-rate-limit'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req: NextRequest) {

--- a/edge-functions/cors/README.md
+++ b/edge-functions/cors/README.md
@@ -20,7 +20,7 @@ import { NextRequest } from 'next/server'
 import cors from '../../lib/cors'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req: NextRequest) {

--- a/edge-functions/cors/pages/api/hello.ts
+++ b/edge-functions/cors/pages/api/hello.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server'
 import cors from '../../lib/cors'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req: NextRequest) {

--- a/edge-functions/crypto/pages/api/crypto.ts
+++ b/edge-functions/crypto/pages/api/crypto.ts
@@ -5,7 +5,7 @@ import type { NextRequest } from 'next/server'
 // ------------------
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function CryptoEdgeAPIRoute(request: NextRequest) {

--- a/edge-functions/feature-flag-apple-store/pages/api/store/close.ts
+++ b/edge-functions/feature-flag-apple-store/pages/api/store/close.ts
@@ -1,7 +1,7 @@
 import { set } from 'lib/feature-flags'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function CloseStore() {

--- a/edge-functions/feature-flag-apple-store/pages/api/store/open.ts
+++ b/edge-functions/feature-flag-apple-store/pages/api/store/open.ts
@@ -1,7 +1,7 @@
 import { set } from 'lib/feature-flags'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function OpenStore() {

--- a/edge-functions/jwt-authentication/pages/api/auth.ts
+++ b/edge-functions/jwt-authentication/pages/api/auth.ts
@@ -3,7 +3,7 @@ import { setUserCookie } from '@lib/auth'
 import { jsonResponse } from '@lib/utils'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function auth(req: NextRequest) {

--- a/edge-functions/jwt-authentication/pages/api/expire.ts
+++ b/edge-functions/jwt-authentication/pages/api/expire.ts
@@ -3,7 +3,7 @@ import { expireUserCookie } from '@lib/auth'
 import { jsonResponse } from '@lib/utils'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function expire(req: NextRequest) {

--- a/edge-functions/jwt-authentication/pages/api/protected.ts
+++ b/edge-functions/jwt-authentication/pages/api/protected.ts
@@ -2,7 +2,7 @@ import { type NextRequest } from 'next/server'
 import { jsonResponse } from '@lib/utils'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function protect(req: NextRequest) {

--- a/edge-functions/streams/pages/api/01-simple.ts
+++ b/edge-functions/streams/pages/api/01-simple.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(_: NextRequest) {

--- a/edge-functions/streams/pages/api/02-simple-transform.ts
+++ b/edge-functions/streams/pages/api/02-simple-transform.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(_: NextRequest) {

--- a/edge-functions/streams/pages/api/03-external-transform.ts
+++ b/edge-functions/streams/pages/api/03-external-transform.ts
@@ -4,7 +4,7 @@ const RESOURCE_URL =
   'https://gist.githubusercontent.com/okbel/8ba642143f6912548df2d79f2c0ebabe/raw/4bcf9dc5750b42fa225cf6571d6aaa68c23a73aa/README.md'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(_: NextRequest) {

--- a/edge-functions/vercel-og-nextjs/pages/api/custom-font.tsx
+++ b/edge-functions/vercel-og-nextjs/pages/api/custom-font.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from '@vercel/og'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 const font = fetch(new URL('../../assets/TYPEWR__.TTF', import.meta.url)).then(

--- a/edge-functions/vercel-og-nextjs/pages/api/dynamic-image.tsx
+++ b/edge-functions/vercel-og-nextjs/pages/api/dynamic-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from '@vercel/og'
 import { NextRequest } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler(req: NextRequest) {

--- a/edge-functions/vercel-og-nextjs/pages/api/emoji.tsx
+++ b/edge-functions/vercel-og-nextjs/pages/api/emoji.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from '@vercel/og'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler() {

--- a/edge-functions/vercel-og-nextjs/pages/api/encrypted.tsx
+++ b/edge-functions/vercel-og-nextjs/pages/api/encrypted.tsx
@@ -6,7 +6,7 @@ import { ImageResponse } from '@vercel/og'
 import { NextRequest } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 const key = crypto.subtle.importKey(

--- a/edge-functions/vercel-og-nextjs/pages/api/image-svg.tsx
+++ b/edge-functions/vercel-og-nextjs/pages/api/image-svg.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from '@vercel/og'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler() {

--- a/edge-functions/vercel-og-nextjs/pages/api/language.tsx
+++ b/edge-functions/vercel-og-nextjs/pages/api/language.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from '@vercel/og'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler() {

--- a/edge-functions/vercel-og-nextjs/pages/api/param.tsx
+++ b/edge-functions/vercel-og-nextjs/pages/api/param.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from '@vercel/og'
 import { NextRequest } from 'next/server'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default function handler(req: NextRequest) {

--- a/edge-functions/vercel-og-nextjs/pages/api/static.tsx
+++ b/edge-functions/vercel-og-nextjs/pages/api/static.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from '@vercel/og'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default function handler() {

--- a/edge-functions/vercel-og-nextjs/pages/api/tailwind.tsx
+++ b/edge-functions/vercel-og-nextjs/pages/api/tailwind.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from '@vercel/og'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler() {

--- a/edge-functions/vercel-og-nextjs/pages/api/vercel.tsx
+++ b/edge-functions/vercel-og-nextjs/pages/api/vercel.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from '@vercel/og'
 
 export const config = {
-  runtime: 'experimental-edge',
+  runtime: 'edge',
 }
 
 export default async function handler() {


### PR DESCRIPTION
Beginning in Next.js v13.0.7, API routes can now specify the runtime as `edge` (without needing `experimental-edge`). Update the occurrences within our API Routes to be `edge`.

### Description

This PR update all occurrences of the runtime configuration of `experimental-edge` with `edge` in API routes.

(In addition, the `edge-api-routes/authed-proxy/api/proxy.ts` file was updated automatically by `prettier`.)

This is a straightforward change, given that our examples are all targeting a new Next.js. In addition, all examples that were changed were tested locally, but we should do a final 👀 post-deploy to ensure that they all work as deploye.d

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
