### PR TITLE
chore: update "transpilePackages" config

### DIFF
--- a/solutions/monorepo/apps/app/next.config.js
+++ b/solutions/monorepo/apps/app/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    transpilePackages: ['@acme/ui'],
-  },
+  transpilePackages: ['@acme/ui'],
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
### Description

The `transpilePackages` feature is no longer considered experimental. I'm getting this warning when running the example on `main`:

> warn `transpilePackages` has been moved out of `experimental`. Please update your next.config.js file accordingly

This is with `next 13.4.5-canary.6`.

### Type of Change

- [x] Example updates (Bug fixes, new features, etc.)