### PR TITLE
always use default export for middleware function

### DIFF
--- a/edge-middleware/ab-testing-google-optimize/middleware.ts
+++ b/edge-middleware/ab-testing-google-optimize/middleware.ts
@@ -6,7 +6,7 @@ export const config = {
   matcher: ['/marketing', '/about'],
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   let cookie = req.cookies.get(COOKIE_NAME)?.value
 
   if (!cookie) {

--- a/edge-middleware/add-header/README.md
+++ b/edge-middleware/add-header/README.md
@@ -20,7 +20,7 @@ Below is the code from [middleware.ts](middleware.ts) showing how to add respons
 ```ts
 import { NextResponse } from 'next/server'
 
-export function middleware() {
+export default function middleware() {
   // Store the response so we can modify its headers
   const response = NextResponse.next()
 

--- a/edge-middleware/add-header/middleware.ts
+++ b/edge-middleware/add-header/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-export function middleware() {
+export default function middleware() {
   // Store the response so we can modify its headers
   const response = NextResponse.next()
 

--- a/edge-middleware/basic-auth-password/middleware.ts
+++ b/edge-middleware/basic-auth-password/middleware.ts
@@ -4,7 +4,7 @@ export const config = {
   matcher: ['/', '/index'],
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   const basicAuth = req.headers.get('authorization')
   const url = req.nextUrl
 

--- a/edge-middleware/cookies/README.md
+++ b/edge-middleware/cookies/README.md
@@ -32,7 +32,7 @@ export const config = {
   matcher: '/',
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   // Parse the cookie
   const isInBeta = JSON.parse(req.cookies.get('beta')?.value || 'false')
 

--- a/edge-middleware/cookies/middleware.ts
+++ b/edge-middleware/cookies/middleware.ts
@@ -4,7 +4,7 @@ export const config = {
   matcher: '/',
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   // Parse the cookie
   const isInBeta = JSON.parse(req.cookies.get('beta')?.value || 'false')
 

--- a/edge-middleware/crypto/middleware.ts
+++ b/edge-middleware/crypto/middleware.ts
@@ -8,7 +8,7 @@ export const config = {
   matcher: '/',
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   const token = crypto.randomUUID()
   const url = req.nextUrl
 

--- a/edge-middleware/geolocation-country-block/README.md
+++ b/edge-middleware/geolocation-country-block/README.md
@@ -10,7 +10,7 @@ import type { NextRequest } from 'next/server'
 // Block Austria, prefer Germany
 const BLOCKED_COUNTRY = 'AT'
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   const country = req.geo.country || 'US'
 
   if (country === BLOCKED_COUNTRY) {

--- a/edge-middleware/geolocation-country-block/middleware.ts
+++ b/edge-middleware/geolocation-country-block/middleware.ts
@@ -10,7 +10,7 @@ export const config = {
   matcher: '/',
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   // Extract country
   const country = req.geo.country || 'US'
 

--- a/edge-middleware/image-response/middleware.ts
+++ b/edge-middleware/image-response/middleware.ts
@@ -4,7 +4,7 @@ export const config = {
   matcher: '/',
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   req.nextUrl.pathname = '/api/img'
   return NextResponse.rewrite(req.nextUrl)
 }

--- a/edge-middleware/json-response/README.md
+++ b/edge-middleware/json-response/README.md
@@ -7,7 +7,7 @@ marketplace: false
 ```ts
 import type { NextRequest } from 'next/server'
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   return new Response(JSON.stringify({ message: 'hello world!' }), {
     status: 200,
     headers: {

--- a/edge-middleware/json-response/middleware.ts
+++ b/edge-middleware/json-response/middleware.ts
@@ -4,6 +4,6 @@ export const config = {
   matcher: '/',
 }
 
-export function middleware() {
+export default function middleware() {
   return NextResponse.json({ message: 'hello world!' })
 }

--- a/edge-middleware/modify-request-header/README.md
+++ b/edge-middleware/modify-request-header/README.md
@@ -21,7 +21,7 @@ Below is the code from [middleware.ts](middleware.ts) showing how to add/update/
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export default function middleware(request: NextRequest) {
   // Clone the request headers
   // You can modify them with headers API: https://developer.mozilla.org/en-US/docs/Web/API/Headers
   const requestHeaders = new Headers(request.headers)

--- a/edge-middleware/modify-request-header/middleware.ts
+++ b/edge-middleware/modify-request-header/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export default function middleware(request: NextRequest) {
   // Clone the request headers
   // You can modify them with headers API: https://developer.mozilla.org/en-US/docs/Web/API/Headers 
   const requestHeaders = new Headers(request.headers)

--- a/edge-middleware/power-parity-pricing-strategies/middleware.ts
+++ b/edge-middleware/power-parity-pricing-strategies/middleware.ts
@@ -5,7 +5,7 @@ export const config = {
   matcher: '/edge',
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   // Get country
   const country = req.geo.country?.toLowerCase() || 'us'
 

--- a/edge-middleware/power-parity-pricing/middleware.ts
+++ b/edge-middleware/power-parity-pricing/middleware.ts
@@ -5,7 +5,7 @@ export const config = {
   matcher: '/',
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   // Get country
   const country = req.geo.country?.toLowerCase() || 'us'
 

--- a/edge-middleware/query-params-filter/README.md
+++ b/edge-middleware/query-params-filter/README.md
@@ -28,7 +28,7 @@ export const config = {
   matcher: '/',
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   const url = req.nextUrl
   let changed = false
 

--- a/edge-middleware/query-params-filter/middleware.ts
+++ b/edge-middleware/query-params-filter/middleware.ts
@@ -6,7 +6,7 @@ export const config = {
   matcher: '/',
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   const url = req.nextUrl
   let changed = false
 

--- a/edge-middleware/user-agent-based-rendering/components/Home.tsx
+++ b/edge-middleware/user-agent-based-rendering/components/Home.tsx
@@ -62,7 +62,7 @@ export const config = {
   matcher: '/',
 }
 
-export function middleware(req) {
+export default function middleware(req) {
   // Parse user agent
   const { device } = userAgent(req)
 

--- a/edge-middleware/user-agent-based-rendering/middleware.ts
+++ b/edge-middleware/user-agent-based-rendering/middleware.ts
@@ -5,7 +5,7 @@ export const config = {
   matcher: '/',
 }
 
-export function middleware(req: NextRequest) {
+export default function middleware(req: NextRequest) {
   // Parse user agent
   const { device } = userAgent(req)
 


### PR DESCRIPTION
### Description

https://vercel.com/docs/functions/edge-middleware/middleware-api#edge-middleware-setup

Although Next.js can still recognize non-default export middleware function, it's good to be consistent across examples.