### PR TITLE
Updated publish templates script

### DIFF
--- a/.github/workflows/publish-template.yaml
+++ b/.github/workflows/publish-template.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: tj-actions/changed-files@v18.7
 
       - name: Publish template
-        run: pnpm update-templates ${{ steps.changed-files.outputs.all_changed_files }}
+        run: pnpm update-templates "${{ steps.changed-files.outputs.all_changed_files }}"
         env:
           CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}

--- a/internal/scripts/lib/update-changed-templates.ts
+++ b/internal/scripts/lib/update-changed-templates.ts
@@ -12,6 +12,8 @@ const DIRS = [
 const IS_README = /readme\.md$/i
 
 export default async function updateChangedTemplates(changedFiles: string[]) {
+  changedFiles = changedFiles.flatMap((fileName) => fileName.split(' '))
+
   if (!changedFiles.length) {
     log('No changed files.')
     return


### PR DESCRIPTION
### Description

Filenames that have symbols like `[]`, `()` need to be inside a double quote so that the shell doesn't confuse them with something else.

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (changes to the codebase, but not to examples)
