### PR TITLE
add warning when adding a domain env variable with http

### DIFF
--- a/edge-middleware/redirects-upstash/lib/upstash.ts
+++ b/edge-middleware/redirects-upstash/lib/upstash.ts
@@ -42,6 +42,12 @@ export async function upstashRest(
     throw new Error('Missing required Upstash credentials of the REST API')
   }
 
+  if (domain.includes('http')) {
+    throw new Error(
+      "UPSTASH_REST_API_DOMAIN shouldn't include protocol (e.g: your-domain.upstash.io)"
+    )
+  }
+
   return upstash({
     token,
     url: `https://${domain}${options?.pipeline ? '/pipeline' : ''}`,
@@ -56,6 +62,12 @@ export async function upstashEdge(args: any[]) {
 
   if (!domain || !token) {
     throw new Error('Missing required Upstash credentials of the Edge API')
+  }
+
+  if (domain.includes('http')) {
+    throw new Error(
+      "UPSTASH_EDGE_API_DOMAIN shouldn't include protocol (e.g: your-domain.upstash.io)"
+    )
   }
 
   return upstash({ token, url: `https://${domain}/${args.join('/')}` })

--- a/edge-middleware/redirects-upstash/scripts/upstash.js
+++ b/edge-middleware/redirects-upstash/scripts/upstash.js
@@ -10,6 +10,12 @@ async function upstash(args) {
     throw new Error('Missing required Upstash credentials of the REST API')
   }
 
+  if (domain.includes('http')) {
+    throw new Error(
+      "UPSTASH_REST_API_DOMAIN shouldn't include protocol (e.g: your-domain.upstash.io)"
+    )
+  }
+
   const res = await fetch(`https://${domain}`, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
### Description
## Context
When working with env variables you could easily pass a domain with a protocol to upstash (e.g. `UPSTASH_REST_API_DOMAIN = https://my-domain.upstash.io`) that would end up creating a url using the protocol again `https://https://my-domain.upstash.io` and the connection to upstash could never be made because of it

## Solution

Check if the variable UPSTASH_REST_API_DOMAIN and UPSTASH_EDGE_API_DOMAIN contains a http protocol and throw an error if that's the case. Which you can see how it shows up in the logs below:

```
Error: UPSTASH_REST_API_DOMAIN shouldn't include protocol (e.g: your-domain.upstash.io)
at upstash (/vercel/path1/scripts/upstash.js:14:11)
at setupUpstash (/vercel/path1/scripts/upstash.js:83:30)
...
error Command failed with exit code 1.
```
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
