### PR TITLE
fix port unavailable issue when running next start

### DIFF
--- a/solutions/microfrontends/apps/docs/package.json
+++ b/solutions/microfrontends/apps/docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev -p 3001",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 3001",
     "lint": "next lint",
     "clean": "rm -rf .next && rm -rf .turbo"
   },


### PR DESCRIPTION
### Description

running multiple next apps with `pnpm start` enforces all the apps to run on port 3000. causing port not available error for all the apps other than the main app

![image](https://user-images.githubusercontent.com/26733312/211392107-4769ebf7-41bc-4cf7-8215-98da62cc5087.png)

### Solution
running the next apps on unique port.
added `-p 3001` to the start script
