### PR TITLE
fix(docs): wrong Git clone command

### DIFF
--- a/solutions/node-hello-world/README.md
+++ b/solutions/node-hello-world/README.md
@@ -8,14 +8,16 @@ You can choose from one of the following two methods to use this repository:
 
 ### One-Click Deploy
 
-Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=vercel-examples):
+Deploy the example using [Vercel][1]:
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/examples/tree/main/solutions/node-hello-world&project-name=node-hello-world&repository-name=node-hello-world)
+[![Deploy with Vercel](https://vercel.com/button)][2]
 
 ### Clone and Deploy
 
 ```bash
-git clone https://github.com/vercel/examples/tree/main/solutions/node-hello-world
+mkdir -p ~/Desktop/Vercel-Node-serverless
+cd ~/Desktop/Vercel-Node-serverless
+npx get-git-folder https://github.com/vercel/examples main solutions/node-hello-world
 ```
 
 Install the Vercel CLI:
@@ -29,3 +31,6 @@ Then run the app at the root of the repository:
 ```bash
 vercel dev
 ```
+
+[1]: https://vercel.com/?utm_source=github&utm_medium=readme&utm_campaign=vercel-examples
+[2]: https://vercel.com/new/git/external?repository-url=https://github.com/vercel/examples/tree/main/solutions/node-hello-world&project-name=node-hello-world&repository-name=node-hello-world


### PR DESCRIPTION
### Description

`git clone` can't download a GitHub folder, so the command in this Example's ReadMe will throw error:

```text
$ git clone https://github.com/vercel/examples/tree/main/solutions/node-hello-world
Cloning into 'node-hello-world'...
fatal: repository 'https://github.com/vercel/examples/tree/main/solutions/node-hello-world/' not found
```

A Node.js CLI tool [`get-git-folder`][1] is a good alternative.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

[1]: https://github.com/idea2app/get-git-folder