### PR TITLE
Fix links to`/templates/next.js/ratelimit-with-upstash-redis`

### DIFF
--- a/edge-middleware/rate-limit-any-framework/README.md
+++ b/edge-middleware/rate-limit-any-framework/README.md
@@ -12,6 +12,6 @@ relatedTemplates:
 
 This template shows how to add rate limiting to any application with [Vercel KV](https://vercel.com/docs/storage/vercel-kv) and [Vercel Edge Middleware](https://vercel.com/docs/concepts/functions/edge-middleware).
 
-> **Note:** If you are using Next.js, you can use the built in Middleware support rather than needing `@vercel/edge` used in this package. Please refer to the [Next.js example](https://vercel.com/templates/next.js/api-rate-limit-upstash).
+> **Note:** If you are using Next.js, you can use the built in Middleware support rather than needing `@vercel/edge` used in this package. Please refer to the [Next.js example](https://vercel.com/templates/next.js/ratelimit-with-upstash-redis).
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/edge-middleware/rate-limit-any-framework&project-name=ratelimit&stores=%5B%7B"type"%3A"kv"%7D%5D)


### PR DESCRIPTION
### Description

Links to `https://vercel.com/templates/next.js/api-rate-limit-upstash` should be `https://vercel.com/templates/next.js/ratelimit-with-upstash-redis`

I'll also add a redirect to our templates redirect remote store.