### PR TITLE
fix og example by bumping latest

### DIFF
--- a/edge-functions/vercel-og-nextjs/package.json
+++ b/edge-functions/vercel-og-nextjs/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/og": "0.0.20",
+    "@vercel/og": "latest",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"


### PR DESCRIPTION
### Description

Use latest `@vercel/og` so it fixes the embedded svg triangle

### Demo URL

https://vercel-og-nextjs-clone2-c5a2kdice-uncurated-tests.vercel.app/api/vercel

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

