### PR TITLE
Fix typo in "Static File Overrides" BOA example

### DIFF
--- a/build-output-api/overrides/README.md
+++ b/build-output-api/overrides/README.md
@@ -11,7 +11,7 @@ https://build-output-api-overrides.vercel.sh
 ### How it Works
 
 The [`.vercel/output/static`](./.vercel/output/static) directory contains static files, _however_ due to the "overrides"
-property in the [`.vercel/output/config.json`]('./.vercel/output/config.json) file, these files are _served_ by Vercel
+property in the [`.vercel/output/config.json`](./.vercel/output/config.json) file, these files are _served_ by Vercel
 at different URL paths and/or with a different `Content-Type` header.
 
 Specifically:


### PR DESCRIPTION
Typo was causing a broken link in the README.