### PR TITLE
fix: remove unused `await`

### DIFF
--- a/storage/postgres-prisma/prisma/seed.ts
+++ b/storage/postgres-prisma/prisma/seed.ts
@@ -22,7 +22,7 @@ async function main() {
           'https://images.ctfassets.net/e5382hct74si/4BtM41PDNrx4z1ml643tdc/7aa88bdde8b5b7809174ea5b764c80fa/adWRdqQ6_400x400.jpg',
       },
     }),
-    await prisma.users.upsert({
+    prisma.users.upsert({
       where: { email: 'stey@vercel.com' },
       update: {},
       create: {


### PR DESCRIPTION
### Description

This pull request includes a small change to the `storage/postgres-prisma/prisma/seed.ts` file. The change involves removing the `await` keyword from the `prisma.users.upsert` call as all these calls are already inside a `Promise.all`.

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)