### PR TITLE
Fix local development for the django example, and document vercel-specific configs

### DIFF
--- a/python/django/README.md
+++ b/python/django/README.md
@@ -20,6 +20,27 @@ INSTALLED_APPS = [
 ]
 ```
 
+We allow "\*.vercel.app" subdomains in `ALLOWED_HOSTS`, in addition to 127.0.0.1:
+
+```python
+# vercel_app/settings.py
+ALLOWED_HOSTS = ['127.0.0.1', '.vercel.app']
+```
+
+The `wsgi` module must use a public variable named `app` to expose the WSGI application:
+
+```python
+# vercel_app/wsgi.py
+app = get_wsgi_application()
+```
+
+The corresponding `WSGI_APPLICATION` setting is configured to use the `app` variable from the `vercel_app.wsgi` module:
+
+```python
+# vercel_app/settings.py
+WSGI_APPLICATION = 'vercel_app.wsgi.app'
+```
+
 There is a single view which renders the current time in `example/views.py`:
 
 ```python

--- a/python/django/vercel_app/settings.py
+++ b/python/django/vercel_app/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-=cldztbc4jg&xl0!x673!*v2_=p$$eu)=7*f#d0#zs$44xx-h^
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['.vercel.app']
+ALLOWED_HOSTS = ['127.0.0.1', '.vercel.app']
 
 
 # Application definition
@@ -68,7 +68,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'vercel_app.wsgi.application'
+WSGI_APPLICATION = 'vercel_app.wsgi.app'
 
 
 # Database


### PR DESCRIPTION
### Description

The django example does not work in local development mode (`./manage.py runserver`) without some configuration changes.

I've also documented configurations that are specific to deploying to vercel -- namely that the `wsgi` module must expose an `app` variable, as opposed to django's default `application` variable.

### Demo URL

Just to show that this still deploys correctly: https://django-brianpeiris.vercel.app/

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)