### PR TITLE
Remove edge runtime usage in solution examples

### DIFF
--- a/solutions/alt-tag-generator/pages/api/generate.ts
+++ b/solutions/alt-tag-generator/pages/api/generate.ts
@@ -1,17 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextApiRequest, NextApiResponse } from 'next'
 import Replicate from 'replicate'
-
-export const config = {
-  runtime: 'edge',
-}
 
 const replicate = new Replicate({
   auth: process.env.REPLICATE_API_TOKEN || '',
 })
 
-export default async function handler(req: NextRequest) {
-  const image =
-    req.nextUrl.searchParams.get('imageUrl') || 'https://dub.sh/confpic'
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const image = (req.query.imageUrl as string) || 'https://dub.sh/confpic'
 
   const output = await replicate.run(
     'salesforce/blip:2e1dddc8621f72155f24cf2e0adbde548458d3cab9f00c0139eea840d0ac4746',
@@ -21,5 +19,5 @@ export default async function handler(req: NextRequest) {
       },
     }
   )
-  return NextResponse.json(output)
+  return res.json(output)
 }

--- a/solutions/cron/README.md
+++ b/solutions/cron/README.md
@@ -5,7 +5,7 @@ description: A Next.js app that uses Vercel Cron Jobs to update data at differen
 framework: Next.js
 useCase:
   - Cron
-  - Edge Functions
+  - Functions
 css: Tailwind
 database: Vercel KV
 deployUrl: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fsolutions%2Fcron&project-name=cron&repository-name=cron&demo-title=Vercel%20Cron%20Job%20Example&demo-description=A%20Next.js%20app%20that%20uses%20Vercel%20Cron%20Jobs%20to%20update%20data%20at%20different%20intervals.&demo-url=https%3A%2F%2Fcron-template.vercel.app%2F&demo-image=https%3A%2F%2Fcron-template.vercel.app%2Fthumbnail.png&stores=%5B%7B"type"%3A"kv"%7D%5D

--- a/solutions/cron/pages/api/cron/[cron].ts
+++ b/solutions/cron/pages/api/cron/[cron].ts
@@ -1,18 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextApiRequest, NextApiResponse } from 'next'
 import { kv } from '@vercel/kv'
 
-export const config = {
-  runtime: 'edge',
-}
-
-export default async function handler(req: NextRequest) {
-  const cron = req.nextUrl.pathname.split('/')[3]
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const cron = req.url?.split('/')[3]
   console.log(cron)
-  if (!cron) return new Response('No cron provided', { status: 400 })
+  if (!cron) return res.status(400).json({ error: 'No cron provided' })
   const response = await update(cron)
-  return new NextResponse(JSON.stringify(response), {
-    status: 200,
-  })
+  return res.status(200).json(response)
 }
 
 async function update(interval: string) {
@@ -22,7 +19,7 @@ async function update(interval: string) {
 
   const response = await kv.set(interval, {
     fetchedAt: Date.now(),
-    id: topstories[0],
+    id: topstories[0]
   })
 
   return response

--- a/solutions/cron/pages/api/data/[interval].ts
+++ b/solutions/cron/pages/api/data/[interval].ts
@@ -1,28 +1,22 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextApiRequest, NextApiResponse } from 'next'
 import { kv } from '@vercel/kv'
 
-export const config = {
-  runtime: 'edge',
-}
-
-export default async function handler(req: NextRequest) {
-  const interval = req.nextUrl.searchParams.get('interval')
-  if (!interval) return new Response('No interval provided', { status: 400 })
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const interval = req.query.interval as string
+  if (!interval) return res.status(400).json({ error: 'No interval provided' })
   const { id, fetchedAt } =
     (await kv.get<{
       id: string
       fetchedAt: string
     } | null>(interval)) || {}
-  const res = await fetch(
-    `https://hacker-news.firebaseio.com/v0/item/${id}.json?print=pretty`
+  const response = await fetch(
+    `https://hacker-news.firebaseio.com/v0/item/${id}.json?print=pretty`,
   ).then((res) => res.json())
-  return new NextResponse(
-    JSON.stringify({
-      fetchedAt,
-      ...res,
-    }),
-    {
-      status: 200,
-    }
-  )
+  return res.status(200).json({
+    fetchedAt,
+    ...response,
+  })
 }


### PR DESCRIPTION
### Description

Changes examples in `/solutions` folder to stop using the edge runtime.

### Demo URL

`cron`: https://cron-git-austinmerrick-update-solution-examples.labs.vercel.dev/
`alt-tag-generator`: tested locally (not deployed)
	
### Type of Change

- [ ] New Example
- [X] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
