### PR TITLE
use edge rendering for hypertune

### DIFF
--- a/edge-middleware/feature-flag-hypertune/app/page.tsx
+++ b/edge-middleware/feature-flag-hypertune/app/page.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import hypertune from '../lib/hypertune'
 import ClientExample from '../lib/ClientExample'
 
+export const runtime = 'edge'
+
 async function getFlags() {
   await hypertune.waitForInitialization()
   const rootNode = hypertune.root({


### PR DESCRIPTION
### Description

Uses the edge runtime and edge rendering for the hypertune example page.