### PR TITLE
Update build output api example node versions

### DIFF
--- a/build-output-api/draft-mode/.vercel/output/functions/index.func/.vc-config.json
+++ b/build-output-api/draft-mode/.vercel/output/functions/index.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs18.x",
+  "runtime": "nodejs20.x",
   "handler": "index.js",
   "launcherType": "Nodejs"
 }

--- a/build-output-api/draft-mode/.vercel/output/functions/login.func/.vc-config.json
+++ b/build-output-api/draft-mode/.vercel/output/functions/login.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs18.x",
+  "runtime": "nodejs20.x",
   "handler": "index.js",
   "launcherType": "Nodejs",
   "shouldAddHelpers": true

--- a/build-output-api/draft-mode/.vercel/output/functions/logout.func/.vc-config.json
+++ b/build-output-api/draft-mode/.vercel/output/functions/logout.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs18.x",
+  "runtime": "nodejs20.x",
   "handler": "index.js",
   "launcherType": "Nodejs",
   "shouldAddHelpers": true

--- a/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].func/.vc-config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/blog/[slug].func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs16.x",
+  "runtime": "nodejs20.x",
   "handler": "index.js",
   "launcherType": "Nodejs"
 }

--- a/build-output-api/on-demand-isr/.vercel/output/functions/data.func/.vc-config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/data.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs16.x",
+  "runtime": "nodejs20.x",
   "handler": "index.js",
   "launcherType": "Nodejs"
 }

--- a/build-output-api/on-demand-isr/.vercel/output/functions/index.func/.vc-config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/index.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs16.x",
+  "runtime": "nodejs20.x",
   "handler": "index.js",
   "launcherType": "Nodejs"
 }

--- a/build-output-api/on-demand-isr/.vercel/output/functions/revalidate.func/.vc-config.json
+++ b/build-output-api/on-demand-isr/.vercel/output/functions/revalidate.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs16.x",
+  "runtime": "nodejs20.x",
   "handler": "index.js",
   "launcherType": "Nodejs",
   "shouldAddHelpers": true

--- a/build-output-api/prerender-functions/.vercel/output/functions/blog/post.func/.vc-config.json
+++ b/build-output-api/prerender-functions/.vercel/output/functions/blog/post.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs18.x",
+  "runtime": "nodejs20.x",
   "handler": "index.js",
   "launcherType": "Nodejs",
   "shouldAddHelpers": true

--- a/build-output-api/serverless-functions/.vercel/output/functions/index.func/.vc-config.json
+++ b/build-output-api/serverless-functions/.vercel/output/functions/index.func/.vc-config.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs18.x",
+  "runtime": "nodejs20.x",
   "handler": "index.js",
   "launcherType": "Nodejs",
   "shouldAddHelpers": true


### PR DESCRIPTION
### Description

Node 16 is discontinued and 18 requires [setting the project's node version](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions#setting-the-node.js-version-in-project-settings), so this updates all the build output api examples to Node 20.

### Demo URL

N/A

### Type of Change

- [ ] New Example
- [X] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
