### PR TITLE
warn when integration has not synced

### DIFF
--- a/edge-middleware/feature-flag-split/README.md
+++ b/edge-middleware/feature-flag-split/README.md
@@ -62,6 +62,8 @@ Then fill it with the following information:
 
 - You can find the Edge Config Connection String on vercel.com -> Storage -> \[Your Edge Config\] -> Projects. You can click Connect Project if your Edge Config is not connected to any project yet. This will automatically create a token for you and set it up as an environment variable on your project. Note that you still need to provide it to your `.env.local` file. Otherwise, click on Tokens in the sidebar and find the token you want to use. Then click on the three dots of and select Copy Connection String.
 
+- You also need to create feature flags called `New_Marketing_Page` and `New_About_Page`. You can set the user targeting to `Joe` and `Bobby` in whatever configuration you'd like as those users are used by this example.
+
 Next, run Next.js in development mode:
 
 ```bash

--- a/edge-middleware/feature-flag-split/app/missing-split-item/page.tsx
+++ b/edge-middleware/feature-flag-split/app/missing-split-item/page.tsx
@@ -19,7 +19,7 @@ function ExclamantionTriangleIcon() {
   )
 }
 
-export default function MissingEdgeConfigDialog() {
+export default function MissingSplitItemDialog() {
   return (
     <div
       className="relative z-30"
@@ -40,20 +40,35 @@ export default function MissingEdgeConfigDialog() {
                   className="text-lg font-medium leading-6 text-gray-900"
                   id="modal-title"
                 >
-                  Incomplete Environment Variables Setup
+                  Incomplete Integration Setup
                 </h3>
                 <div className="mt-2">
                   <p className="text-sm text-gray-500">
-                    Follow these steps to finish the setup of this example:
+                    Double check the following to ensure the example is set up
+                    correctly:
                   </p>
                   <ol className="text-sm text-gray-500 list-disc ml-8 mt-2 flex gap-2 flex-col">
                     <li className="list-item list-disc">
-                      Create an Edge Config and connect it to this project and
-                      store its connection string under the{' '}
-                      <span className="bg-gray-100 p-1 text-gray-900 rounded">
-                        EDGE_CONFIG
-                      </span>{' '}
-                      environment variable
+                      Make sure you have the{' '}
+                      <a
+                        href="https://vercel.com/integrations/split"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Split integration
+                      </a>{' '}
+                      installed.
+                    </li>
+                    <li className="list-item list-disc">
+                      Make sure the integration is configured to sync your Split
+                      project to a Vercel Edge Config. Go to vercel.com →
+                      Integrations → Split → Manage → Configure.
+                    </li>
+                    <li className="list-item list-disc">
+                      Make sure that Edge Config is connected to your project.
+                      To do so, open vercel.com, find your project and click on
+                      Storage. The Edge Config should show up there. If not, add
+                      it.
                     </li>
                     <li className="list-item list-disc">
                       Ensure you have the{' '}
@@ -62,8 +77,20 @@ export default function MissingEdgeConfigDialog() {
                       </span>{' '}
                       environment variable configured and it contains the item
                       key as specified by the Split integration. You can find
-                      this key on your account at Vercel under Integrations &gt;
-                      Split &gt; Manage &gt; Configure &gt; Edge Config Item Key
+                      this key on your account at Vercel under Integrations →
+                      Split → Manage → Configure → Edge Config Item Key
+                    </li>
+                    <li className="list-item list-disc">
+                      Ensure the Edge Config actually contains your Split data.
+                      Check whether your Edge Config contains a key called{' '}
+                      <span className="bg-gray-100 p-1 text-gray-900 rounded">
+                        {process.env.EDGE_CONFIG_SPLIT_ITEM_KEY}
+                      </span>
+                      , as defined by the EDGE_CONFIG_SPLIT_ITEM_KEY environment
+                      variable. If it does not contain such a key, you can go to
+                      Split and make a change to a feature flag. This causes the
+                      integration to resync. You should then see the value in
+                      your Edge Config.
                     </li>
                     <li className="list-item list-disc">
                       Pull your latest Environment Variables if you are

--- a/edge-middleware/feature-flag-split/middleware.ts
+++ b/edge-middleware/feature-flag-split/middleware.ts
@@ -4,6 +4,7 @@
  * It would not be needed in a real application.
  */
 import { NextRequest, NextResponse } from 'next/server'
+import { has } from '@vercel/edge-config'
 
 export const config = {
   matcher: ['/', '/about', '/marketing'],
@@ -12,6 +13,11 @@ export const config = {
 export async function middleware(req: NextRequest) {
   if (!process.env.EDGE_CONFIG || !process.env.EDGE_CONFIG_SPLIT_ITEM_KEY) {
     req.nextUrl.pathname = `/missing-edge-config`
+    return NextResponse.rewrite(req.nextUrl)
+  }
+
+  if (!(await has(process.env.EDGE_CONFIG_SPLIT_ITEM_KEY))) {
+    req.nextUrl.pathname = `/missing-split-item`
     return NextResponse.rewrite(req.nextUrl)
   }
 }


### PR DESCRIPTION
### Description

Adds a warning in case the user did not yet cause the Split integration to sync into an Edge Config. In that case the demo would not work anyhow, so it's better to show instructions.

<img width="1624" alt="image" src="https://github.com/vercel/examples/assets/1765075/70911889-60d5-48a8-b81b-5edc4b8ef1bc">
