### PR TITLE
Fix typo in variable name: last10mesages to last10messages

### DIFF
--- a/solutions/ai-chatgpt/components/Chat.tsx
+++ b/solutions/ai-chatgpt/components/Chat.tsx
@@ -66,7 +66,7 @@ export function Chat() {
       { message: message, who: 'user' } as Message,
     ]
     setMessages(newMessages)
-    const last10mesages = newMessages.slice(-10)
+    const last10messages = newMessages.slice(-10)
 
     const response = await fetch('/api/chat', {
       method: 'POST',
@@ -74,7 +74,7 @@ export function Chat() {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        messages: last10mesages,
+        messages: last10messages,
         user: cookie[COOKIE_NAME],
       }),
     })


### PR DESCRIPTION
### Description

I have made a small edit to the code by correcting a typo in the variable name `'last10mesages'` to `'last10messages'`. This change ensures that the code is functioning as intended and does not cause any errors. Please review and let me know if there are any further changes needed. Thank you!



```diff
+ const last10messages = newMessages.slice(-10);
- const last10mesages = newMessages.slice(-10);
```
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
