### PR TITLE
Update FastHTML docs URL

### DIFF
--- a/framework-boilerplates/fasthtml/main.py
+++ b/framework-boilerplates/fasthtml/main.py
@@ -29,7 +29,7 @@ def get():
                             href="https://vercel.com/templates/python/fasthtml-python-boilerplate",
                         ),
                         " or ",
-                        A("learn more", href="https://docs.fastht.ml/"),
+                        A("learn more", href="https://www.fastht.ml/docs"),
                         "about FastHTML.",
                     )
                 ),


### PR DESCRIPTION
### Description

The previous URL (https://docs.fastht.ml) is no longer valid. Updated the link in the footer to the current documentation location at https://www.fastht.ml/docs.

### Demo URL

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)
