### PR TITLE
Fix typo in solutions/blog/README.md.

### DIFF
--- a/solutions/blog/README.md
+++ b/solutions/blog/README.md
@@ -1,6 +1,6 @@
 # Portfolio Blog Starter
 
-This is a porfolio site template complete with a blog. Includes:
+This is a portfolio site template complete with a blog. Includes:
 
 - MDX and Markdown support
 - Optimized for SEO (sitemap, robots, JSON-LD schema)


### PR DESCRIPTION
### Description

Fix typo: `porfolio` -> `portfolio`.