### PR TITLE
Update runtime setting on flags-sdk examples

### DIFF
--- a/flags-sdk/experimentation-statsig/app/.well-known/vercel/flags/route.ts
+++ b/flags-sdk/experimentation-statsig/app/.well-known/vercel/flags/route.ts
@@ -3,7 +3,6 @@ import { type ProviderData, mergeProviderData } from 'flags'
 import { createFlagsDiscoveryEndpoint, getProviderData } from 'flags/next'
 import * as flags from '../../../../flags'
 
-export const runtime = 'edge'
 export const dynamic = 'force-dynamic' // defaults to auto
 
 export const GET = createFlagsDiscoveryEndpoint(async () => {

--- a/flags-sdk/openfeature/app/.well-known/vercel/flags/route.ts
+++ b/flags-sdk/openfeature/app/.well-known/vercel/flags/route.ts
@@ -1,7 +1,6 @@
 import { createFlagsDiscoveryEndpoint, getProviderData } from 'flags/next'
 import * as flags from '../../../../flags'
 
-export const runtime = 'edge'
 export const dynamic = 'force-dynamic' // defaults to auto
 
 export const GET = createFlagsDiscoveryEndpoint(() => getProviderData(flags))


### PR DESCRIPTION
We can remove `runtime='edge'` in some parts of flags-sdk examples.