### PR TITLE
Flush exposure logs to Statsig in Statsig A/B testing example

### DIFF
--- a/edge-functions/ab-testing-statsig/middleware.ts
+++ b/edge-functions/ab-testing-statsig/middleware.ts
@@ -41,5 +41,8 @@ export async function middleware(req: NextRequest) {
     })
   }
 
+  // Flush exposure logs to Statsig
+  Statsig.flush();
+
   return res
 }


### PR DESCRIPTION
### Description

In deployments, it seems middleware functions are shutting down before exposure data can be sent to Statsig. Send exposure data over to Statsig at the end of the middleware function.

### Demo URL

https://statsig-vercel-test-5xjiuggon-statsigio.vercel.app/

Can't really see a different in the deployment, but I'm actually able to get Statsig exposure logs with this deployment. 

### Type of Change

- [ ] New Example
- [X] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

