### PR TITLE
[cdn] Add descriptive home pages and timeout test route to custom err…

### DIFF
--- a/cdn/custom-error-pages-app-dir/app/page.tsx
+++ b/cdn/custom-error-pages-app-dir/app/page.tsx
@@ -3,56 +3,90 @@ import Image from "next/image";
 export default function Home() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
+      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-16 px-8 bg-white dark:bg-black sm:items-start sm:px-16 sm:py-24">
         <Image
           className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
+          src="/vercel.svg"
+          alt="Vercel logo"
+          width={120}
+          height={28}
           priority
         />
         <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
+          <h1 className="max-w-lg text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
+            Custom Error Pages with App Router
           </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
+          <p className="max-w-lg text-base leading-7 text-zinc-600 dark:text-zinc-400">
+            This example demonstrates how to create custom error pages using
+            Next.js App Router conventions. Replace Vercel&apos;s default
+            platform error pages with your own branded experience for errors
+            like function timeouts or throttling.
           </p>
+          <div className="max-w-lg text-base leading-7 text-zinc-600 dark:text-zinc-400">
+            <p className="font-medium text-zinc-800 dark:text-zinc-200">
+              How it works:
+            </p>
+            <ul className="mt-2 list-disc pl-5 space-y-1">
+              <li>
+                Create error pages at <code className="text-sm bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">app/500/page.tsx</code> and{" "}
+                <code className="text-sm bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">app/504/page.tsx</code>
+              </li>
+              <li>
+                Vercel automatically detects and serves these for platform
+                errors
+              </li>
+              <li>
+                The 500 page acts as a fallback for all unhandled error codes
+              </li>
+            </ul>
+          </div>
+          <div className="max-w-lg text-base leading-7 text-zinc-600 dark:text-zinc-400">
+            <p className="font-medium text-zinc-800 dark:text-zinc-200">
+              Template tokens:
+            </p>
+            <ul className="mt-2 list-disc pl-5 space-y-1">
+              <li>
+                <code className="text-sm bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">::vercel:REQUEST_ID::</code> - Unique request identifier
+              </li>
+              <li>
+                <code className="text-sm bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">::vercel:ERROR_CODE::</code> - Error type (e.g.,
+                FUNCTION_INVOCATION_TIMEOUT)
+              </li>
+            </ul>
+          </div>
+          <div className="max-w-lg text-base leading-7 text-zinc-600 dark:text-zinc-400">
+            <p className="font-medium text-zinc-800 dark:text-zinc-200">
+              Try it out:
+            </p>
+            <p className="mt-2">
+              Click &quot;Trigger Timeout&quot; to trigger a function timeout and see
+              the custom error page in action. The page is configured to timeout
+              after 3 seconds.
+            </p>
+          </div>
         </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
+        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row sm:flex-wrap">
           <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] sm:w-auto"
+            href="/slow-page"
           >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
+            Trigger Timeout
           </a>
           <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
+            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] sm:w-auto"
+            href="/500"
+          >
+            View 500 Page
+          </a>
+          <a
+            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] sm:w-auto"
+            href="/504"
+          >
+            View 504 Page
+          </a>
+          <a
+            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] sm:w-auto"
+            href="https://vercel.com/docs/custom-error-pages"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/cdn/custom-error-pages-app-dir/app/slow-page/page.tsx
+++ b/cdn/custom-error-pages-app-dir/app/slow-page/page.tsx
@@ -1,0 +1,24 @@
+// Force dynamic rendering so the sleep happens on each request
+export const dynamic = "force-dynamic";
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function SlowPage() {
+  // Sleep for 60 seconds - this will trigger a timeout since maxDuration is 3s
+  await sleep(60000);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center px-6 py-24 bg-gray-50">
+      <div className="text-center">
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+          Slow Page
+        </h1>
+        <p className="mt-6 text-base leading-7 text-gray-600">
+          If you see this, the page did not timeout (waited 60 seconds).
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/cdn/custom-error-pages-app-dir/vercel.json
+++ b/cdn/custom-error-pages-app-dir/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "app/slow-page/page.tsx": {
+      "maxDuration": 3
+    }
+  }
+}

