### PR TITLE
chore(blob-starter): fix corepack configuration

### DIFF
--- a/storage/blob-starter/package.json
+++ b/storage/blob-starter/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "pnpm": "^9"
+    "pnpm": "9.13.0"
   },
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Seems like both engines and packageManager need to have the exact same version
when deploying on Vercel.
