### PR TITLE
[monorepo] Remove command overrides for `deployUrl`

### DIFF
--- a/solutions/monorepo/README.md
+++ b/solutions/monorepo/README.md
@@ -7,7 +7,7 @@ useCase:
   - Monorepos
   - Documentation
 css: Tailwind
-deployUrl: https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/monorepo&project-name=monorepo&repository-name=monorepo&root-directory=apps/app&install-command=pnpm%20install&build-command=cd%20..%2F..%20%26%26%20pnpm%20build%20--filter%3Dapp...&ignore-command=npx%20turbo-ignore
+deployUrl: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fsolutions%2Fmonorepo&project-name=monorepo&repository-name=monorepo&root-directory=apps%2Fapp
 demoUrl: https://solutions-monorepo.vercel.sh
 relatedTemplates:
   - monorepo-nx


### PR DESCRIPTION
### Description

This example appears to be outdated since the user no longer needs to override these commands. We infer default monorepo build commands automatically.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)