### PR TITLE
CRON example: Update link to kv marketing page

### DIFF
--- a/solutions/cron/pages/index.tsx
+++ b/solutions/cron/pages/index.tsx
@@ -81,7 +81,7 @@ export default function Home({ data }: { data: any }) {
           </Link>{' '}
           and stored in{' '}
           <Link
-            href="https://vercel.com/kv"
+            href="https://vercel.com/storage/kv"
             target="_blank"
             rel="noreferrer noopener"
           >


### PR DESCRIPTION
Current link to https://vercel.com/kv is blank and doesn't forward anywhere, updating to actual canonical marketing page https://vercel.com/storage/kv