### PR TITLE
[boilerplate-nodejs] switch prebuilt project id for faster builds

### DIFF
--- a/.github/workflows/faster-template-prebuild-boilerplate-nextjs.yml
+++ b/.github/workflows/faster-template-prebuild-boilerplate-nextjs.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           vc build --debug --token $VERCEL_TOKEN --yes --prod
         env:
-          VERCEL_PROJECT_ID: prj_qav3SWw0ZQDfehj7w47xPaBESx8P
+          VERCEL_PROJECT_ID: prj_D1Kp06w4jE67wyV3WlMHjtfDLjhC
           VERCEL_TOKEN: ${{ secrets.VERCEL_EXAMPLES_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_EXAMPLES_ORG_ID }}
 
@@ -45,6 +45,6 @@ jobs:
         run: |
           vc deploy --debug --token $VERCEL_TOKEN --yes --prod --prebuilt --archive=tgz
         env:
-          VERCEL_PROJECT_ID: prj_qav3SWw0ZQDfehj7w47xPaBESx8P
+          VERCEL_PROJECT_ID: prj_D1Kp06w4jE67wyV3WlMHjtfDLjhC
           VERCEL_TOKEN: ${{ secrets.VERCEL_EXAMPLES_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_EXAMPLES_ORG_ID }}


### PR DESCRIPTION
The initial PR for this workflow reused the existing projectId from the [workflow in `vercel/vercel`](https://github.com/vercel/vercel/blob/00c622d4497d37932d17571854c19bd2340d5c36/.github/workflows/faster-template-prebuild-nextjs.yml#L40) but I want to further isolate these two examples for migration.