### PR TITLE
fix: :bug: incorrect path in 18n example app-dir

### DIFF
--- a/app-directory/i18n/app/layout.tsx
+++ b/app-directory/i18n/app/layout.tsx
@@ -11,7 +11,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <Layout path="app-directory/css-in-js">{children}</Layout>
+        <Layout path="app-directory/i18n">{children}</Layout>
       </body>
     </html>
   )


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

Fixes #838. 
Incorrect path in i18n example.
Changed to the correct dir.

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->
https://vercel-examples-orpin.vercel.app/en

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
