### PR TITLE
Add nitro framework boilerplate

### DIFF
--- a/framework-boilerplates/nitro/.gitignore
+++ b/framework-boilerplates/nitro/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.data
+.nitro
+.cache
+.output
+.env

--- a/framework-boilerplates/nitro/.npmrc
+++ b/framework-boilerplates/nitro/.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+strict-peer-dependencies=false

--- a/framework-boilerplates/nitro/README.md
+++ b/framework-boilerplates/nitro/README.md
@@ -1,0 +1,19 @@
+# Nitro
+
+This directory is a brief example of [Nitro](https://nitro.build/) that can be deployed to Vercel with zero configuration. Go to the [nitro quick start](https://nitro.unjs.io/guide#quick-start) to learn more.
+
+## Deploy Your Own
+
+Deploy your own Nitro project with Vercel.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/framework-boilerplates/nitro&template=nitro)
+
+_Live Example: https://nitro.vercel.app_
+
+## Developing
+
+Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+
+```bash
+npm run dev
+```

--- a/framework-boilerplates/nitro/nitro.config.ts
+++ b/framework-boilerplates/nitro/nitro.config.ts
@@ -1,0 +1,4 @@
+//https://nitro.unjs.io/config
+export default defineNitroConfig({
+  srcDir: "server"
+});

--- a/framework-boilerplates/nitro/package.json
+++ b/framework-boilerplates/nitro/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "nitro build",
+    "dev": "nitro dev",
+    "prepare": "nitro prepare",
+    "preview": "node .output/server/index.mjs"
+  },
+  "devDependencies": {
+    "nitropack": "latest"
+  }
+}

--- a/framework-boilerplates/nitro/server/routes/index.ts
+++ b/framework-boilerplates/nitro/server/routes/index.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler((event) => {
+  return "Start by editing <code>server/routes/index.ts</code>.";
+});

--- a/framework-boilerplates/nitro/tsconfig.json
+++ b/framework-boilerplates/nitro/tsconfig.json
@@ -1,0 +1,4 @@
+// https://nitro.unjs.io/guide/typescript
+{
+  "extends": "./.nitro/types/tsconfig.json"
+}


### PR DESCRIPTION
### Description

Nitro build detects the env var `VERCEL=1` and emits build output API code, so Nitro already works great on Vercel with zero configuration. This adds the framework boilerplat that [the framework entry](https://github.com/vercel/vercel/pull/13472) will reference.

### Demo URL

https://nitro.vercel.app_

### Type of Change

- [X] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [X] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [X] 📱 Is it responsive? Are mobile and tablets considered?
