### PR TITLE
Upgrade Statsig Edge Config NPM package version

### DIFF
--- a/edge-middleware/ab-testing-statsig/package.json
+++ b/edge-middleware/ab-testing-statsig/package.json
@@ -15,7 +15,7 @@
     "react": "latest",
     "react-dom": "latest",
     "statsig-node": "^5.1.0",
-    "statsig-node-vercel": "^0.0.3",
+    "statsig-node-vercel": "^0.0.5",
     "statsig-react": "^1.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Bump Statsig Edge Config Adapter NPM package version from 0.0.3 -> 0.0.5. It just fixes some typing issues. 

### Demo URL

No changes in functionality

### Type of Change

- [ ] New Example
- [X] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
