### PR TITLE
remove Statsig.shutdown()

### DIFF
--- a/edge-middleware/ab-testing-statsig/middleware.ts
+++ b/edge-middleware/ab-testing-statsig/middleware.ts
@@ -48,11 +48,7 @@ export async function middleware(req: NextRequest, event: NextFetchEvent) {
   }
 
   // Flush exposure logs to Statsig
-  event.waitUntil(
-    Statsig.flush().then(() => {
-      Statsig.shutdown()
-    })
-  )
+  event.waitUntil(Statsig.flush())
 
   return res
 }


### PR DESCRIPTION
### Description

Removes `Statsig.shutdown()` from middleware.

Calling Statsig.shutdown leads to a race condition when multiple requests happen to the same middleware:
- Request A calls `await Statsig.initialize()`
- Request B calls `await Statsig.initialize()`
- Request A calls `Statsig.shutdown()` destroying the singleton
- Request B tries to use Statsig but the singleton is no longer initialized

This leads to the following error being thrown

```
Error: Call and wait for initialize() to finish first.
    at (node_modules/.pnpm/statsig-node@5.9.3/node_modules/statsig-node/dist/Errors.js:22:27)
    at (node_modules/.pnpm/statsig-node@5.9.3/node_modules/statsig-node/dist/StatsigServer.js:532:27)
    at (node_modules/.pnpm/statsig-node@5.9.3/node_modules/statsig-node/dist/StatsigServer.js:523:30)
    at (node_modules/.pnpm/statsig-node@5.9.3/node_modules/statsig-node/dist/StatsigServer.js:463:22)
    at (node_modules/.pnpm/statsig-node@5.9.3/node_modules/statsig-node/dist/StatsigServer.js:224:70)
    at (node_modules/.pnpm/statsig-node@5.9.3/node_modules/statsig-node/dist/ErrorBoundary.js:27:25)
    at (node_modules/.pnpm/statsig-node@5.9.3/node_modules/statsig-node/dist/StatsigServer.js:224:35)
    at (node_modules/.pnpm/statsig-node@5.9.3/node_modules/statsig-node/dist/index.js:160:37)
    at (middleware.ts:33:27)
    at (node_modules/.pnpm/next@13.4.20-canary.30_react-dom@18.2.0+react@18.2.0/node_modules/next/dist/esm/server/web/adapter.js:150:19)
```
