### PR TITLE
Use "nodejs18.x" for Build Output API examples

### DIFF
--- a/build-output-api/draft-mode/.vercel/output/functions/index.func/.vc-config.json
+++ b/build-output-api/draft-mode/.vercel/output/functions/index.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs14.x",
+  "runtime": "nodejs18.x",
   "handler": "index.js",
   "launcherType": "Nodejs"
 }

--- a/build-output-api/draft-mode/.vercel/output/functions/login.func/.vc-config.json
+++ b/build-output-api/draft-mode/.vercel/output/functions/login.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs14.x",
+  "runtime": "nodejs18.x",
   "handler": "index.js",
   "launcherType": "Nodejs",
   "shouldAddHelpers": true

--- a/build-output-api/draft-mode/.vercel/output/functions/logout.func/.vc-config.json
+++ b/build-output-api/draft-mode/.vercel/output/functions/logout.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs14.x",
+  "runtime": "nodejs18.x",
   "handler": "index.js",
   "launcherType": "Nodejs",
   "shouldAddHelpers": true

--- a/build-output-api/prerender-functions/.vercel/output/functions/blog/post.func/.vc-config.json
+++ b/build-output-api/prerender-functions/.vercel/output/functions/blog/post.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs14.x",
+  "runtime": "nodejs18.x",
   "handler": "index.js",
   "launcherType": "Nodejs",
   "shouldAddHelpers": true

--- a/build-output-api/serverless-functions/.vercel/output/functions/index.func/.vc-config.json
+++ b/build-output-api/serverless-functions/.vercel/output/functions/index.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs14.x",
+  "runtime": "nodejs18.x",
   "handler": "index.js",
   "launcherType": "Nodejs",
   "shouldAddHelpers": true

--- a/build-output-api/serverless-functions/README.md
+++ b/build-output-api/serverless-functions/README.md
@@ -14,8 +14,8 @@ In this case, the contents of the Serverless Function are located in the
 [`.vercel/output/functions/index.func`](./.vercel/output/functions/index.func) directory.
 This means that the Serverless Function will be accessible at the `/index` (or `/`) path of the Deployment.
 
-The [`.vc-config.json`](./.vercel/output/functions/index.func/.vc-config.json) file specifies `"runtime": "nodejs14.x"`
-which informs Vercel that the endpoint should be created as a Serverless Function, using Node.js version 14.
+The [`.vc-config.json`](./.vercel/output/functions/index.func/.vc-config.json) file specifies `"runtime": "nodejs18.x"`
+which informs Vercel that the endpoint should be created as a Serverless Function, using Node.js version 18.
 
 The `"handler": "index.js"` field indicates that the [`index.js`](.vercel/output/functions/index.func/index.js)
 source code file will be the starting point of execution when the Serverless Function is invoked.


### PR DESCRIPTION
### Description

Node 14.x is discontinued, so update these Build Output API examples to use Node 18.x instead.

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
