### PR TITLE
fix: use the actual Code component in plop-template example 

### DIFF
--- a/plop-templates/example/app/page.tsx
+++ b/plop-templates/example/app/page.tsx
@@ -1,4 +1,4 @@
-import { Page, Text, Code, Link } from '@vercel/examples-ui'
+import { Page, Text, Code } from '@vercel/examples-ui'
 
 export default function Home() {
   return (
@@ -17,7 +17,7 @@ export default function Home() {
         <Text variant="h2">Header</Text>
         <Text>
           Lorem ipsum dolor, sit amet consectetur adipisicing elit. Error quasi{' '}
-          <code>dolorum natus</code>, quaerat voluptatum laboriosam minima quis
+          <Code>dolorum natus</Code>, quaerat voluptatum laboriosam minima quis
           consectetur quam architecto veniam! Ex atque rem, unde tempora eaque
           quasi mollitia tenetur.
         </Text>


### PR DESCRIPTION
### Description
Spotted typo regarding usage of `Code` component, removed unused `<Link>` import
 <!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
