### PR TITLE
Fixing relative path

### DIFF
--- a/edge-middleware/feature-flag-split/README.md
+++ b/edge-middleware/feature-flag-split/README.md
@@ -48,7 +48,7 @@ Then open `.env.local` and set the environment variables to match the ones in yo
 
 #### Set up environment variables
 
-Copy [.env.example](./env.example) to `.env.local`:
+Copy [.env.example](./.env.example) to `.env.local`:
 
 ```bash
 cp .env.example .env.local


### PR DESCRIPTION
### Description

.env.example link in https://github.com/vercel/examples/blob/main/edge-middleware/feature-flag-split/ is not pointing to the right file.

### Demo URL

Go to https://github.com/vercel/examples/blob/main/edge-middleware/feature-flag-split/ and look for the .env.example link

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)