### PR TITLE
Remove dependency on fs from npm

### DIFF
--- a/solutions/platforms-slate-supabase/package.json
+++ b/solutions/platforms-slate-supabase/package.json
@@ -20,7 +20,6 @@
     "cuid": "^2.1.8",
     "date-fns": "^2.29.3",
     "escape-html": "^1.0.3",
-    "fs": "0.0.1-security",
     "gray-matter": "^4.0.3",
     "is-hotkey": "^0.2.0",
     "js-cookie": "^3.0.1",

--- a/solutions/platforms-slate-supabase/pnpm-lock.yaml
+++ b/solutions/platforms-slate-supabase/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
-      fs:
-        specifier: 0.0.1-security
-        version: 0.0.1-security
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -1066,9 +1063,6 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -3368,8 +3362,6 @@ snapshots:
   fs-constants@1.0.0: {}
 
   fs.realpath@1.0.0: {}
-
-  fs@0.0.1-security: {}
 
   fsevents@2.3.2:
     optional: true


### PR DESCRIPTION
Was added in the original version of the example: https://github.com/vercel/examples/pull/134

But it's a useless package that doesn't do anything.