### PR TITLE
[ci] fix broken workflow

### DIFF
--- a/.github/workflows/publish-template.yaml
+++ b/.github/workflows/publish-template.yaml
@@ -39,7 +39,9 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v18.7
+        run: |
+          changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | tr '\n' ' ')
+          echo "all_changed_files=${changed_files}" >> $GITHUB_OUTPUT
 
       - name: Publish template
         run: pnpm update-templates "${{ steps.changed-files.outputs.all_changed_files }}"


### PR DESCRIPTION
### Description

The publish template workflow was broken due to the following error:
```
The action tj-actions/changed-files@v18.7 is not allowed in vercel/examples because all actions must be from a repository owned by your enterprise, created by GitHub, verified in the GitHub Marketplace, or match one of the patterns: action@*, actions/checkout@*, actions/setup-node@*, changesets/action@*, pnpm/action-setup@*.
```

As this action was previously compromised in a supply chain attack, I've added a native workaround.

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
