### PR TITLE
[cdn] Adding examples of template token variables

### DIFF
--- a/cdn/custom-error-pages-app-dir/app/500/page.tsx
+++ b/cdn/custom-error-pages-app-dir/app/500/page.tsx
@@ -6,6 +6,12 @@ export default function ServerError() {
       <p className="mt-2 text-sm text-gray-500">
         Something went wrong on our end. Please try again later.
       </p>
+      <p className="mt-2 text-sm text-gray-500">
+        Request ID: ::vercel:REQUEST_ID::
+      </p>
+      <p className="mt-2 text-sm text-gray-500">
+        Error: ::vercel:ERROR_CODE::
+      </p>
       <a href="/" className="mt-6 text-blue-600 hover:underline">
         Go back home
       </a>

--- a/cdn/custom-error-pages-app-dir/app/504/page.tsx
+++ b/cdn/custom-error-pages-app-dir/app/504/page.tsx
@@ -6,6 +6,12 @@ export default function GatewayTimeout() {
       <p className="mt-2 text-sm text-gray-500">
         The server took too long to respond. Please try again later.
       </p>
+      <p className="mt-2 text-sm text-gray-500">
+        Request ID: ::vercel:REQUEST_ID::
+      </p>
+      <p className="mt-2 text-sm text-gray-500">
+        Error: ::vercel:ERROR_CODE::
+      </p>
       <a href="/" className="mt-6 text-blue-600 hover:underline">
         Go back home
       </a>

--- a/cdn/custom-error-pages-public-dir/public/500.html
+++ b/cdn/custom-error-pages-public-dir/public/500.html
@@ -50,6 +50,8 @@
     <h1>500</h1>
     <p class="description">Internal Server Error</p>
     <p class="hint">Something went wrong on our end. Please try again later.</p>
+    <p class="hint">Request ID: ::vercel:REQUEST_ID::</p>
+    <p class="hint">Error: ::vercel:ERROR_CODE::</p>
     <a href="/">Go back home</a>
   </div>
 </body>

--- a/cdn/custom-error-pages-public-dir/public/504.html
+++ b/cdn/custom-error-pages-public-dir/public/504.html
@@ -50,6 +50,8 @@
     <h1>504</h1>
     <p class="description">Gateway Timeout</p>
     <p class="hint">The server took too long to respond. Please try again later.</p>
+    <p class="hint">Request ID: ::vercel:REQUEST_ID::</p>
+    <p class="hint">Error: ::vercel:ERROR_CODE::</p>
     <a href="/">Go back home</a>
   </div>
 </body>


### PR DESCRIPTION
### Description
Add `::vercel:REQUEST_ID::` and `::vercel:ERROR_CODE::` template tokens to custom error page examples. These tokens are replaced by Vercel with actual values when serving error pages, helping users reference specific requests when contacting support.


### Type of Change

- [ ] New Example
- [X] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
