### PR TITLE
Blog: Add support for shadcn-ui

### DIFF
--- a/solutions/blog/next.config.ts
+++ b/solutions/blog/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  /* config options here */
+};
+
+export default nextConfig;

--- a/solutions/blog/tsconfig.json
+++ b/solutions/blog/tsconfig.json
@@ -20,6 +20,9 @@
         "name": "next"
       }
     ],
+    "paths": {
+      "@/*": ["./*"]
+    },
     "strictNullChecks": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
### Description

We had a [post](https://vercel.community/t/portfolio-blog-starter-with-shadcn-ui/6033) on the Vercel Community where the user couldn't install the shadcn-ui components in the Portfolio Starter Kit even when following the Tailwind v4 documentation.

![image](https://github.com/user-attachments/assets/ebd75f38-803e-4446-bb63-950a19347c02)

After comparing the project with a new project created by following the [shadcn docs](https://ui.shadcn.com/docs/tailwind-v4#nextjs), we [fixed](https://vercel.community/t/portfolio-blog-starter-with-shadcn-ui/6033/4) this by adding the following changes: 

- Add Next config file
- Update tsconfig to add alias 

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
