### PR TITLE
fix(solutions-blog): refer the `github` links to actual github source

### DIFF
--- a/solutions/blog/app/components/footer.tsx
+++ b/solutions/blog/app/components/footer.tsx
@@ -35,7 +35,7 @@ export default function Footer() {
             className="flex items-center transition-all hover:text-neutral-800 dark:hover:text-neutral-100"
             rel="noopener noreferrer"
             target="_blank"
-            href="https://vercel.com/templates/next.js/portfolio-starter-kit"
+            href="https://github.com/vercel/next.js"
           >
             <ArrowIcon />
             <p className="ml-2 h-7">github</p>
@@ -46,7 +46,7 @@ export default function Footer() {
             className="flex items-center transition-all hover:text-neutral-800 dark:hover:text-neutral-100"
             rel="noopener noreferrer"
             target="_blank"
-            href="https://vercel.com/templates/next.js/portfolio-starter-kit"
+            href="https://github.com/vercel/examples/tree/main/solutions/blog"
           >
             <ArrowIcon />
             <p className="ml-2 h-7">view source</p>

--- a/solutions/blog/app/components/footer.tsx
+++ b/solutions/blog/app/components/footer.tsx
@@ -46,7 +46,7 @@ export default function Footer() {
             className="flex items-center transition-all hover:text-neutral-800 dark:hover:text-neutral-100"
             rel="noopener noreferrer"
             target="_blank"
-            href="https://github.com/vercel/examples/tree/main/solutions/blog"
+            href="https://vercel.com/templates/next.js/portfolio-starter-kit"
           >
             <ArrowIcon />
             <p className="ml-2 h-7">view source</p>


### PR DESCRIPTION
cc @leerob

### Description

The `github` links are redirecting to vercel deploy, some visitors are confused and find it hard to find the source.

x-ref: [twitter comment #1](https://x.com/lxopetrucci/status/1777336583982612488)
x-ref: [twitter comment #2](https://x.com/CIMSTA_official/status/1777330594638094366)

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
