### PR TITLE
Replace prisma with drizzle in metadata of drizzle example

### DIFF
--- a/storage/postgres-drizzle/README.md
+++ b/storage/postgres-drizzle/README.md
@@ -1,7 +1,7 @@
 ---
 name: Vercel Postgres + Drizzle Next.js Starter
 slug: postgres-drizzle
-description: Simple Next.js template that uses Vercel Postgres as the database and Prisma as the ORM.
+description: Simple Next.js template that uses Vercel Postgres as the database and Drizzle as the ORM.
 framework: Next.js
 useCase: Starter
 css: Tailwind

--- a/storage/postgres-drizzle/app/layout.tsx
+++ b/storage/postgres-drizzle/app/layout.tsx
@@ -2,9 +2,9 @@ import './globals.css';
 import { Inter } from 'next/font/google';
 
 export const metadata = {
-  title: 'Vercel Postgres Demo with Prisma',
+  title: 'Vercel Postgres Demo with Drizzle',
   description:
-    'A simple Next.js app with Vercel Postgres as the database and Prisma as the ORM',
+    'A simple Next.js app with Vercel Postgres as the database and Drizzle as the ORM',
 };
 
 const inter = Inter({


### PR DESCRIPTION
### Description

The metadata had prisma instead of drizzle inside it, just replaced it.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
