### PR TITLE
Remove edge runtime usage from solution examples

### DIFF
--- a/solutions/alt-tag-generator/pages/api/generate.ts
+++ b/solutions/alt-tag-generator/pages/api/generate.ts
@@ -1,10 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import Replicate from 'replicate'
 
-export const config = {
-  runtime: 'edge',
-}
-
 const replicate = new Replicate({
   auth: process.env.REPLICATE_API_TOKEN || '',
 })

--- a/solutions/cron/README.md
+++ b/solutions/cron/README.md
@@ -5,7 +5,7 @@ description: A Next.js app that uses Vercel Cron Jobs to update data at differen
 framework: Next.js
 useCase:
   - Cron
-  - Edge Functions
+  - Functions
 css: Tailwind
 database: Vercel KV
 deployUrl: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fsolutions%2Fcron&project-name=cron&repository-name=cron&demo-title=Vercel%20Cron%20Job%20Example&demo-description=A%20Next.js%20app%20that%20uses%20Vercel%20Cron%20Jobs%20to%20update%20data%20at%20different%20intervals.&demo-url=https%3A%2F%2Fcron-template.vercel.app%2F&demo-image=https%3A%2F%2Fcron-template.vercel.app%2Fthumbnail.png&stores=%5B%7B"type"%3A"kv"%7D%5D

--- a/solutions/cron/pages/api/cron/[cron].ts
+++ b/solutions/cron/pages/api/cron/[cron].ts
@@ -1,10 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { kv } from '@vercel/kv'
 
-export const config = {
-  runtime: 'edge',
-}
-
 export default async function handler(req: NextRequest) {
   const cron = req.nextUrl.pathname.split('/')[3]
   console.log(cron)

--- a/solutions/cron/pages/api/data/[interval].ts
+++ b/solutions/cron/pages/api/data/[interval].ts
@@ -1,10 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { kv } from '@vercel/kv'
 
-export const config = {
-  runtime: 'edge',
-}
-
 export default async function handler(req: NextRequest) {
   const interval = req.nextUrl.searchParams.get('interval')
   if (!interval) return new Response('No interval provided', { status: 400 })


### PR DESCRIPTION
### Description

Switch from edge functions -> functions in examples.

### Type of Change

- [ ] New Example
- [X] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
