### PR TITLE
Enhance README and index.ts for Hono AI SDK usage instructions

### DIFF
--- a/starter/hono-ai-sdk/README.md
+++ b/starter/hono-ai-sdk/README.md
@@ -31,3 +31,20 @@ To deploy:
 npm install
 vc deploy
 ```
+
+
+### Usage
+
+Pass a prompt via the `prompt` URL query parameter to get a streamed response:
+
+- Browser:
+  - `http://localhost:3000/?prompt=What%20is%20the%20capital%20of%20France?`
+
+- cURL:
+
+```bash
+curl -G 'http://localhost:3000/' \
+  --data-urlencode 'prompt=What is the capital of France?'
+```
+
+If `prompt` is omitted, the server falls back to a default prompt.

--- a/starter/hono-ai-sdk/src/index.ts
+++ b/starter/hono-ai-sdk/src/index.ts
@@ -4,9 +4,10 @@ import { stream } from 'hono/streaming'
 
 const app = new Hono()
 
-const prompt = 'Why is the sky blue?'
+const defaultPrompt = 'Why is the sky blue?'
 
 app.get('/', async (c) => {
+  const prompt = c.req.query('prompt') ?? defaultPrompt
   const result = streamText({
     model: 'xai/grok-3',
     prompt,


### PR DESCRIPTION
- Added usage instructions to README.md for passing prompts via URL query parameters.
- Updated index.ts to use a default prompt if none is provided in the request.