### PR TITLE
fix: kysely seed script is broken because `current_timestamp` is passed as a string literal.

### DIFF
--- a/storage/postgres-kysely/lib/seed.ts
+++ b/storage/postgres-kysely/lib/seed.ts
@@ -8,7 +8,7 @@ export async function seed() {
     .addColumn('email', 'varchar(255)', (cb) => cb.notNull().unique())
     .addColumn('image', 'varchar(255)')
     .addColumn('createdAt', sql`timestamp with time zone`, (cb) =>
-      cb.defaultTo('CURRENT_TIMESTAMP')
+      cb.defaultTo(sql`CURRENT_TIMESTAMP`)
     )
     .execute()
   console.log(`Created "users" table`)

--- a/storage/postgres-kysely/lib/seed.ts
+++ b/storage/postgres-kysely/lib/seed.ts
@@ -3,6 +3,7 @@ import { db, sql } from '@/lib/kysely'
 export async function seed() {
   const createTable = await db.schema
     .createTable('users')
+    .ifNotExists()
     .addColumn('id', 'serial', (cb) => cb.primaryKey())
     .addColumn('name', 'varchar(255)', (cb) => cb.notNull())
     .addColumn('email', 'varchar(255)', (cb) => cb.notNull().unique())

--- a/storage/postgres-kysely/lib/seed.ts
+++ b/storage/postgres-kysely/lib/seed.ts
@@ -8,7 +8,7 @@ export async function seed() {
     .addColumn('email', 'varchar(255)', (cb) => cb.notNull().unique())
     .addColumn('image', 'varchar(255)')
     .addColumn('createdAt', sql`timestamp with time zone`, (cb) =>
-      cb.defaultTo(sql`CURRENT_TIMESTAMP`)
+      cb.defaultTo(sql`current_timestamp`)
     )
     .execute()
   console.log(`Created "users" table`)


### PR DESCRIPTION
### Description

Kysely seed script is broken because I passed `current_timestamp` as a string literal instead of raw sql (using sql template tag).

Also forgot to add `if not exists`.

So sorry. 😞 

I'm rushing this, didn't run this.

### Demo URL

Here's how its done in tests..
https://github.com/kysely-org/kysely/blob/master/test/node/src/schema.test.ts#L70-L72

here's a playground link to see it matches the raw sql before move to built-in schema module code.
https://kyse.link/?p=s&i=UVScTQg9PZr8zSbGM63J

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
