### PR TITLE
Fix link to platform starter kit in hostname rewrites example

### DIFF
--- a/edge-middleware/hostname-rewrites/README.md
+++ b/edge-middleware/hostname-rewrites/README.md
@@ -40,7 +40,7 @@ const mockDB = [
 
 When deploying your own clone of this example, you will need to replace the data fetching methods in `getStaticPaths` and `getStaticProps` with your own database of choice (BYOD, _Bring-Your-Own-Database_).
 
-To give a bit of context of how this can be applied in a real-world context, we recently launched the [Platforms Starter Kit](https://demo.vercel.pub/platforms-starter-kit) – a comprehensive template for site builders, multi-tenant platforms, and low-code tools:
+To give a bit of context of how this can be applied in a real-world context, we recently launched the [Platforms Starter Kit](https://vercel.com/templates/next.js/platforms-starter-kit) – a comprehensive template for site builders, multi-tenant platforms, and low-code tools:
 
 - [demo.vercel.pub](https://demo.vercel.pub)
 - [platformize.co](https://platformize.co) (custom domain that maps to [demo.vercel.pub](https://demo.vercel.pub))


### PR DESCRIPTION
### Description

This PR fixes the link to the platform starter kit in hostname rewrites example

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
