### PR TITLE
basic-auth-password | Remove the use of atob

### DIFF
--- a/edge-middleware/basic-auth-password/middleware.ts
+++ b/edge-middleware/basic-auth-password/middleware.ts
@@ -10,7 +10,7 @@ export function middleware(req: NextRequest) {
 
   if (basicAuth) {
     const authValue = basicAuth.split(' ')[1]
-    const [user, pwd] = atob(authValue).split(':')
+    const [user, pwd] = Buffer.from(authValue, 'base64').toString().split(':')
 
     if (user === '4dmin' && pwd === 'testpwd123') {
       return NextResponse.next()


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

This sample has been modified by #247 to use `atob`, but the function is now flagged as [`deprecated`](https://github.com/microsoft/TypeScript/issues/45566).

|IDE|
|:--:|
|<img width="500" alt="image" src="https://user-images.githubusercontent.com/69892552/221188112-0631862e-90d0-4c81-a7ef-9a9db66e50a9.png">|



Also, in the current Next, `ArrayBuffer` works with edge runtime, so reverting to the original works fine.
edge doc: https://nextjs.org/docs/api-reference/edge-runtime#web-standard-apis

Since this sample is often referenced, I thought it would be better to modify it rather than wait.

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
