### PR TITLE
Make bottom links in postgres examples clickable

### DIFF
--- a/storage/postgres-drizzle/app/page.tsx
+++ b/storage/postgres-drizzle/app/page.tsx
@@ -48,7 +48,7 @@ export default function Home() {
         .
       </p>
 
-      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600">
+      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600 z-10">
         <Link
           href="https://postgres-prisma.vercel.app/"
           className="font-medium underline underline-offset-4 hover:text-black transition-colors"

--- a/storage/postgres-drizzle/app/page.tsx
+++ b/storage/postgres-drizzle/app/page.tsx
@@ -48,7 +48,7 @@ export default function Home() {
         .
       </p>
 
-      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600 z-10">
+      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 max-w-xl text-gray-600 z-10">
         <Link
           href="https://postgres-prisma.vercel.app/"
           className="font-medium underline underline-offset-4 hover:text-black transition-colors"

--- a/storage/postgres-kysely/app/page.tsx
+++ b/storage/postgres-kysely/app/page.tsx
@@ -48,7 +48,7 @@ export default function Home() {
         .
       </p>
 
-      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600">
+      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600 z-10">
         <Link
           href="https://postgres-prisma.vercel.app/"
           className="font-medium underline underline-offset-4 hover:text-black transition-colors"

--- a/storage/postgres-kysely/app/page.tsx
+++ b/storage/postgres-kysely/app/page.tsx
@@ -48,7 +48,7 @@ export default function Home() {
         .
       </p>
 
-      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600 z-10">
+      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 max-w-xl text-gray-600 z-10">
         <Link
           href="https://postgres-prisma.vercel.app/"
           className="font-medium underline underline-offset-4 hover:text-black transition-colors"

--- a/storage/postgres-prisma/app/page.tsx
+++ b/storage/postgres-prisma/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
         .
       </p>
 
-      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600">
+      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600 z-10">
         <Link
           href="https://postgres-starter.vercel.app/"
           className="font-medium underline underline-offset-4 hover:text-black transition-colors"

--- a/storage/postgres-prisma/app/page.tsx
+++ b/storage/postgres-prisma/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
         .
       </p>
 
-      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600 z-10">
+      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 max-w-xl text-gray-600 z-10">
         <Link
           href="https://postgres-starter.vercel.app/"
           className="font-medium underline underline-offset-4 hover:text-black transition-colors"

--- a/storage/postgres-starter/app/page.tsx
+++ b/storage/postgres-starter/app/page.tsx
@@ -42,7 +42,7 @@ export default function Home() {
         .
       </p>
 
-      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600">
+      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600 z-10">
         <Link
           href="https://postgres-prisma.vercel.app/"
           className="font-medium underline underline-offset-4 hover:text-black transition-colors"

--- a/storage/postgres-starter/app/page.tsx
+++ b/storage/postgres-starter/app/page.tsx
@@ -42,7 +42,7 @@ export default function Home() {
         .
       </p>
 
-      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 w-full max-w-xl text-gray-600 z-10">
+      <div className="flex justify-center space-x-5 pt-10 mt-10 border-t border-gray-300 max-w-xl text-gray-600 z-10">
         <Link
           href="https://postgres-prisma.vercel.app/"
           className="font-medium underline underline-offset-4 hover:text-black transition-colors"


### PR DESCRIPTION
### Description

Makes the nav items on the bottom of the postgres examples clickable

<img width="1510" alt="Screenshot 2024-02-06 at 9 35 13 PM" src="https://github.com/vercel/examples/assets/8961613/e2c2d03f-1930-4ee1-9477-263e02596009">

To repro, check out the example demo ([seen here](https://postgres-drizzle.vercel.app/)) and try to click on one of the links (e.g. "Prisma").  Note: the window needs to be short enough that these nav items are in line with the footer

### What These Changes Do

Before these links were showing up behind the footer, so this change sets their z-index to 10 in order to have them render on top

<img width="1231" alt="image" src="https://github.com/vercel/examples/assets/8961613/0c20b785-d49b-4389-8b77-4be760912af1">

It also removes the `w-full` style so the opposite problem (e.g. the other example links covering the footer) does not happen

<img width="637" alt="image" src="https://github.com/vercel/examples/assets/8961613/5df0634f-6640-42c6-be22-3a0396d7e186">


On mobile, there isn't overlap

<img width="329" alt="image" src="https://github.com/vercel/examples/assets/8961613/e7bfef54-0b7e-43eb-908c-c136d99f6550">


### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

