### PR TITLE
Update more Next.js settings

### DIFF
--- a/edge-middleware/feature-flag-hypertune/app/api/flags/route.ts
+++ b/edge-middleware/feature-flag-hypertune/app/api/flags/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 import getHypertune from '../../../lib/getHypertune'
 
-export const runtime = 'edge'
 export const dynamic = 'force-dynamic'
 
 export async function GET() {

--- a/edge-middleware/feature-flag-hypertune/app/layout.tsx
+++ b/edge-middleware/feature-flag-hypertune/app/layout.tsx
@@ -10,8 +10,6 @@ export const metadata = getMetadata({
   description: 'An example showing how to use Hypertune with Vercel.',
 })
 
-export const runtime = 'edge'
-
 export default async function RootLayout({
   children,
 }: Readonly<{ children: ReactNode }>) {

--- a/edge-middleware/feature-flag-hypertune/app/page.tsx
+++ b/edge-middleware/feature-flag-hypertune/app/page.tsx
@@ -9,8 +9,6 @@ export const metadata = {
     'An example showing how to use Hypertune with Vercel. This example builds on top of the Hypertune integration which syncs Hypertune flags into Edge Config so you can read them from your application near-instantly. It also shows how to integrate with the Vercel Toolbar so you can easily view and override your feature flags without leaving your frontend. Finally, it shows how to use the Vercel Feature Flags pattern to use flags on a static page.',
 }
 
-export const runtime = 'edge'
-
 export default async function Home() {
   return (
     <Page className="flex flex-col gap-12">

--- a/edge-middleware/feature-flag-launchdarkly/app/layout.tsx
+++ b/edge-middleware/feature-flag-launchdarkly/app/layout.tsx
@@ -6,7 +6,6 @@ export const metadata = getMetadata({
   title: 'feature-flag-launchdarkly',
   description: 'An example showing how to use Vercel with LaunchDarkly',
 })
-export const runtime = 'edge'
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/edge-middleware/feature-flag-launchdarkly/app/page.tsx
+++ b/edge-middleware/feature-flag-launchdarkly/app/page.tsx
@@ -8,7 +8,6 @@ export const metadata = {
   description:
     'An example showing how to use LaunchDarkly and Vercel. This example builds on top of the LaunchDarkly integration which syncs LaunchDarkly flags into Edge Config, so you can read them from your application near-instantly.',
 }
-export const runtime = 'edge'
 
 const edgeConfigClient = createClient(process.env.EDGE_CONFIG)
 

--- a/edge-middleware/feature-flag-split/app/about/page.tsx
+++ b/edge-middleware/feature-flag-split/app/about/page.tsx
@@ -3,10 +3,6 @@ import { AboutA } from './a'
 import { AboutB } from './b'
 import { createSplitClient } from '@lib/split'
 
-// export const runtime = 'edge'
-export const dynamic = 'force-dynamic'
-export const runtime = 'edge'
-
 export default async function About() {
   const userKey = cookies().get('split-userkey')?.value ?? 'anonymous'
   const client = await createSplitClient(userKey)

--- a/edge-middleware/feature-flag-split/app/marketing/page.tsx
+++ b/edge-middleware/feature-flag-split/app/marketing/page.tsx
@@ -3,10 +3,6 @@ import { MarketingA } from './a'
 import { MarketingB } from './b'
 import { createSplitClient } from '@lib/split'
 
-// export const runtime = 'edge'
-export const dynamic = 'force-dynamic'
-export const runtime = 'edge'
-
 export default async function Marketing() {
   const userKey = cookies().get('split-userkey')?.value ?? 'anonymous'
   const client = await createSplitClient(userKey)

--- a/flags-sdk/bucket/app/.well-known/vercel/flags/route.ts
+++ b/flags-sdk/bucket/app/.well-known/vercel/flags/route.ts
@@ -3,8 +3,6 @@ import { getProviderData as getBucketProviderData } from '@flags-sdk/bucket'
 import { mergeProviderData } from 'flags'
 import * as flags from '../../../../flags'
 
-export const dynamic = 'force-dynamic' // defaults to auto
-
 export const GET = createFlagsDiscoveryEndpoint(async (request) => {
   return mergeProviderData([
     // Data declared from Flags in Code

--- a/flags-sdk/experimentation-statsig/app/.well-known/vercel/flags/route.ts
+++ b/flags-sdk/experimentation-statsig/app/.well-known/vercel/flags/route.ts
@@ -3,8 +3,6 @@ import { type ProviderData, mergeProviderData } from 'flags'
 import { createFlagsDiscoveryEndpoint, getProviderData } from 'flags/next'
 import * as flags from '../../../../flags'
 
-export const dynamic = 'force-dynamic' // defaults to auto
-
 export const GET = createFlagsDiscoveryEndpoint(async () => {
   // Fetches additional metadata from the Statsig API for the Flags Explorer
   let statsigData: ProviderData = { definitions: {}, hints: [] }

--- a/flags-sdk/openfeature/app/.well-known/vercel/flags/route.ts
+++ b/flags-sdk/openfeature/app/.well-known/vercel/flags/route.ts
@@ -1,6 +1,4 @@
 import { createFlagsDiscoveryEndpoint, getProviderData } from 'flags/next'
 import * as flags from '../../../../flags'
 
-export const dynamic = 'force-dynamic' // defaults to auto
-
 export const GET = createFlagsDiscoveryEndpoint(() => getProviderData(flags))


### PR DESCRIPTION
#### Pull Request Description

This PR proposes the following changes:
1. Remove unnecessary `force-dynamic` 
2. Remove unnecessary `runtime=edge`

Cookies usage and `createFlagsDiscoveryEndpoint` should ensure dynamic behaviour. Edge middleware examples use runtime=edge in middleware, but we can still remove it in some places.

This PR is more opinionated than the changes presented in [PR #1136](https://github.com/vercel/examples/pull/1136) so is published separately
