### PR TITLE
Update Node.js engine version to 22.x in Preact and Vue boilerplates

### DIFF
--- a/framework-boilerplates/preact/package.json
+++ b/framework-boilerplates/preact/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": "18.x"
+    "node": "22.x"
   },
   "eslintConfig": {
     "extends": "preact",

--- a/framework-boilerplates/vue/package.json
+++ b/framework-boilerplates/vue/package.json
@@ -6,7 +6,7 @@
     "lint": "vue-cli-service lint"
   },
   "engines": {
-    "node": "18.x"
+    "node": "22.x"
   },
   "dependencies": {
     "core-js": "^3.30.2",


### PR DESCRIPTION
### Description

Fixes an issue with deprecated templates due to Node 18.

<img width="1765" height="283" alt="image" src="https://github.com/user-attachments/assets/80dde585-1cd5-4a2f-8317-7c46a09a9cb6" />


### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
