### PR TITLE
[CI] Use environment_url

### DIFF
--- a/solutions/testing/.github/workflows/playwright-reusable.yml
+++ b/solutions/testing/.github/workflows/playwright-reusable.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run ${{ inputs.test-type }} tests
         run: pnpm run ${{ inputs.test-type }}
         env:
-          BASE_URL: ${{ github.event_name == 'deployment_status' && github.event.deployment_status.target_url || 'https://solutions-testing.vercel.app' }}
+          BASE_URL: ${{ github.event_name == 'deployment_status' && github.event.deployment_status.environment_url || 'https://solutions-testing.vercel.app' }}
 
       - name: Upload test results to GitHub
         if: ${{ always() }}


### PR DESCRIPTION
### Description

Forward fixing.
`target_url` is deprecated and `environment_url` contains the same value and is future proof.
Internal x-ref: https://github.com/vercel/api/pull/22337

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
