### PR TITLE
Remove `express` install and use directions that don't work

### DIFF
--- a/solutions/express/README.md
+++ b/solutions/express/README.md
@@ -13,21 +13,3 @@ You can choose from one of the following two methods to use this repository:
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=vercel-examples):
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/examples/tree/main/solutions/express&project-name=express&repository-name=express)
-
-### Clone and Deploy
-
-```bash
-git clone https://github.com/vercel/examples/tree/main/solutions/express
-```
-
-Install the Vercel CLI:
-
-```bash
-npm i -g vercel
-```
-
-Then run the app at the root of the repository:
-
-```bash
-vercel dev
-```


### PR DESCRIPTION
I'm assuming these instructions worked at some point when the express example got shifted into a monorepo the updated instructions weren't tested. As written it is not possible to do this in a one-liner with `git`

The closes think we could come up with was (h/t @TooTallNate)

```
curl -sfLS https://github.com/vercel/examples/archive/refs/heads/main.tar.gz | tar -xv --strip-components=2 examples-main/solutions/express
```

But the general reaction was 🤢 .

I think we just need to remove this at the moment.