### PR TITLE
refactor ai chat example to use edge

### DIFF
--- a/solutions/ai-chatgpt/README.md
+++ b/solutions/ai-chatgpt/README.md
@@ -1,6 +1,12 @@
 # AI Chat GPT-3 example
 
-This example shows how to implement a simple chat bot using Next.js, API Routes, and [OpenAI SDK](https://beta.openai.com/docs/api-reference/completions/create).
+This example shows how to implement a simple chat bot using Next.js, API Routes, and [OpenAI API](https://beta.openai.com/docs/api-reference/completions/create).
+
+### Components
+
+- Next.js
+- OpenAI API (REST endpoint)
+- API Routes (Edge runtime)
 
 ## Demo
 

--- a/solutions/ai-chatgpt/package.json
+++ b/solutions/ai-chatgpt/package.json
@@ -12,7 +12,6 @@
     "@vercel/analytics": "^0.1.6",
     "@vercel/examples-ui": "^1.0.4",
     "next": "latest",
-    "openai": "^3.1.0",
     "react": "latest",
     "react-cookie": "^4.1.1",
     "react-dom": "latest",

--- a/solutions/ai-chatgpt/pages/api/chat.ts
+++ b/solutions/ai-chatgpt/pages/api/chat.ts
@@ -1,5 +1,4 @@
-import { Configuration, OpenAIApi } from 'openai'
-
+import type { NextRequest } from 'next/server'
 import { initialMessages } from '../../components/Chat'
 import { type Message } from '../../components/ChatLine'
 
@@ -8,15 +7,9 @@ if (!process.env.OPENAI_API_KEY) {
   throw new Error('Missing Environment Variable OPENAI_API_KEY')
 }
 
-const configuration = new Configuration({
-  apiKey: process.env.OPENAI_API_KEY,
-})
-
 const botName = 'AI'
 const userName = 'News reporter' // TODO: move to ENV var
 const firstMessge = initialMessages[0].message
-
-const openai = new OpenAIApi(configuration)
 
 // @TODO: unit test this. good case for unit testing
 const generatePromptFromMessages = (messages: Message[]) => {
@@ -43,9 +36,16 @@ const generatePromptFromMessages = (messages: Message[]) => {
   return prompt
 }
 
-export default async function handler(req: any, res: any) {
-  const messages = req.body.messages
-  const messagesPrompt = generatePromptFromMessages(messages)
+export const config = {
+  runtime: 'edge',
+}
+
+export default async function handler(req: NextRequest) {
+  // read body from request
+  const body = await req.json()
+
+  // const messages = req.body.messages
+  const messagesPrompt = generatePromptFromMessages(body.messages)
   const defaultPrompt = `I am Friendly AI Assistant. \n\nThis is the conversation between AI Bot and a news reporter.\n\n${botName}: ${firstMessge}\n${userName}: ${messagesPrompt}\n${botName}: `
   const finalPrompt = process.env.AI_PROMPT
     ? `${process.env.AI_PROMPT}${messagesPrompt}\n${botName}: `
@@ -62,17 +62,25 @@ export default async function handler(req: any, res: any) {
     frequency_penalty: 0,
     presence_penalty: 0,
     stop: [`${botName}:`, `${userName}:`],
-    user: req.body?.user,
+    user: body?.user,
   }
 
-  /**
-   * @doc https://vercel.com/docs/concepts/limits/overview#serverless-function-execution-timeout
-   * Serverless Function Execution Timeout
-   * The maximum execution timeout is 10 seconds when deployed on a Personal Account (Hobby plan).
-   * For Teams, the execution timeout is 60 seconds (Pro plan) or 900 seconds (Enterprise plan).
-   */
-  const response = await openai.createCompletion(payload)
-  const firstResponse = response.data.choices[0].text
+  const response = await fetch('https://api.openai.com/v1/completions', {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
 
-  res.status(200).json({ text: firstResponse })
+  const data = await response.json()
+
+  // return response with 200 and stringify json text
+  return new Response(JSON.stringify({ text: data.choices[0].text }), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+    },
+  })
 }

--- a/solutions/ai-chatgpt/pages/api/chat.ts
+++ b/solutions/ai-chatgpt/pages/api/chat.ts
@@ -1,4 +1,4 @@
-import type { NextRequest } from 'next/server'
+import { type NextRequest, NextResponse } from 'next/server'
 import { initialMessages } from '../../components/Chat'
 import { type Message } from '../../components/ChatLine'
 
@@ -77,10 +77,5 @@ export default async function handler(req: NextRequest) {
   const data = await response.json()
 
   // return response with 200 and stringify json text
-  return new Response(JSON.stringify({ text: data.choices[0].text }), {
-    status: 200,
-    headers: {
-      'content-type': 'application/json',
-    },
-  })
+  return NextResponse.json({ text: data.choices[0].text })
 }


### PR DESCRIPTION
### Description

- replace OpenAI SDK with standard fetch and OpenAI REST endpoint in order to [reduce the overall size and make it work on the edge](https://github.com/openai/openai-node/issues/47)
- switch API Route from serverless `nodejs` to `edge` runtime
- Now Response can be streamed even longer than 10 seconds with this method


### Demo URL

https://ai-chatgpt-k8d3achfc-vercel-solutions-vtest314.vercel.app/


### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
