### PR TITLE
chore: docs should use `.env.local`

### DIFF
--- a/solutions/static-tweets-tailwind/README.md
+++ b/solutions/static-tweets-tailwind/README.md
@@ -18,7 +18,7 @@ This example shows you how you can generate static tweets using Tailwind CSS & `
 ### Gotchas
 
 - Don't forget to add pbs.twimg.com to your allowed `images` in your `next.config.js` file.
-- Don't forget to add Twitter Auth Bearer Token to your `.env` file.
+- Don't forget to add Twitter Auth Bearer Token to your `.env.local` file.
 
 ## Demo
 

--- a/solutions/web3-sessions/README.md
+++ b/solutions/web3-sessions/README.md
@@ -37,7 +37,7 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 pnpm create next-app --example https://github.com/vercel/examples/tree/main/solutions/web3-sessions
 ```
 
-Rename the `.env.example` file to `.env` and add your own secrets:
+Rename the `.env.example` file to `.env.local` and add your own secrets:
 
 ```
 // generate random secrets on https://passwordsgenerator.net/ or anywhere else similar

--- a/storage/blob-starter/README.md
+++ b/storage/blob-starter/README.md
@@ -45,7 +45,7 @@ Once that's done, copy the .env.example file in this directory to .env.local (wh
 cp .env.example .env.local
 ```
 
-Then open .env.local and set the environment variables to match the ones in your Vercel Storage Dashboard. Your keys should be available under your database's `.env` tab.
+Then open `.env.local` and set the environment variables to match the ones in your Vercel Storage Dashboard.
 
 Next, run Next.js in development mode:
 

--- a/storage/kv-redis-starter/README.md
+++ b/storage/kv-redis-starter/README.md
@@ -45,7 +45,7 @@ Once that's done, copy the .env.example file in this directory to .env.local (wh
 cp .env.example .env.local
 ```
 
-Then open .env.local and set the environment variables to match the ones in your Vercel Storage Dashboard. Your keys should be available under your database's `.env` tab.
+Then open `.env.local` and set the environment variables to match the ones in your Vercel Storage Dashboard.
 
 Next, run Next.js in development mode:
 

--- a/storage/postgres-kysely/README.md
+++ b/storage/postgres-kysely/README.md
@@ -46,7 +46,7 @@ Once that's done, copy the .env.example file in this directory to .env.local (wh
 cp .env.example .env.local
 ```
 
-Then open .env.local and set the environment variables to match the ones in your Vercel Storage Dashboard. Your keys should be available under your database's `.env` tab.
+Then open `.env.local` and set the environment variables to match the ones in your Vercel Storage Dashboard.
 
 Next, run Next.js in development mode:
 

--- a/storage/postgres-pgvector/README.md
+++ b/storage/postgres-pgvector/README.md
@@ -46,7 +46,7 @@ Once that's done, copy the .env.example file in this directory to .env.local (wh
 cp .env.example .env.local
 ```
 
-Then open .env.local and set the environment variables to match the ones in your Vercel Storage Dashboard. Your keys should be available under your database's `.env` tab.
+Then open `.env.local` and set the environment variables to match the ones in your Vercel Storage Dashboard.
 
 Next, run Next.js in development mode:
 

--- a/storage/postgres-prisma/README.md
+++ b/storage/postgres-prisma/README.md
@@ -46,7 +46,7 @@ Once that's done, copy the .env.example file in this directory to .env.local (wh
 cp .env.example .env.local
 ```
 
-Then open .env.local and set the environment variables to match the ones in your Vercel Storage Dashboard. Your keys should be available under your database's `.env` tab.
+Then open `.env.local` and set the environment variables to match the ones in your Vercel Storage Dashboard.
 
 Next, run Next.js in development mode:
 

--- a/storage/postgres-starter/README.md
+++ b/storage/postgres-starter/README.md
@@ -46,7 +46,7 @@ Once that's done, copy the .env.example file in this directory to .env.local (wh
 cp .env.example .env.local
 ```
 
-Then open .env.local and set the environment variables to match the ones in your Vercel Storage Dashboard. Your keys should be available under your database's `.env` tab.
+Then open `.env.local` and set the environment variables to match the ones in your Vercel Storage Dashboard.
 
 Next, run Next.js in development mode:
 


### PR DESCRIPTION
The `.env` file should never be used because its too easy to accidentally commit to git.

https://twitter.com/vedovelli74/status/1653378406304677889

Instead, use `.env.local` for local development which is already in `.gitignore` for each project.