### PR TITLE
Python vibe coding ide backend url fix

### DIFF
--- a/python/vibe-coding-ide/frontend/src/constants.ts
+++ b/python/vibe-coding-ide/frontend/src/constants.ts
@@ -1,6 +1,8 @@
 declare const process: { env: Record<string, string | undefined> }
 const env = process.env
 
+// Normalize API base: supports env with or without '/api' suffix.
+// If absolute and path empty -> '<origin>/api'; otherwise preserve path; trims trailing slashes.
 export const API_BASE = (() => {
   const raw = (
     env.NEXT_PUBLIC_API_URL ||


### PR DESCRIPTION
### Description

Small fix on python example to normalize backend url in env var

### Demo URL

https://python-vibe-coding-ide.labs.vercel.dev/

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
