### PR TITLE
fix: update README to correct cloning instructions for Node.js Hello World example

### DIFF
--- a/solutions/node-hello-world/README.md
+++ b/solutions/node-hello-world/README.md
@@ -14,8 +14,16 @@ Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_mediu
 
 ### Clone and Deploy
 
+First, clone the entire repository:
+
 ```bash
-git clone https://github.com/vercel/examples/tree/main/solutions/node-hello-world
+git clone https://github.com/vercel/examples.git
+```
+
+Navigate to the specific example directory:
+
+```bash
+cd examples/solutions/node-hello-world
 ```
 
 Install the Vercel CLI:


### PR DESCRIPTION
The previous README instructions for cloning the repository were incorrect, as Git does not support cloning a specific subdirectory.  This update modifies the instructions to:
- Clone the entire repository.
- Navigate to the specific example directory.
- Ensure the process is clear for users to deploy the Node.js Hello World example using Vercel CLI.

This change addresses the issue reported in #992.


### Description

The previous README contained incorrect instructions for cloning the repository. This PR updates the instructions to:
- Clone the entire repository instead of attempting to clone a specific subdirectory.
- Provide steps to navigate to the desired example directory.
- Improve clarity for deploying the example using the Vercel CLI.

This change ensures users can successfully follow the README to deploy the Node.js Hello World example.

### Demo URL

Not applicable for this change as it only involves documentation updates. 
However, the steps in the README were tested locally to ensure correctness.