### PR TITLE
Fix geo property to match Header in Geo demo

### DIFF
--- a/edge-middleware/geolocation/middleware.ts
+++ b/edge-middleware/geolocation/middleware.ts
@@ -12,7 +12,7 @@ export async function middleware(req: NextRequest) {
   const geo = geolocation(req)
   const country = geo.country || 'US'
   const city = geo.city || 'San Francisco'
-  const region = geo.region || 'CA'
+  const region = geo.countryRegion || 'CA'
 
   const countryInfo = countries.find((x) => x.cca2 === country)
 


### PR DESCRIPTION
The current geolocation property doesn't show the user's region but the Server's compute region.
https://edge-functions-geolocation.vercel.sh/
![image](https://github.com/user-attachments/assets/9a13f248-791f-4bc2-8dd4-5983dde39b9e)
