### PR TITLE
shut down statsig after usage

### DIFF
--- a/edge-middleware/ab-testing-statsig/middleware.ts
+++ b/edge-middleware/ab-testing-statsig/middleware.ts
@@ -42,7 +42,11 @@ export async function middleware(req: NextRequest, event: NextFetchEvent) {
   }
 
   // Flush exposure logs to Statsig
-  event.waitUntil(Statsig.flush());
+  event.waitUntil(
+    Statsig.flush().then(() => {
+      Statsig.shutdown()
+    })
+  )
 
   return res
 }


### PR DESCRIPTION
### Description

We did not shut down Statsig after usage which causes further Edge Config reads for as long as the middleware stays alive.

The video also shows an attempted read to `statsig.id_lists` which can be ignored since it does not cause an actual Edge Config read. Statsig's EdgeConfigDataAdapter throws in case any key other than `statsig.cache` is read, which is then handled by the SDK itself.

This video shows how continuous Edge Config reads are made when `Statsig.shutdown()` is not called. I don't think this would happen when actually deployed, since the middleware doesn't wait for dangling promises or timeouts afaik.

https://github.com/vercel/examples/assets/1765075/56d0f61c-3599-445d-b135-e2396aef115f

