### PR TITLE
fix: Update Hono documentation link to correct backend frameworks URL

### DIFF
--- a/framework-boilerplates/hono/src/index.ts
+++ b/framework-boilerplates/hono/src/index.ts
@@ -4,7 +4,7 @@ const app = new Hono()
 
 const welcomeStrings = [
   "Hello Hono!",
-  "To learn more about Hono on Vercel, visit https://vercel.com/docs/frameworks/hono",
+  "To learn more about Hono on Vercel, visit https://vercel.com/docs/frameworks/backend/hono",
 ]
 
 app.get('/', (c) => {


### PR DESCRIPTION
## Summary

Updated the Hono example documentation link to point to the correct URL for backend frameworks.

## Changes

- Updated documentation link in `framework-boilerplates/hono/src/index.ts`
  - Old: `https://vercel.com/docs/frameworks/hono`
  - New: `https://vercel.com/docs/frameworks/backend/hono`

## Why this change is needed

Hono is now officially supported as a backend framework on Vercel, and the documentation has been moved to the backend frameworks section. The old URL may lead users to outdated or incorrect information.

This update ensures that developers using the Hono example are directed to the proper, up-to-date documentation for deploying Hono applications on Vercel.

This PR fixes #1177.
