### PR TITLE
Remove redundant `requestHeaders` variable in chatgpt api example

### DIFF
--- a/solutions/ai-chatgpt/pages/api/chat.ts
+++ b/solutions/ai-chatgpt/pages/api/chat.ts
@@ -28,15 +28,6 @@ const handler = async (req: Request): Promise<Response> => {
   ]
   messages.push(...body?.messages)
 
-  const requestHeaders: Record<string, string> = {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-  }
-
-  if (process.env.OPENAI_API_ORG) {
-    requestHeaders['OpenAI-Organization'] = process.env.OPENAI_API_ORG
-  }
-
   const payload: OpenAIStreamPayload = {
     model: 'gpt-3.5-turbo',
     messages: messages,


### PR DESCRIPTION
### Description

Noticed that there is a `requestHeaders` object that is declared, however, it never actually gets used in this file. This example can be simplified by removing these redundant lines.

I tested with my personal OpenAPI key and the requests were still fulfilled as expected. 

The other alternative to removing the variable would be to pass `requestHeaders` as an additional parameter to `OpenAIStream` and allowing the default request headers to be overridden.

### Type of Change

- [ ] New Example
- [X] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
