### PR TITLE
Use string for "fallback" in `build-output-api/prerender-functions` example

### DIFF
--- a/build-output-api/prerender-functions/.vercel/output/functions/blog/post.prerender-config.json
+++ b/build-output-api/prerender-functions/.vercel/output/functions/blog/post.prerender-config.json
@@ -3,9 +3,5 @@
   "group": 1,
   "bypassToken": "2ec9172003a647b296f324848dd3d407",
   "allowQuery": ["slug"],
-  "fallback": {
-    "type": "FileFsRef",
-    "mode": 33188,
-    "fsPath": "post.prerender-fallback.html"
-  }
+  "fallback": "post.prerender-fallback.html"
 }


### PR DESCRIPTION
Fixes #400.