### PR TITLE
[vercel-tutor] Do not use useSearchParams

### DIFF
--- a/vercel-tutor/app/page.tsx
+++ b/vercel-tutor/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Image from "next/image";
-import { useSearchParams } from "next/navigation";
 import { useState, useEffect } from "react";
 import vercelSvg from "@/app/vercel.svg";
 
@@ -30,11 +29,10 @@ export default function Home() {
   const [nextUrl, setNextUrl] = useState("#");
   const [isLocalhost, setIsLocalhost] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const searchParams = useSearchParams();
-  const prUrl = searchParams.get("prUrl");
 
   useEffect(() => {
     const host = window.location.hostname;
+    const prUrl = new URLSearchParams(window.location.search).get("prUrl");
 
     if (
       prUrl?.match(
@@ -51,7 +49,7 @@ export default function Home() {
     } else {
       setIsLocalhost(true);
     }
-  }, [prUrl]);
+  }, []);
 
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">


### PR DESCRIPTION
### Description

Fix for https://github.com/vercel/examples/pull/1086 - do not use `useSearchParams` to avoid using `Suspense`.

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