--- a/cdn/custom-error-pages-public-dir/app/page.tsx
+++ b/cdn/custom-error-pages-public-dir/app/page.tsx
@@ -3,56 +3,90 @@ import Image from "next/image";
 export default function Home() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
+      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-16 px-8 bg-white dark:bg-black sm:items-start sm:px-16 sm:py-24">
         <Image
           className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
+          src="/vercel.svg"
+          alt="Vercel logo"
+          width={120}
+          height={28}
           priority
         />
         <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
+          <h1 className="max-w-lg text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
+            Custom Error Pages with Public Directory
           </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
+          <p className="max-w-lg text-base leading-7 text-zinc-600 dark:text-zinc-400">
+            This example demonstrates how to create custom error pages using
+            static HTML files in the public directory. Replace Vercel&apos;s
+            default platform error pages with your own branded experience for
+            errors like function timeouts or throttling.
           </p>
+          <div className="max-w-lg text-base leading-7 text-zinc-600 dark:text-zinc-400">
+            <p className="font-medium text-zinc-800 dark:text-zinc-200">
+              How it works:
+            </p>
+            <ul className="mt-2 list-disc pl-5 space-y-1">
+              <li>
+                Add static HTML files at <code className="text-sm bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">public/500.html</code> and{" "}
+                <code className="text-sm bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">public/504.html</code>
+              </li>
+              <li>
+                Vercel automatically detects and serves these for platform
+                errors
+              </li>
+              <li>
+                The 500 page acts as a fallback for all unhandled error codes
+              </li>
+            </ul>
+          </div>
+          <div className="max-w-lg text-base leading-7 text-zinc-600 dark:text-zinc-400">
+            <p className="font-medium text-zinc-800 dark:text-zinc-200">
+              Template tokens:
+            </p>
+            <ul className="mt-2 list-disc pl-5 space-y-1">
+              <li>
+                <code className="text-sm bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">::vercel:REQUEST_ID::</code> - Unique request identifier
+              </li>
+              <li>
+                <code className="text-sm bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">::vercel:ERROR_CODE::</code> - Error type (e.g.,
+                FUNCTION_INVOCATION_TIMEOUT)
+              </li>
+            </ul>
+          </div>
+          <div className="max-w-lg text-base leading-7 text-zinc-600 dark:text-zinc-400">
+            <p className="font-medium text-zinc-800 dark:text-zinc-200">
+              Try it out:
+            </p>
+            <p className="mt-2">
+              Click &quot;Trigger Timeout&quot; to trigger a function timeout and see
+              the custom error page in action. The page is configured to timeout
+              after 3 seconds.
+            </p>
+          </div>
         </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
+        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row sm:flex-wrap">
           <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] sm:w-auto"
+            href="/slow-page"
           >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
+            Trigger Timeout
           </a>
           <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
+            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] sm:w-auto"
+            href="/500.html"
+          >
+            View 500 Page
+          </a>
+          <a
+            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] sm:w-auto"
+            href="/504.html"
+          >
+            View 504 Page
+          </a>
+          <a
+            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] sm:w-auto"
+            href="https://vercel.com/docs/custom-error-pages"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/cdn/custom-error-pages-public-dir/app/slow-page/page.tsx
+++ b/cdn/custom-error-pages-public-dir/app/slow-page/page.tsx
@@ -1,0 +1,24 @@
+// Force dynamic rendering so the sleep happens on each request
+export const dynamic = "force-dynamic";
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function SlowPage() {
+  // Sleep for 60 seconds - this will trigger a timeout since maxDuration is 3s
+  await sleep(60000);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center px-6 py-24 bg-gray-50">
+      <div className="text-center">
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+          Slow Page
+        </h1>
+        <p className="mt-6 text-base leading-7 text-gray-600">
+          If you see this, the page did not timeout (waited 60 seconds).
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/cdn/custom-error-pages-public-dir/vercel.json
+++ b/cdn/custom-error-pages-public-dir/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "app/slow-page/page.tsx": {
+      "maxDuration": 3
+    }
+  }
+}


### PR DESCRIPTION
### Description
Making the home pages descriptive and adding a testable error route

### Demo URL
https://custom-error-pages-public-dir.vercel.app/
https://custom-error-pages-app-dir.vercel.app/

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [x] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
