### PR TITLE
Resolve Domain Hijacking in Domains API Example

### DIFF
--- a/solutions/domains-api/lib/consts.js
+++ b/solutions/domains-api/lib/consts.js
@@ -1,1 +1,1 @@
-export const restrictedDomains = ['cat.vercel.pub']
+export const restrictedDomains = ['cat.vercel.pub', 'domains-api.vercel.app']


### PR DESCRIPTION
### Description

This pull request adds `domains-api.vercel.app` to the restricted domains const, preventing it from being removed.

### Demo URL

Image showing current behaviour:
![image](https://github.com/user-attachments/assets/ec89f8d0-321b-494a-8ece-e3b35408fac1)

https://domains-api.vercel.app

### Type of Change

- [x] Bug fix
