### PR TITLE
Remove references to prisma in postgres example metadata

### DIFF
--- a/storage/postgres-starter/app/layout.tsx
+++ b/storage/postgres-starter/app/layout.tsx
@@ -3,9 +3,9 @@ import { Inter } from 'next/font/google'
 
 export const metadata = {
   metadataBase: new URL('https://postgres-starter.vercel.app'),
-  title: 'Vercel Postgres Demo with Prisma',
+  title: 'Vercel Postgres Demo',
   description:
-    'A simple Next.js app with Vercel Postgres as the database and Prisma as the ORM',
+    'A simple Next.js app with Vercel Postgres as the database',
 }
 
 const inter = Inter({


### PR DESCRIPTION
### Description

Fix the layout metadata which references prisma as the orm in the postgres with no orm example.

### Demo URL

n/a

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
