### PR TITLE
feat(chatgpt): update to streaming and new ChatGPT API

### DIFF
--- a/solutions/ai-chatgpt/.env.example
+++ b/solutions/ai-chatgpt/.env.example
@@ -1,7 +1,5 @@
 # Created by Vercel CLI
 OPENAI_API_KEY=
-# Change the default prompt definition to describe the bot's behavior, knowledge, and response style.
-AI_PROMPT=
 # The temperature controls how much randomness is in the output
 AI_TEMP=0.7
 # The size of the response

--- a/solutions/ai-chatgpt/README.md
+++ b/solutions/ai-chatgpt/README.md
@@ -1,12 +1,12 @@
 # AI Chat GPT-3 example
 
-This example shows how to implement a simple chat bot using Next.js, API Routes, and [OpenAI API](https://beta.openai.com/docs/api-reference/completions/create).
+This example shows how to implement a simple chat bot using Next.js, API Routes, and [OpenAI ChatGPT API](https://beta.openai.com/docs/api-reference/completions/create).
 
 ### Components
 
 - Next.js
-- OpenAI API (REST endpoint)
-- API Routes (Edge runtime)
+- OpenAI API (ChatGPT) - streaming
+- API Routes (Edge runtime) - streaming
 
 ## How to Use
 

--- a/solutions/ai-chatgpt/components/Chat.tsx
+++ b/solutions/ai-chatgpt/components/Chat.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from 'react'
 import { Button } from './Button'
-import { type Message, ChatLine, LoadingChatLine } from './ChatLine'
+import { type ChatGPTMessage, ChatLine, LoadingChatLine } from './ChatLine'
 import { useCookies } from 'react-cookie'
 
 const COOKIE_NAME = 'nextjs-example-ai-chat-gpt3'
 
 // default first message to display in UI (not necessary to define the prompt)
-export const initialMessages: Message[] = [
+export const initialMessages: ChatGPTMessage[] = [
   {
-    who: 'bot',
-    message: 'Hi! I’m A friendly AI assistant. Ask me anything!',
+    role: 'assistant',
+    content: 'Hi! I am a friendly AI assistant. Ask me anything!',
   },
 ]
 
@@ -45,7 +45,7 @@ const InputMessage = ({ input, setInput, sendMessage }: any) => (
 )
 
 export function Chat() {
-  const [messages, setMessages] = useState<Message[]>(initialMessages)
+  const [messages, setMessages] = useState<ChatGPTMessage[]>(initialMessages)
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
   const [cookie, setCookie] = useCookies([COOKIE_NAME])
@@ -64,7 +64,7 @@ const sendMessage = async (message: string) => {
   setLoading(true);
   const newMessages = [
     ...messages,
-    { message: message, who: "user" } as Message,
+    { role: "user", content: message } as ChatGPTMessage,
   ];
   setMessages(newMessages);
   const last10messages = newMessages.slice(-10); // remember last 10 messages
@@ -107,7 +107,7 @@ const sendMessage = async (message: string) => {
 
     setMessages([
       ...newMessages,
-      { message: lastMessage, who: "bot" } as Message,
+      { role: "assistant", content: lastMessage } as ChatGPTMessage,
     ]);
 
     setLoading(false);
@@ -118,8 +118,8 @@ const sendMessage = async (message: string) => {
 
   return (
     <div className="rounded-2xl border-zinc-100  lg:border lg:p-6">
-      {messages.map(({ message, who }, index) => (
-        <ChatLine key={index} who={who} message={message} />
+      {messages.map(({ content, role }, index) => (
+        <ChatLine key={index} role={role} content={content} />
       ))}
 
       {loading && <LoadingChatLine />}

--- a/solutions/ai-chatgpt/components/ChatLine.tsx
+++ b/solutions/ai-chatgpt/components/ChatLine.tsx
@@ -4,11 +4,11 @@ import Balancer from 'react-wrap-balancer'
 // wrap Balancer to remove type errors :( - @TODO - fix this ugly hack
 const BalancerWrapper = (props: any) => <Balancer {...props} />
 
-type ChatGPTAgent = "user" | "system" | "assistant";
+type ChatGPTAgent = 'user' | 'system' | 'assistant'
 
 export interface ChatGPTMessage {
-  role: ChatGPTAgent;
-  content: string;
+  role: ChatGPTAgent
+  content: string
 }
 
 // loading placeholder animation for the chat line

--- a/solutions/ai-chatgpt/components/ChatLine.tsx
+++ b/solutions/ai-chatgpt/components/ChatLine.tsx
@@ -4,9 +4,11 @@ import Balancer from 'react-wrap-balancer'
 // wrap Balancer to remove type errors :( - @TODO - fix this ugly hack
 const BalancerWrapper = (props: any) => <Balancer {...props} />
 
-export type Message = {
-  who: 'bot' | 'user' | undefined
-  message?: string
+type ChatGPTAgent = "user" | "system" | "assistant";
+
+export interface ChatGPTMessage {
+  role: ChatGPTAgent;
+  content: string;
 }
 
 // loading placeholder animation for the chat line
@@ -40,16 +42,16 @@ const convertNewLines = (text: string) =>
     </span>
   ))
 
-export function ChatLine({ who = 'bot', message }: Message) {
-  if (!message) {
+export function ChatLine({ role = 'assistant', content }: ChatGPTMessage) {
+  if (!content) {
     return null
   }
-  const formatteMessage = convertNewLines(message)
+  const formatteMessage = convertNewLines(content)
 
   return (
     <div
       className={
-        who != 'bot' ? 'float-right clear-both' : 'float-left clear-both'
+        role != 'assistant' ? 'float-right clear-both' : 'float-left clear-both'
       }
     >
       <BalancerWrapper>
@@ -58,13 +60,13 @@ export function ChatLine({ who = 'bot', message }: Message) {
             <div className="flex-1 gap-4">
               <p className="font-large text-xxl text-gray-900">
                 <a href="#" className="hover:underline">
-                  {who == 'bot' ? 'AI' : 'You'}
+                  {role == 'assistant' ? 'AI' : 'You'}
                 </a>
               </p>
               <p
                 className={clsx(
                   'text ',
-                  who == 'bot' ? 'font-semibold font- ' : 'text-gray-400'
+                  role == 'assistant' ? 'font-semibold font- ' : 'text-gray-400'
                 )}
               >
                 {formatteMessage}

--- a/solutions/ai-chatgpt/package.json
+++ b/solutions/ai-chatgpt/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@vercel/analytics": "^0.1.6",
     "@vercel/examples-ui": "^1.0.4",
+    "eventsource-parser": "^0.1.0",
     "next": "latest",
     "react": "latest",
     "react-cookie": "^4.1.1",

--- a/solutions/ai-chatgpt/pages/api/chat.ts
+++ b/solutions/ai-chatgpt/pages/api/chat.ts
@@ -1,5 +1,5 @@
 import { type ChatGPTMessage } from '../../components/ChatLine'
-import { OpenAIStream, OpenAIStreamPayload } from "../../utils/OpenAIStream";
+import { OpenAIStream, OpenAIStreamPayload } from '../../utils/OpenAIStream'
 
 // break the app if the API key is missing
 if (!process.env.OPENAI_API_KEY) {
@@ -14,7 +14,11 @@ const handler = async (req: Request): Promise<Response> => {
   const body = await req.json()
 
   const messages: ChatGPTMessage[] = [
-    { role: 'system', content: "I am Friendly AI Assistant. \n\nThis is the conversation between AI Bot and a news reporter."},
+    {
+      role: 'system',
+      content:
+        'I am Friendly AI Assistant. \n\nThis is the conversation between AI Bot and a news reporter.',
+    },
   ]
   messages.push(...body?.messages)
 
@@ -28,7 +32,7 @@ const handler = async (req: Request): Promise<Response> => {
   }
 
   const payload: OpenAIStreamPayload = {
-    model: "gpt-3.5-turbo",
+    model: 'gpt-3.5-turbo',
     messages: messages,
     temperature: process.env.AI_TEMP ? parseFloat(process.env.AI_TEMP) : 0.7,
     max_tokens: process.env.AI_MAX_TOKENS
@@ -40,10 +44,9 @@ const handler = async (req: Request): Promise<Response> => {
     stream: true,
     user: body?.user,
     n: 1,
-  };
+  }
 
-  const stream = await OpenAIStream(payload);
-  return new Response(stream);
-
+  const stream = await OpenAIStream(payload)
+  return new Response(stream)
 }
-export default handler;
+export default handler

--- a/solutions/ai-chatgpt/pages/api/chat.ts
+++ b/solutions/ai-chatgpt/pages/api/chat.ts
@@ -1,5 +1,4 @@
-import { initialMessages } from '../../components/Chat'
-import { type Message } from '../../components/ChatLine'
+import { type ChatGPTMessage } from '../../components/ChatLine'
 import { OpenAIStream, OpenAIStreamPayload } from "../../utils/OpenAIStream";
 
 // break the app if the API key is missing
@@ -7,48 +6,17 @@ if (!process.env.OPENAI_API_KEY) {
   throw new Error('Missing Environment Variable OPENAI_API_KEY')
 }
 
-const botName = 'AI'
-const userName = 'News reporter' // TODO: move to ENV var
-const firstMessge = initialMessages[0].message
-
-// @TODO: unit test this. good case for unit testing
-const generatePromptFromMessages = (messages: Message[]) => {
-  console.log('== INITIAL messages ==', messages)
-
-  let prompt = ''
-
-  // add first user message to prompt
-  prompt += messages[1].message
-
-  // remove first conversaiton (first 2 messages)
-  const messagesWithoutFirstConvo = messages.slice(2)
-  console.log(' == messagesWithoutFirstConvo', messagesWithoutFirstConvo)
-
-  // early return if no messages
-  if (messagesWithoutFirstConvo.length == 0) {
-    return prompt
-  }
-
-  messagesWithoutFirstConvo.forEach((message: Message) => {
-    const name = message.who === 'user' ? userName : botName
-    prompt += `\n${name}: ${message.message}`
-  })
-  return prompt
-}
-
 export const config = {
   runtime: 'edge',
 }
 
 const handler = async (req: Request): Promise<Response> => {
-  // read body from request
   const body = await req.json()
 
-  const messagesPrompt = generatePromptFromMessages(body.messages)
-  const defaultPrompt = `I am Friendly AI Assistant. \n\nThis is the conversation between AI Bot and a news reporter.\n\n${botName}: ${firstMessge}\n${userName}: ${messagesPrompt}\n${botName}: `
-  const finalPrompt = process.env.AI_PROMPT
-    ? `${process.env.AI_PROMPT}${messagesPrompt}\n${botName}: `
-    : defaultPrompt
+  const messages: ChatGPTMessage[] = [
+    { role: 'system', content: "I am Friendly AI Assistant. \n\nThis is the conversation between AI Bot and a news reporter."},
+  ]
+  messages.push(...body?.messages)
 
   const requestHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -60,8 +28,8 @@ const handler = async (req: Request): Promise<Response> => {
   }
 
   const payload: OpenAIStreamPayload = {
-    model: "text-davinci-003",
-    prompt: finalPrompt,
+    model: "gpt-3.5-turbo",
+    messages: messages,
     temperature: process.env.AI_TEMP ? parseFloat(process.env.AI_TEMP) : 0.7,
     max_tokens: process.env.AI_MAX_TOKENS
       ? parseInt(process.env.AI_MAX_TOKENS)
@@ -69,7 +37,6 @@ const handler = async (req: Request): Promise<Response> => {
     top_p: 1,
     frequency_penalty: 0,
     presence_penalty: 0,
-    stop: [`${botName}:`, `${userName}:`],
     stream: true,
     user: body?.user,
     n: 1,

--- a/solutions/ai-chatgpt/pages/api/chat.ts
+++ b/solutions/ai-chatgpt/pages/api/chat.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { initialMessages } from '../../components/Chat'
 import { type Message } from '../../components/ChatLine'
+import { OpenAIStream, OpenAIStreamPayload } from "../../utils/OpenAIStream";
 
 // break the app if the API key is missing
 if (!process.env.OPENAI_API_KEY) {
@@ -44,26 +45,11 @@ export default async function handler(req: NextRequest) {
   // read body from request
   const body = await req.json()
 
-  // const messages = req.body.messages
   const messagesPrompt = generatePromptFromMessages(body.messages)
   const defaultPrompt = `I am Friendly AI Assistant. \n\nThis is the conversation between AI Bot and a news reporter.\n\n${botName}: ${firstMessge}\n${userName}: ${messagesPrompt}\n${botName}: `
   const finalPrompt = process.env.AI_PROMPT
     ? `${process.env.AI_PROMPT}${messagesPrompt}\n${botName}: `
     : defaultPrompt
-
-  const payload = {
-    model: 'text-davinci-003',
-    prompt: finalPrompt,
-    temperature: process.env.AI_TEMP ? parseFloat(process.env.AI_TEMP) : 0.7,
-    max_tokens: process.env.AI_MAX_TOKENS
-      ? parseInt(process.env.AI_MAX_TOKENS)
-      : 200,
-    top_p: 1,
-    frequency_penalty: 0,
-    presence_penalty: 0,
-    stop: [`${botName}:`, `${userName}:`],
-    user: body?.user,
-  }
 
   const requestHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -74,21 +60,23 @@ export default async function handler(req: NextRequest) {
     requestHeaders['OpenAI-Organization'] = process.env.OPENAI_API_ORG
   }
 
-  const response = await fetch('https://api.openai.com/v1/completions', {
-    headers: requestHeaders,
-    method: 'POST',
-    body: JSON.stringify(payload),
-  })
+  const payload: OpenAIStreamPayload = {
+    model: "text-davinci-003",
+    prompt: finalPrompt,
+    temperature: process.env.AI_TEMP ? parseFloat(process.env.AI_TEMP) : 0.7,
+    max_tokens: process.env.AI_MAX_TOKENS
+      ? parseInt(process.env.AI_MAX_TOKENS)
+      : 100,
+    top_p: 1,
+    frequency_penalty: 0,
+    presence_penalty: 0,
+    stop: [`${botName}:`, `${userName}:`],
+    stream: true,
+    user: body?.user,
+    n: 1,
+  };
 
-  const data = await response.json()
+  const stream = await OpenAIStream(payload);
+  return new Response(stream);
 
-  if (data.error) {
-    console.error('OpenAI API error: ', data.error)
-    return NextResponse.json({
-      text: `ERROR with API integration. ${data.error.message}`,
-    })
-  }
-
-  // return response with 200 and stringify json text
-  return NextResponse.json({ text: data.choices[0].text })
 }

--- a/solutions/ai-chatgpt/pages/api/chat.ts
+++ b/solutions/ai-chatgpt/pages/api/chat.ts
@@ -1,4 +1,3 @@
-import { type NextRequest, NextResponse } from 'next/server'
 import { initialMessages } from '../../components/Chat'
 import { type Message } from '../../components/ChatLine'
 import { OpenAIStream, OpenAIStreamPayload } from "../../utils/OpenAIStream";
@@ -41,7 +40,7 @@ export const config = {
   runtime: 'edge',
 }
 
-export default async function handler(req: NextRequest) {
+const handler = async (req: Request): Promise<Response> => {
   // read body from request
   const body = await req.json()
 
@@ -80,3 +79,4 @@ export default async function handler(req: NextRequest) {
   return new Response(stream);
 
 }
+export default handler;

--- a/solutions/ai-chatgpt/pages/api/chat.ts
+++ b/solutions/ai-chatgpt/pages/api/chat.ts
@@ -16,8 +16,14 @@ const handler = async (req: Request): Promise<Response> => {
   const messages: ChatGPTMessage[] = [
     {
       role: 'system',
-      content:
-        'I am Friendly AI Assistant. \n\nThis is the conversation between AI Bot and a news reporter.',
+      content: `An AI assistant that is a Front-end expert in Next.js, React and Vercel have an inspiring and humorous conversation. 
+      AI assistant is a brand new, powerful, human-like artificial intelligence. 
+      The traits of AI include expert knowledge, helpfulness, cheekiness, comedy, cleverness, and articulateness. 
+      AI is a well-behaved and well-mannered individual. 
+      AI is not a therapist, but instead an engineer and frontend developer. 
+      AI is always friendly, kind, and inspiring, and he is eager to provide vivid and thoughtful responses to the user. 
+      AI has the sum of all knowledge in their brain, and is able to accurately answer nearly any question about any topic in conversation. 
+      AI assistant is a big fan of Nex.js.`,
     },
   ]
   messages.push(...body?.messages)

--- a/solutions/ai-chatgpt/utils/OpenAIStream.ts
+++ b/solutions/ai-chatgpt/utils/OpenAIStream.ts
@@ -40,8 +40,6 @@ export async function OpenAIStream(payload: OpenAIStreamPayload) {
     requestHeaders["OpenAI-Organization"] = process.env.OPENAI_API_ORG;
   }
 
-  console.log("requestHeaders", requestHeaders)
-  console.log("payload", payload)
   const res = await fetch("https://api.openai.com/v1/chat/completions", {
     headers: requestHeaders,
     method: "POST",

--- a/solutions/ai-chatgpt/utils/OpenAIStream.ts
+++ b/solutions/ai-chatgpt/utils/OpenAIStream.ts
@@ -1,0 +1,89 @@
+import {
+  createParser,
+  ParsedEvent,
+  ReconnectInterval,
+} from "eventsource-parser";
+
+export type ChatGPTAgent = "user" | "system";
+
+export interface ChatGPTMessage {
+  role: ChatGPTAgent;
+  content: string;
+}
+
+export interface OpenAIStreamPayload {
+  model: string;
+  prompt: string;
+  temperature: number;
+  top_p: number;
+  frequency_penalty: number;
+  presence_penalty: number;
+  max_tokens: number;
+  stream: boolean;
+  stop?: string[];
+  user?: string;
+  n: number;
+}
+
+export async function OpenAIStream(payload: OpenAIStreamPayload) {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  let counter = 0;
+
+  const requestHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${process.env.OPENAI_API_KEY ?? ""}`,
+  };
+
+  if (process.env.OPENAI_API_ORG) {
+    requestHeaders["OpenAI-Organization"] = process.env.OPENAI_API_ORG;
+  }
+
+  const res = await fetch("https://api.openai.com/v1/completions", {
+    headers: requestHeaders,
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      // callback
+      function onParse(event: ParsedEvent | ReconnectInterval) {
+        if (event.type === "event") {
+          const data = event.data;
+          // https://beta.openai.com/docs/api-reference/completions/create#completions/create-stream
+          if (data === "[DONE]") {
+            console.log("DONE");
+            controller.close();
+            return;
+          }
+          try {
+            const json = JSON.parse(data);
+            const text = json.choices[0].text;
+            if (counter < 2 && (text.match(/\n/) || []).length) {
+              // this is a prefix character (i.e., "\n\n"), do nothing
+              return;
+            }
+            const queue = encoder.encode(text);
+            controller.enqueue(queue);
+            counter++;
+          } catch (e) {
+            // maybe parse error
+            controller.error(e);
+          }
+        }
+      }
+
+      // stream response (SSE) from OpenAI may be fragmented into multiple chunks
+      // this ensures we properly read chunks and invoke an event for each SSE event stream
+      const parser = createParser(onParse);
+      // https://web.dev/streams/#asynchronous-iteration
+      for await (const chunk of res.body as any) {
+        parser.feed(decoder.decode(chunk));
+      }
+    },
+  });
+
+  return stream;
+}

--- a/solutions/ai-chatgpt/utils/OpenAIStream.ts
+++ b/solutions/ai-chatgpt/utils/OpenAIStream.ts
@@ -2,88 +2,87 @@ import {
   createParser,
   ParsedEvent,
   ReconnectInterval,
-} from "eventsource-parser";
+} from 'eventsource-parser'
 
-export type ChatGPTAgent = "user" | "system" | "assistant";
+export type ChatGPTAgent = 'user' | 'system' | 'assistant'
 
 export interface ChatGPTMessage {
-  role: ChatGPTAgent;
-  content: string;
+  role: ChatGPTAgent
+  content: string
 }
 
 export interface OpenAIStreamPayload {
-  model: string;
-  messages: ChatGPTMessage[];
-  temperature: number;
-  top_p: number;
-  frequency_penalty: number;
-  presence_penalty: number;
-  max_tokens: number;
-  stream: boolean;
-  stop?: string[];
-  user?: string;
-  n: number;
+  model: string
+  messages: ChatGPTMessage[]
+  temperature: number
+  top_p: number
+  frequency_penalty: number
+  presence_penalty: number
+  max_tokens: number
+  stream: boolean
+  stop?: string[]
+  user?: string
+  n: number
 }
 
 export async function OpenAIStream(payload: OpenAIStreamPayload) {
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
+  const encoder = new TextEncoder()
+  const decoder = new TextDecoder()
 
-  let counter = 0;
+  let counter = 0
 
   const requestHeaders: Record<string, string> = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${process.env.OPENAI_API_KEY ?? ""}`,
-  };
-
-  if (process.env.OPENAI_API_ORG) {
-    requestHeaders["OpenAI-Organization"] = process.env.OPENAI_API_ORG;
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${process.env.OPENAI_API_KEY ?? ''}`,
   }
 
-  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+  if (process.env.OPENAI_API_ORG) {
+    requestHeaders['OpenAI-Organization'] = process.env.OPENAI_API_ORG
+  }
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
     headers: requestHeaders,
-    method: "POST",
+    method: 'POST',
     body: JSON.stringify(payload),
-  });
+  })
 
   const stream = new ReadableStream({
     async start(controller) {
       // callback
       function onParse(event: ParsedEvent | ReconnectInterval) {
-        if (event.type === "event") {
-          const data = event.data;
+        if (event.type === 'event') {
+          const data = event.data
           // https://beta.openai.com/docs/api-reference/completions/create#completions/create-stream
-          if (data === "[DONE]") {
-            console.log("DONE");
-            controller.close();
-            return;
+          if (data === '[DONE]') {
+            console.log('DONE')
+            controller.close()
+            return
           }
           try {
-            const json = JSON.parse(data);
-            const text = json.choices[0].delta?.content || "";
+            const json = JSON.parse(data)
+            const text = json.choices[0].delta?.content || ''
             if (counter < 2 && (text.match(/\n/) || []).length) {
               // this is a prefix character (i.e., "\n\n"), do nothing
-              return;
+              return
             }
-            const queue = encoder.encode(text);
-            controller.enqueue(queue);
-            counter++;
+            const queue = encoder.encode(text)
+            controller.enqueue(queue)
+            counter++
           } catch (e) {
             // maybe parse error
-            controller.error(e);
+            controller.error(e)
           }
         }
       }
 
       // stream response (SSE) from OpenAI may be fragmented into multiple chunks
       // this ensures we properly read chunks and invoke an event for each SSE event stream
-      const parser = createParser(onParse);
-      // https://web.dev/streams/#asynchronous-iteration
+      const parser = createParser(onParse)
       for await (const chunk of res.body as any) {
-        parser.feed(decoder.decode(chunk));
+        parser.feed(decoder.decode(chunk))
       }
     },
-  });
+  })
 
-  return stream;
+  return stream
 }


### PR DESCRIPTION
### Description

- reused [OpenAIStream.ts](https://github.com/vercel/examples/compare/chat-gpt-update?expand=1#diff-a5e6c5d666557cf9baf9310bd3e97f11a41636cdb3112b1a16ebe83b0b9b095c) from our other examples
- removed a lot of code and made it simpler.
- removed `AI_PROMPT` to simplify implementation

### How to test?

- test locally on the branch
- `cd solutions/ai-chatgpt`
- `cp .env.example .env.local`
- update OPENAI_API_KEY with your [OpenAI](https://beta.openai.com/account/api-keys) secret key.
- `npm run dev`

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)

### New Example Checklist

- [x] 📱 Is it responsive? Are mobile and tablets considered?
