### PR TITLE
solved neon connection error

### DIFF
--- a/storage/postgres-nuxt/server/api/get-users.ts
+++ b/storage/postgres-nuxt/server/api/get-users.ts
@@ -39,7 +39,7 @@ async function seed() {
 }
 export default defineEventHandler(async () => {
   const startTime = Date.now()
-  const db = createPool()
+  const db = createPool({ connectionString: process.env.POSTGRES_URL_NO_SSL})
   try {
     const { rows: users } = await db.query('SELECT * FROM users')
     const duration = Date.now() - startTime


### PR DESCRIPTION
solved conflict on ssl with websocket tunel and postgres connection

### Description

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)


when using the standard connection string that has sslmode=required the following error occurred:
SSL is enabled for both Postgres (e.g. ?sslmode=true in the connection string) and the WebSocket tunnel (useSecureWebSocket = true). Double encryption will increase latency and CPU usage. Please disable SSL on the Postgres connection.
