### PR TITLE
Updates README error message when syncing templates to Contentful.

### DIFF
--- a/scripts/lib/contentful/update-template.ts
+++ b/scripts/lib/contentful/update-template.ts
@@ -16,7 +16,7 @@ export default async function updateTemplate({
   const readme = await getReadme(examplePath)
 
   if (!readme) {
-    throw new Error('No readme.md found in example directory')
+    throw new Error(`No README.md found in example directory ${examplePath}`)
   }
 
   const { body: readmeBody, lang, template } = await getTemplate(readme)

--- a/scripts/lib/get-readme.ts
+++ b/scripts/lib/get-readme.ts
@@ -1,12 +1,6 @@
 import fs from 'fs/promises'
 
 export default async function getReadme(path: string) {
-  const files = await fs.readdir(path)
-
-  if (!files.includes('package.json')) {
-    throw new Error('No package.json found in example directory')
-  }
-
   return fs
     .readFile(`./${path}/README.md`, 'utf8')
     .then((str) => str)


### PR DESCRIPTION
### Description

Needlessly checking for a `package.json` file when trying to read `README.md` content. 

The `README.md` frontmatter should take care of marketplace availability (ie. `marketplace: false`).

### Type of Change

- [x] Other (changes to the codebase, but not to examples)