### PR TITLE
Fix a small typo in `domains-api`

### DIFF
--- a/solutions/domains-api/README.md
+++ b/solutions/domains-api/README.md
@@ -48,7 +48,7 @@ When a domain is added, there are 3 possible outcomes:
 
 #### Verifying Project Domain
 
-Verifying a project domain can be done with the `/v9/projeccts/{projectId}/domains/{domain}/verify` endpoint as shown [here](./pages/api/verify-domain.js) ([full documentation](https://vercel.com/docs/rest-api#endpoints/projects/verify-project-domain)).
+Verifying a project domain can be done with the `/v9/projects/{projectId}/domains/{domain}/verify` endpoint as shown [here](./pages/api/verify-domain.js) ([full documentation](https://vercel.com/docs/rest-api#endpoints/projects/verify-project-domain)).
 
 ### 2. Auto-checking Domain Configuration
 


### PR DESCRIPTION
### Description

Fixes a typo in the README of `solutions/domains-api` example.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

