### PR TITLE
Add comma in WWW-authenticate header value

### DIFF
--- a/edge-middleware/basic-auth-password/pages/api/auth.ts
+++ b/edge-middleware/basic-auth-password/pages/api/auth.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 export default function handler(_: NextApiRequest, res: NextApiResponse) {
-  res.setHeader('WWW-authenticate', 'Basic realm="Secure Area"')
+  res.setHeader('WWW-authenticate', 'Basic , realm="Secure Area"')
   res.statusCode = 401
   res.end(`Auth Required.`)
 }


### PR DESCRIPTION
Comma seems to be required for a better browser support: http://test.greenbytes.de/tech/tc/httpauth/#simplebasiccomma

### Description

-

### Demo URL

Tested on localhost only.

### Type of Change

-

### New Example Checklist

-