### PR TITLE
Fix: Tailwind content path should match TS

### DIFF
--- a/solutions/monorepo/packages/ui/src/tailwind.cjs
+++ b/solutions/monorepo/packages/ui/src/tailwind.cjs
@@ -3,7 +3,7 @@ const path = require('path')
 module.exports = {
   // `content` is replaced instead of extended, so this line has to be added in
   // the `content` of each app' tailwind.config.js
-  content: [path.join(path.dirname(require.resolve('@acme/ui')), '**/*.js')],
+  content: [path.join(path.dirname(require.resolve('@acme/ui')), '**/*.{js,ts,jsx,tsx}')],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
### Description

Tailwind configuration is not working because the package content path does not on Typescript extensions.

### Type of Change
- [x] Example updates (Bug fixes, new features, etc.)