### PR TITLE
Update package.json

### DIFF
--- a/storage/blob-starter/package.json
+++ b/storage/blob-starter/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "pnpm": "9.13.0"
+    "pnpm": "9.15.4"
   },
   "scripts": {
     "dev": "next dev --turbopack",
@@ -33,5 +33,5 @@
     "turbo": "^2.3.0",
     "typescript": "^5.6.3"
   },
-  "packageManager": "pnpm@9.13.0"
+  "packageManager": "pnpm@9.15.4"
 }


### PR DESCRIPTION
pnpm was out of date and failed to deploy. Updating package fixed the issue.

### Description

I updated pnpm from 9.13.0 to 9.15.4

### Demo URL

https://blob-starter-omega-sand.vercel.app/

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
