### PR TITLE
remove legacy options from vercel.json

### DIFF
--- a/python/flask/vercel.json
+++ b/python/flask/vercel.json
@@ -1,14 +1,5 @@
 {
-  "builds": [
-    {
-      "src": "api/index.py",
-      "use": "@vercel/python"
-    }
-  ],
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "api/index.py"
-    }
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/api/index" }
   ]
 }


### PR DESCRIPTION
### Description

Very small change to remove legacy `builds` from the flask python example `vercel.json`

For issue https://github.com/vercel/examples/issues/524 

### Demo URL

https://vercel-flask-cyan.vercel.app/
https://vercel.com/tillys-test-team-vtest314/vercel-flask/7ETaH2GYUUHJEZnQhQvy63t1tRcq

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

