### PR TITLE
Ignore datadome examples from the playwright action

### DIFF
--- a/edge-middleware/bot-protection-datadome/README.md
+++ b/edge-middleware/bot-protection-datadome/README.md
@@ -7,6 +7,7 @@ useCase: Edge Middleware
 css: Tailwind
 deployUrl: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-customer-feedback%2Fedge-middleware%2Ftree%2Fmain%2Fexamples%2Fbot-protection-datadome&env=NEXT_PUBLIC_DATADOME_CLIENT_KEY,DATADOME_SERVER_KEY&project-name=bot-protection-datadome&repository-name=bot-protection-datadome
 demoUrl: https://edge-functions-bot-protection-datadome.vercel.app
+ignoreE2E: true
 relatedTemplates:
   - api-rate-limit-and-tokens
   - bot-protection-botd

--- a/edge-middleware/ip-blocking-datadome/README.md
+++ b/edge-middleware/ip-blocking-datadome/README.md
@@ -7,6 +7,7 @@ useCase: Edge Middleware
 css: Tailwind
 deployUrl: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel-customer-feedback%2Fedge-middleware%2Ftree%2Fmain%2Fexamples%2Fip-blocking-datadome&env=NEXT_PUBLIC_DATADOME_CLIENT_KEY,DATADOME_SERVER_KEY,DATADOME_MANAGEMENT_KEY&project-name=ip-blocking-datadome&repository-name=ip-blocking-datadome
 demoUrl: https://edge-functions-ip-blocking-datadome.vercel.app
+ignoreE2E: true
 relatedTemplates:
   - bot-protection-botd
   - bot-protection-datadome

--- a/internal/packages/playwright/scripts/generate-tests.ts
+++ b/internal/packages/playwright/scripts/generate-tests.ts
@@ -5,6 +5,7 @@ import getTest from './lib/get-test'
 
 type Attributes = {
   demoUrl?: string
+  ignoreE2E?: boolean
 }
 
 async function generateTests() {
@@ -48,7 +49,7 @@ async function generateTests() {
           )
           const { attributes } = frontMatter<Attributes>(content)
 
-          if (!attributes.demoUrl) return
+          if (!attributes.demoUrl || attributes.ignoreE2E) return
 
           const testContent = getTest(attributes.demoUrl)
 


### PR DESCRIPTION
The check for these examples are constantly failing but the example is doing blocking as expected.