### PR TITLE
ci: fix @vercel/examples-ui publish (2)

### DIFF
--- a/internal/.changeset/gold-lies-eat.md
+++ b/internal/.changeset/gold-lies-eat.md
@@ -1,0 +1,5 @@
+---
+'@vercel/examples-ui': patch
+---
+
+Export layout, allow react 19

--- a/internal/packages/playwright/scripts/generate-tests.ts
+++ b/internal/packages/playwright/scripts/generate-tests.ts
@@ -19,7 +19,6 @@ async function generateTests() {
   const getFiles = (folder: string): Promise<[string, string[]]> =>
     fs.readdir(path.join(rootDir, folder)).then((paths) => [folder, paths])
   const examplesBySection = await Promise.all([
-    getFiles('edge-functions'),
     getFiles('edge-middleware'),
     getFiles('solutions'),
     getFiles('starter'),

--- a/internal/packages/ui/CHANGELOG.md
+++ b/internal/packages/ui/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @vercel/examples-ui
 
-## 2.0.4
-
-### Patch Changes
-
-- 6e341f6b: Export layout, allow react 19
-
 ## 2.0.3
 
 ### Patch Changes

--- a/internal/packages/ui/package.json
+++ b/internal/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/examples-ui",
-  "version": "2.0.4",
+  "version": "2.0.3",
   "license": "MIT",
   "scripts": {
     "dev": "pnpm build:swc -w",

--- a/internal/scripts/lib/update-changed-templates.ts
+++ b/internal/scripts/lib/update-changed-templates.ts
@@ -2,14 +2,7 @@ import path from 'path'
 import log from './log'
 import updateTemplate from './contentful/update-template'
 
-const DIRS = [
-  'edge-functions',
-  'edge-middleware',
-  'rust',
-  'solutions',
-  'starter',
-  'storage',
-]
+const DIRS = ['edge-middleware', 'rust', 'solutions', 'starter', 'storage']
 const IS_README = /readme\.md$/i
 
 export default async function updateChangedTemplates(changedFiles: string[]) {


### PR DESCRIPTION
### Description

More references of deleted dir that makes the publish fail 💀
2f34205a7364cc4c892427d7c64f50ec3a78e837

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
