### PR TITLE
fix: version conflict of werkzeug

### DIFF
--- a/python/nextjs-flask/requirements.txt
+++ b/python/nextjs-flask/requirements.txt
@@ -1,2 +1,3 @@
 numpy==1.24.3
 Flask==2.2.2
+Werkzeug==2.2.2


### PR DESCRIPTION
```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls'
```

reference: https://stackoverflow.com/questions/77213053/importerror-cannot-import-name-url-quote-from-werkzeug-urls

### Description

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
