### PR TITLE
use custom deploy button urls

### DIFF
--- a/edge-middleware/feature-flag-hypertune/app/layout.tsx
+++ b/edge-middleware/feature-flag-hypertune/app/layout.tsx
@@ -13,7 +13,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <Layout path="edge-middleware/feature-flag-hypertune">
+        <Layout
+          path="edge-middleware/feature-flag-hypertune"
+          deployButton={{
+            customDeployUrl:
+              'https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fhypertunehq%2Fvercel-examples-fork%2Ftree%2Fmain%2Fedge-middleware%2Ffeature-flag-hypertune&env=NEXT_PUBLIC_HYPERTUNE_TOKEN,EDGE_CONFIG,EDGE_CONFIG_HYPERTUNE_ITEM_KEY&envDescription=Environment%20variables%20needed%20to%20use%20Hypertune%20with%20Vercel%20Edge%20Config&envLink=https%3A%2F%2Fdocs.hypertune.com%2Fgetting-started%2Fvercel-quickstart&project-name=feature-flag-hypertune&repository-name=feature-flag-hypertune&demo-title=Hypertune%20with%20Vercel%20Edge%20Config&demo-description=Use%20Hypertune%20with%20Vercel%20Edge%20Config&demo-url=https%3A%2F%2Ffeature-flag-hypertune.vercel.app%2F&demo-image=https%3A%2F%2Ffeature-flag-hypertune.vercel.app%2Fdemo.png&integration-ids=oac_naLXREDG2o9KihTGYBVz9fVl',
+          }}
+        >
           {children}
         </Layout>
       </body>

--- a/edge-middleware/feature-flag-launchdarkly/app/layout.tsx
+++ b/edge-middleware/feature-flag-launchdarkly/app/layout.tsx
@@ -12,7 +12,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <Layout path="edge-middleware/feature-flag-launchdarkly">
+        <Layout
+          path="edge-middleware/feature-flag-launchdarkly"
+          deployButton={{
+            customDeployUrl:
+              'https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/edge-middleware/feature-flag-launchdarkly&project-name=feature-flag-launchdarkly&repository-name=feature-flag-launchdarkly&integration-ids=oac_8DFUMlauSkqeQhdGHpL5xbWp&env=NEXT_PUBLIC_LD_CLIENT_SIDE_ID&env=EDGE_CONFIG&edge-config-stores=%7B%22EDGE_CONFIG%22%3A%7B%7D%7D',
+          }}
+        >
           {children}
         </Layout>
       </body>


### PR DESCRIPTION
### Description

Passes the custom clone url to the deploy button so clones actually include the integrations.

<img width="370" alt="image" src="https://github.com/vercel/examples/assets/1765075/fc703f12-5647-4e60-aec4-eb220ce1f062">
