### PR TITLE
fix: Fonts in the blog example

### DIFF
--- a/solutions/blog/app/layout.tsx
+++ b/solutions/blog/app/layout.tsx
@@ -1,7 +1,6 @@
 import './global.css'
 import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
-import { GeistMono } from 'geist/font/mono'
 import { Navbar } from './components/nav'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
@@ -48,8 +47,7 @@ export default function RootLayout({
       lang="en"
       className={cx(
         'text-black bg-white dark:text-white dark:bg-black',
-        GeistSans.variable,
-        GeistMono.variable
+        GeistSans.className
       )}
     >
       <body className="antialiased max-w-xl mx-4 mt-8 lg:mx-auto">


### PR DESCRIPTION
The Geist Sans font family is not applied to the body. This PR changes the code to use classname instead of the variable in the classname prop.