### PR TITLE
fix optimizely example repo link

### DIFF
--- a/edge-middleware/feature-flag-optimizely/pages/_app.tsx
+++ b/edge-middleware/feature-flag-optimizely/pages/_app.tsx
@@ -13,7 +13,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       deployButton={{
         env: ['OPTIMIZELY_SDK_KEY'],
         repositoryUrl:
-          'https://github.com/optimizely/vercel-examples/tree/main/edge-middleware/feature-flag-optimizely',
+          'https://github.com/vercel/examples/tree/main/edge-middleware/feature-flag-optimizely',
       }}
     >
       <Component {...pageProps} />


### PR DESCRIPTION
Fixes the source repo link in the example


<img width="1636" alt="Bildschirmfoto 2024-11-28 um 08 07 40" src="https://github.com/user-attachments/assets/e23f5c83-ce58-4379-b9bc-8d573e2936f4">
