### PR TITLE
feat(ai-chatgpt): convert OpenAI example into BYOK

### DIFF
--- a/solutions/ai-chatgpt/components/ChatAPI.tsx
+++ b/solutions/ai-chatgpt/components/ChatAPI.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Button } from './Button'
+import { InputMessage } from './InputMessage'
 import { type Message, ChatLine, LoadingChatLine } from './ChatLine'
 import { useCookies } from 'react-cookie'
 
@@ -12,37 +12,6 @@ export const initialMessages: Message[] = [
     message: 'Hi! I’m A friendly AI assistant. Ask me anything!',
   },
 ]
-
-const InputMessage = ({ input, setInput, sendMessage }: any) => (
-  <div className="mt-6 flex clear-both">
-    <input
-      type="text"
-      aria-label="chat input"
-      required
-      className="min-w-0 flex-auto appearance-none rounded-md border border-zinc-900/10 bg-white px-3 py-[calc(theme(spacing.2)-1px)] shadow-md shadow-zinc-800/5 placeholder:text-zinc-400 focus:border-teal-500 focus:outline-none focus:ring-4 focus:ring-teal-500/10 sm:text-sm"
-      value={input}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter') {
-          sendMessage(input)
-          setInput('')
-        }
-      }}
-      onChange={(e) => {
-        setInput(e.target.value)
-      }}
-    />
-    <Button
-      type="submit"
-      className="ml-4 flex-none"
-      onClick={() => {
-        sendMessage(input)
-        setInput('')
-      }}
-    >
-      Say
-    </Button>
-  </div>
-)
 
 export function Chat() {
   const [messages, setMessages] = useState<Message[]>(initialMessages)
@@ -66,7 +35,7 @@ export function Chat() {
       { message: message, who: 'user' } as Message,
     ]
     setMessages(newMessages)
-    const last10messages = newMessages.slice(-10)
+    const last10messages = newMessages.slice(-6) // remember last 6 messages
 
     const response = await fetch('/api/chat', {
       method: 'POST',
@@ -82,6 +51,9 @@ export function Chat() {
 
     // strip out white spaces from the bot message
     const botNewMessage = data.text.trim()
+
+    // wait 10 seconds before adding the bot message
+    await new Promise((resolve) => setTimeout(resolve, 10000))
 
     setMessages([
       ...newMessages,

--- a/solutions/ai-chatgpt/components/ChatBrowser.tsx
+++ b/solutions/ai-chatgpt/components/ChatBrowser.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react'
+import { useCookies } from 'react-cookie'
+
+import { type Message, ChatLine, LoadingChatLine } from './ChatLine'
+import { InputMessage } from './InputMessage'
+import InputKey from './InputKey'
+import { generatePromptFromMessages } from '../lib/generatePromptFromMessages'
+
+const COOKIE_NAME = 'nextjs-example-ai-chat-gpt3-user'
+const COOKIE_KEY = 'nextjs-example-ai-chat-gpt3-key'
+
+// default first message to display in UI (not necessary to define the prompt)
+export const initialMessages: Message[] = [
+  {
+    who: 'bot',
+    message: 'Hi! I’m A friendly AI assistant. Ask me anything!',
+  },
+]
+
+export function Chat() {
+  const [messages, setMessages] = useState<Message[]>(initialMessages)
+  const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [cookie, setCookie] = useCookies([COOKIE_NAME, COOKIE_KEY])
+
+  const [botName, setBotName] = useState('AI')
+  const [userName, setUserName] = useState('News reporter')
+  const [keyOpenAI, setKeyOpenAI] = useState('sk-XXXX') // default OpenAI key
+  const [prompt, setPrompt] = useState(
+    `I am Friendly AI Assistant. \n\nThis is the conversation between AI Bot and a news reporter.\n\n${botName}: ${initialMessages[0].message}\n${userName}: `
+  )
+
+  useEffect(() => {
+    if (!cookie[COOKIE_NAME]) {
+      // generate a semi random short id
+      const randomId = Math.random().toString(36).substring(7)
+      setCookie(COOKIE_NAME, randomId)
+    }
+    // override the default key if it's set in the cookie
+    if (cookie[COOKIE_KEY]) {
+      setKeyOpenAI(cookie[COOKIE_KEY])
+    }
+  }, [cookie, setCookie])
+
+  const sendMessage = async (message: string) => {
+    setLoading(true)
+    const newMessages = [
+      ...messages,
+      { message: message, who: 'user' } as Message,
+    ]
+    setMessages(newMessages)
+    const last10messages = newMessages.slice(-12) // remember last 12 messages
+
+    // const messages = req.body.messages
+    const messagesPrompt = generatePromptFromMessages(
+      last10messages,
+      userName,
+      botName
+    )
+    const finalPrompt = `${prompt}${messagesPrompt}\n${botName}: `
+
+    const payload = {
+      model: 'text-davinci-003',
+      prompt: finalPrompt,
+      temperature: process.env.AI_TEMP ? parseFloat(process.env.AI_TEMP) : 0.7,
+      max_tokens: process.env.AI_MAX_TOKENS
+        ? parseInt(process.env.AI_MAX_TOKENS)
+        : 200,
+      top_p: 1,
+      frequency_penalty: 0,
+      presence_penalty: 0,
+      stop: [`${botName}:`, `${userName}:`],
+      user: cookie[COOKIE_NAME],
+    }
+
+    const requestHeaders: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${keyOpenAI}`,
+    }
+
+    // use OpenAI API directly in browser to generate a response
+    const response = await fetch('https://api.openai.com/v1/completions', {
+      headers: requestHeaders,
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+
+    const data = await response.json()
+
+    // strip out white spaces from the bot message
+    let botNewMessage = ''
+
+    if (data.error) {
+      console.error('OpenAI API error: ', data.error)
+      botNewMessage = `ERROR with API integration. ${data.error.message}`
+    } else {
+      console.log(' == DATA = ', data)
+      botNewMessage = data.choices[0].text.trim()
+    }
+
+    setMessages([
+      ...newMessages,
+      { message: botNewMessage, who: 'bot' } as Message,
+    ])
+    setLoading(false)
+  }
+
+  return (
+    <>
+      <InputKey
+        input={keyOpenAI}
+        setInput={(key: string) => {
+          setKeyOpenAI(key)
+          setCookie(COOKIE_KEY, key)
+        }}
+      />
+      <div className="rounded-2xl border-zinc-100  lg:border lg:p-6">
+        {messages.map(({ message, who }, index) => (
+          <ChatLine key={index} who={who} message={message} />
+        ))}
+
+        {loading && <LoadingChatLine />}
+
+        {messages.length < 2 && (
+          <span className="mx-auto flex flex-grow text-gray-600 clear-both">
+            Type a message to start the conversation
+          </span>
+        )}
+        <InputMessage
+          input={input}
+          setInput={setInput}
+          sendMessage={sendMessage}
+        />
+      </div>
+    </>
+  )
+}

--- a/solutions/ai-chatgpt/components/InputKey.tsx
+++ b/solutions/ai-chatgpt/components/InputKey.tsx
@@ -1,0 +1,21 @@
+import { Text } from '@vercel/examples-ui'
+
+export const InputKey = ({ input, setInput, sendMessage }: any) => (
+  <div className="pb-20 flex flex-col clear-both">
+    <Text className="py-2">
+      <strong>OpenAI Key:</strong>
+    </Text>
+    <input
+      type="text"
+      aria-label="OpenAI Key"
+      required
+      className="min-w-0 flex-auto appearance-none rounded-md border border-zinc-900/10 bg-white px-3 py-[calc(theme(spacing.2)-1px)] shadow-md shadow-zinc-800/5 placeholder:text-zinc-400 focus:border-teal-500 focus:outline-none focus:ring-4 focus:ring-teal-500/10 sm:text-sm"
+      value={input}
+      onChange={(e) => {
+        setInput(e.target.value)
+      }}
+    />
+  </div>
+)
+
+export default InputKey

--- a/solutions/ai-chatgpt/components/InputMessage.tsx
+++ b/solutions/ai-chatgpt/components/InputMessage.tsx
@@ -1,0 +1,34 @@
+import { Button } from './Button'
+
+export const InputMessage = ({ input, setInput, sendMessage }: any) => (
+  <div className="mt-6 flex clear-both">
+    <input
+      type="text"
+      aria-label="chat input"
+      required
+      className="min-w-0 flex-auto appearance-none rounded-md border border-zinc-900/10 bg-white px-3 py-[calc(theme(spacing.2)-1px)] shadow-md shadow-zinc-800/5 placeholder:text-zinc-400 focus:border-teal-500 focus:outline-none focus:ring-4 focus:ring-teal-500/10 sm:text-sm"
+      value={input}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          sendMessage(input)
+          setInput('')
+        }
+      }}
+      onChange={(e) => {
+        setInput(e.target.value)
+      }}
+    />
+    <Button
+      type="submit"
+      className="ml-4 flex-none"
+      onClick={() => {
+        sendMessage(input)
+        setInput('')
+      }}
+    >
+      Say
+    </Button>
+  </div>
+)
+
+export default InputMessage

--- a/solutions/ai-chatgpt/lib/generatePromptFromMessages.ts
+++ b/solutions/ai-chatgpt/lib/generatePromptFromMessages.ts
@@ -1,0 +1,30 @@
+import { type Message } from '../components/ChatLine'
+
+// @TODO: unit test this. good case for unit testing
+export const generatePromptFromMessages = (
+  messages: Message[],
+  botName: string,
+  userName: string
+) => {
+  console.log('== INITIAL messages ==', messages)
+
+  let prompt = ''
+
+  // add first user message to prompt
+  prompt += messages[1].message
+
+  // remove first conversaiton (first 2 messages)
+  const messagesWithoutFirstConvo = messages.slice(2)
+  console.log(' == messagesWithoutFirstConvo', messagesWithoutFirstConvo)
+
+  // early return if no messages
+  if (messagesWithoutFirstConvo.length == 0) {
+    return prompt
+  }
+
+  messagesWithoutFirstConvo.forEach((message: Message) => {
+    const name = message.who === 'user' ? userName : botName
+    prompt += `\n${name}: ${message.message}`
+  })
+  return prompt
+}

--- a/solutions/ai-chatgpt/pages/api/chat.ts
+++ b/solutions/ai-chatgpt/pages/api/chat.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server'
-import { initialMessages } from '../../components/Chat'
-import { type Message } from '../../components/ChatLine'
+import { initialMessages } from '../../components/ChatAPI'
+import { generatePromptFromMessages } from '../../lib/generatePromptFromMessages'
 
 // break the app if the API key is missing
 if (!process.env.OPENAI_API_KEY) {
@@ -11,31 +11,6 @@ const botName = 'AI'
 const userName = 'News reporter' // TODO: move to ENV var
 const firstMessge = initialMessages[0].message
 
-// @TODO: unit test this. good case for unit testing
-const generatePromptFromMessages = (messages: Message[]) => {
-  console.log('== INITIAL messages ==', messages)
-
-  let prompt = ''
-
-  // add first user message to prompt
-  prompt += messages[1].message
-
-  // remove first conversaiton (first 2 messages)
-  const messagesWithoutFirstConvo = messages.slice(2)
-  console.log(' == messagesWithoutFirstConvo', messagesWithoutFirstConvo)
-
-  // early return if no messages
-  if (messagesWithoutFirstConvo.length == 0) {
-    return prompt
-  }
-
-  messagesWithoutFirstConvo.forEach((message: Message) => {
-    const name = message.who === 'user' ? userName : botName
-    prompt += `\n${name}: ${message.message}`
-  })
-  return prompt
-}
-
 export const config = {
   runtime: 'edge',
 }
@@ -45,7 +20,11 @@ export default async function handler(req: NextRequest) {
   const body = await req.json()
 
   // const messages = req.body.messages
-  const messagesPrompt = generatePromptFromMessages(body.messages)
+  const messagesPrompt = generatePromptFromMessages(
+    body.messages,
+    botName,
+    userName
+  )
   const defaultPrompt = `I am Friendly AI Assistant. \n\nThis is the conversation between AI Bot and a news reporter.\n\n${botName}: ${firstMessge}\n${userName}: ${messagesPrompt}\n${botName}: `
   const finalPrompt = process.env.AI_PROMPT
     ? `${process.env.AI_PROMPT}${messagesPrompt}\n${botName}: `

--- a/solutions/ai-chatgpt/pages/index.tsx
+++ b/solutions/ai-chatgpt/pages/index.tsx
@@ -1,7 +1,11 @@
-import { Layout, Text, Page } from '@vercel/examples-ui'
-import { Chat } from '../components/Chat'
+import { useState } from 'react'
+import { Layout, Page, Text, Button } from '@vercel/examples-ui'
+import { Chat as ChatAPIRoute } from '../components/ChatAPI'
+import { Chat as BrowserChat } from '../components/ChatBrowser'
 
 function Home() {
+  const [chatVersion, setChatVersion] = useState('api')
+
   return (
     <Page className="flex flex-col gap-12">
       <section className="flex flex-col gap-6">
@@ -10,12 +14,45 @@ function Home() {
           In this example, a simple chat bot is implemented using Next.js, API
           Routes, and OpenAI API.
         </Text>
-      </section>
+        <Text className="text-zinc-600">
+          This example have two versions of the chat bot. The are differences in
+          OpenAI API usage (API vs. browser), history context, and the prompt
+        </Text>
+        <ul>
+          <li className="py-6">
+            <strong>Simple - </strong> The Chat uses an API Route and the prompt
+            is hidden behind the API call. This simple example sets the context
+            history to 6 last messages. To limit API usage, the response is
+            delayed.
+          </li>
 
+          <li>
+            <strong>Advanced - </strong> This is the BYOK (Bring Your Own Key)
+            version. OpenAI API is directly accessed through the browser in the
+            Chat. The key is only stored in the browser, not on the Vercel
+            server. OpenAI context history is set to the last 12 messages, and
+            there is no artificial delay in response time.
+          </li>
+        </ul>
+      </section>
+      <section className="flex gap-4">
+        <Button
+          variant={chatVersion === 'api' ? 'primary' : 'secondary'}
+          onClick={() => setChatVersion('api')}
+        >
+          Simple (API)
+        </Button>{' '}
+        <Button
+          variant={chatVersion === 'browser' ? 'primary' : 'secondary'}
+          onClick={() => setChatVersion('browser')}
+        >
+          Advanced (BYOK)
+        </Button>
+      </section>
       <section className="flex flex-col gap-3">
         <Text variant="h2">AI Chat Bot:</Text>
         <div className="lg:w-2/3">
-          <Chat />
+          {chatVersion == 'api' ? <ChatAPIRoute /> : <BrowserChat />}
         </div>
       </section>
     </Page>


### PR DESCRIPTION
- converted Chat CPT-3 Example into two versions
- Added BYOK version (Bring Your Own Key)
- impose limitations on simple public demo (in order to save on OpenAI API calls)

# How to test?

Preview: https://ai-chatgpt-cnmpi4shz-vercel-solutions-vtest314.vercel.app/

- Simple version will return response after 10 seconds delay and will only hold short conversation history context
- advance version require to put in your own OpenAI KEY

