### PR TITLE
aws-dynamo DELETE should use query, not body

### DIFF
--- a/solutions/aws-dynamodb/pages/api/item.js
+++ b/solutions/aws-dynamodb/pages/api/item.js
@@ -61,7 +61,7 @@ export default async function handler(req, res) {
       new DeleteItemCommand({
         TableName: process.env.TABLE_NAME,
         Key: {
-          id: { S: req.body.id }
+          id: { S: req.query.id }
         }
       })
     );


### PR DESCRIPTION
The sample "curl" command for DELETE has the UUID in the query-string, not in a body. This change fixes the "curl" command.

### Description

The sample curl URL is: curl -X DELETE http://localhost:3000/api/item\?id\=bdc38386-2b35-47a3-bdfc-8ee29bd0686f

### Demo URL
None provided; easy to verify. Start the example locally and run the steps here: https://vercel.com/new/templates/next.js/aws-dynamodb-with-nextjs-api-routes

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [x] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
