### PR TITLE
Add CometChat Chat Starter (solutions/cometchat-chat)

### DIFF
--- a/solutions/cometchat-chat/.agents/skills/cometchat-astro-patterns/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-astro-patterns/SKILL.md
@@ -1,0 +1,687 @@
+---
+name: cometchat-astro-patterns
+description: "Framework-specific patterns for integrating CometChat React UI Kit v6 into Astro projects using React islands. Covers client:only rendering, island communication, CSS handling, and common pitfalls."
+license: "MIT"
+compatibility: "Node.js >=18; React >=18; Astro >=3; @astrojs/react; @cometchat/chat-uikit-react ^6; @cometchat/chat-sdk-javascript ^4"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "chat cometchat astro react islands client-only patterns"
+---
+
+## Purpose
+
+This skill teaches Claude how to integrate CometChat into an Astro project using React islands. Astro is a static-first framework -- most of the page is HTML rendered at build time. Interactive React components run as isolated "islands" in the browser. CometChat components are React islands that must use `client:only="react"` to bypass server rendering entirely.
+
+**Read these companion skills first:**
+- `cometchat-core` -- initialization, login, CSS, provider pattern, anti-patterns
+- `cometchat-components` -- component catalog and composition patterns
+- `cometchat-placement` -- WHERE to put chat (route, modal, drawer, embedded)
+
+---
+
+## 1. Project detection
+
+A project uses Astro when `package.json` has `astro` as a dependency. CometChat integration also requires the React integration:
+
+```bash
+# Check for Astro + React
+grep -E '"astro"|"@astrojs/react"' package.json
+```
+
+**If `@astrojs/react` is missing**, it must be installed first:
+
+```bash
+npx astro add react
+```
+
+This adds `@astrojs/react` to `package.json` and configures it in `astro.config.mjs`.
+
+Verify the React integration is configured:
+
+```bash
+# astro.config.mjs should have react() in the integrations array
+grep -A 5 "integrations" astro.config.mjs 2>/dev/null || grep -A 5 "integrations" astro.config.ts 2>/dev/null
+```
+
+---
+
+## 2. Critical: client:only="react"
+
+Every Astro component that renders CometChat MUST use `client:only="react"`. This is the single most important rule for Astro + CometChat.
+
+### Why client:only and not client:load or client:visible
+
+Astro's client directives control when and how interactive components are hydrated:
+
+| Directive | Server renders? | When hydrates? | Works with CometChat? |
+|---|---|---|---|
+| `client:load` | Yes | On page load | **NO** -- server render crashes |
+| `client:visible` | Yes | When visible in viewport | **NO** -- server render crashes |
+| `client:idle` | Yes | When browser is idle | **NO** -- server render crashes |
+| `client:only="react"` | No | On page load (client-only) | **YES** |
+
+`client:load`, `client:visible`, and `client:idle` all attempt to render the component on the server first, then hydrate in the browser. CometChat components access `window` and `document` at import time, so server rendering crashes with `ReferenceError: window is not defined`.
+
+`client:only="react"` skips server rendering entirely. The component only runs in the browser. This is the ONLY valid directive for CometChat.
+
+### Usage in .astro files
+
+```astro
+---
+import ChatView from "../components/ChatView";
+---
+
+<!-- CORRECT -->
+<ChatView client:only="react" />
+
+<!-- WRONG -- will crash during build -->
+<ChatView client:load />
+
+<!-- WRONG -- will crash during build -->
+<ChatView client:visible />
+
+<!-- WRONG -- no directive, component won't be interactive at all -->
+<ChatView />
+```
+
+---
+
+## 3. CometChatProvider for Astro
+
+The provider pattern is the same React component as in other frameworks, but in Astro it runs entirely inside a React island. The provider is not mounted at the Astro layout level -- it is mounted inside the React island.
+
+### Full implementation
+
+```tsx
+// src/components/CometChatProvider.tsx
+import React, { useEffect, useState, createContext, useContext } from "react";
+import { CometChatUIKit, UIKitSettingsBuilder } from "@cometchat/chat-uikit-react";
+import "@cometchat/chat-uikit-react/css-variables.css";
+
+interface CometChatContextValue {
+  isReady: boolean;
+  error: string | null;
+}
+
+const CometChatContext = createContext<CometChatContextValue>({
+  isReady: false,
+  error: null,
+});
+
+export const useCometChat = () => useContext(CometChatContext);
+
+// Module-level state prevents both double-init AND double-login in React
+// StrictMode. Without the loginInFlight guard, a second mount calls
+// login() while the first is still pending and the SDK throws
+// "Please wait until the previous login request ends."
+let initialized = false;
+let loginInFlight: Promise<unknown> | null = null;
+
+async function ensureLoggedIn(
+  uid: string,
+  authToken?: string,
+): Promise<void> {
+  const existing = await CometChatUIKit.getLoggedinUser();
+  if (existing) return;
+  if (loginInFlight) {
+    await loginInFlight;
+    return;
+  }
+  loginInFlight = authToken
+    ? CometChatUIKit.loginWithAuthToken(authToken)
+    : CometChatUIKit.login(uid);
+  try {
+    await loginInFlight;
+  } finally {
+    loginInFlight = null;
+  }
+}
+
+interface CometChatProviderProps {
+  children: React.ReactNode;
+}
+
+export function CometChatProvider({ children }: CometChatProviderProps) {
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function setup() {
+      try {
+        if (!initialized) {
+          initialized = true;
+
+          const settings = new UIKitSettingsBuilder()
+            .setAppId(import.meta.env.PUBLIC_COMETCHAT_APP_ID)
+            .setRegion(import.meta.env.PUBLIC_COMETCHAT_REGION)
+            .setAuthKey(import.meta.env.PUBLIC_COMETCHAT_AUTH_KEY)
+            .subscribePresenceForAllUsers()
+            .build();
+
+          await CometChatUIKit.init(settings);
+        }
+
+        await ensureLoggedIn("cometchat-uid-1"); // DEVELOPMENT ONLY — see cometchat-production skill
+
+        setIsReady(true);
+      } catch (e) {
+        setError(String(e));
+      }
+    }
+
+    setup();
+  }, []);
+
+  if (error) {
+    return (
+      <div style={{ color: "red", padding: 16, fontFamily: "monospace" }}>
+        CometChat Error: {error}
+      </div>
+    );
+  }
+
+  if (!isReady) return null;
+
+  return (
+    <CometChatContext.Provider value={{ isReady, error }}>
+      {children}
+    </CometChatContext.Provider>
+  );
+}
+```
+
+### Key difference: CSS import is INSIDE the component
+
+Notice that `@cometchat/chat-uikit-react/css-variables.css` is imported inside the React component file, not in an Astro layout or global stylesheet. This is because `client:only` islands are completely isolated from Astro's CSS pipeline. Stylesheets imported in `.astro` files or global CSS do NOT reach `client:only` islands.
+
+---
+
+## 4. Chat page with React island
+
+### Full page implementation
+
+```astro
+---
+// src/pages/messages.astro
+import Layout from "../layouts/Layout.astro";
+import ChatView from "../components/ChatView";
+---
+
+<Layout title="Messages">
+  <div class="chat-container">
+    <ChatView client:only="react" />
+  </div>
+</Layout>
+
+<style>
+  .chat-container {
+    height: calc(100vh - 64px); /* subtract header height */
+    width: 100%;
+  }
+</style>
+```
+
+### ChatView component
+
+```tsx
+// src/components/ChatView.tsx
+import { useState } from "react";
+import { CometChatProvider } from "./CometChatProvider";
+import {
+  CometChatConversations,
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+export default function ChatView() {
+  return (
+    <CometChatProvider>
+      <ChatContent />
+    </CometChatProvider>
+  );
+}
+
+function ChatContent() {
+  const [selectedUser, setSelectedUser] = useState<CometChat.User>();
+  const [selectedGroup, setSelectedGroup] = useState<CometChat.Group>();
+
+  function handleConversationClick(conversation: CometChat.Conversation) {
+    const entity = conversation.getConversationWith();
+    if (entity instanceof CometChat.User) {
+      setSelectedUser(entity);
+      setSelectedGroup(undefined);
+    } else if (entity instanceof CometChat.Group) {
+      setSelectedUser(undefined);
+      setSelectedGroup(entity);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", height: "100%" }}>
+      <div style={{ width: "360px", borderRight: "1px solid #eee" }}>
+        <CometChatConversations onItemClick={handleConversationClick} />
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        {(selectedUser || selectedGroup) ? (
+          <>
+            {selectedUser && <CometChatMessageHeader user={selectedUser} />}
+            {selectedGroup && <CometChatMessageHeader group={selectedGroup} />}
+            {selectedUser && <CometChatMessageList user={selectedUser} />}
+            {selectedGroup && <CometChatMessageList group={selectedGroup} />}
+            {selectedUser && <CometChatMessageComposer user={selectedUser} />}
+            {selectedGroup && <CometChatMessageComposer group={selectedGroup} />}
+          </>
+        ) : (
+          <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#999" }}>
+            Select a conversation to start chatting
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+**Important:** The `CometChatProvider` wraps the content INSIDE the React island, not at the Astro level. Each island is an independent React tree. The provider initializes CometChat when this specific island mounts.
+
+---
+
+## 5. Drawer and modal patterns
+
+### Chat drawer as a React island
+
+```tsx
+// src/components/ChatDrawerIsland.tsx
+import { useState, useEffect } from "react";
+import { CometChatProvider } from "./CometChatProvider";
+import {
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+interface ChatDrawerIslandProps {
+  targetUserId: string;
+}
+
+export default function ChatDrawerIsland({ targetUserId }: ChatDrawerIslandProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <CometChatProvider>
+      <button onClick={() => setIsOpen(true)}>Message</button>
+
+      {isOpen && (
+        <>
+          <div
+            onClick={() => setIsOpen(false)}
+            style={{ position: "fixed", inset: 0, zIndex: 999, backgroundColor: "rgba(0,0,0,0.3)" }}
+          />
+          <div style={{
+            position: "fixed", top: 0, right: 0, bottom: 0, width: "400px", zIndex: 1000,
+            backgroundColor: "#fff", boxShadow: "-4px 0 20px rgba(0,0,0,0.15)",
+            display: "flex", flexDirection: "column",
+          }}>
+            <div style={{ display: "flex", justifyContent: "space-between", padding: "12px", borderBottom: "1px solid #eee" }}>
+              <span style={{ fontWeight: 600 }}>Chat</span>
+              <button onClick={() => setIsOpen(false)} style={{ background: "none", border: "none", cursor: "pointer" }} aria-label="Close">&times;</button>
+            </div>
+            <DrawerContent targetUserId={targetUserId} />
+          </div>
+        </>
+      )}
+    </CometChatProvider>
+  );
+}
+
+function DrawerContent({ targetUserId }: { targetUserId: string }) {
+  const [user, setUser] = useState<CometChat.User>();
+
+  useEffect(() => {
+    CometChat.getUser(targetUserId).then(setUser);
+  }, [targetUserId]);
+
+  if (!user) return <div style={{ padding: 16 }}>Loading...</div>;
+
+  return (
+    <>
+      <CometChatMessageHeader user={user} />
+      <div style={{ flex: 1, overflow: "hidden" }}>
+        <CometChatMessageList user={user} />
+      </div>
+      <CometChatMessageComposer user={user} />
+    </>
+  );
+}
+```
+
+Usage in an Astro page:
+
+```astro
+---
+import Layout from "../layouts/Layout.astro";
+import ChatDrawerIsland from "../components/ChatDrawerIsland";
+---
+
+<Layout title="Product">
+  <h1>Product Details</h1>
+  <p>Some product description...</p>
+  <ChatDrawerIsland client:only="react" targetUserId="seller-uid-123" />
+</Layout>
+```
+
+**Note:** The trigger button is INSIDE the React island. Astro's static HTML cannot trigger React state changes directly. The button must be part of the same React tree.
+
+---
+
+## 6. Inter-island communication
+
+Astro's island architecture means different React islands are separate React trees. They cannot share React state, context, or refs. If you need communication between a navbar island and a chat island, use one of these approaches:
+
+### Option A: Custom DOM events
+
+```tsx
+// NavbarIsland.tsx -- fires a custom event
+function NavbarIsland() {
+  function openChat() {
+    window.dispatchEvent(new CustomEvent("open-chat", { detail: { userId: "uid-123" } }));
+  }
+
+  return <button onClick={openChat}>Messages</button>;
+}
+
+// ChatIsland.tsx -- listens for the event
+function ChatIsland() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [targetUserId, setTargetUserId] = useState<string>();
+
+  useEffect(() => {
+    function handleOpenChat(e: CustomEvent) {
+      setTargetUserId(e.detail.userId);
+      setIsOpen(true);
+    }
+
+    window.addEventListener("open-chat", handleOpenChat as EventListener);
+    return () => window.removeEventListener("open-chat", handleOpenChat as EventListener);
+  }, []);
+
+  // ... render chat drawer when isOpen
+}
+```
+
+### Option B: Nanostores (Astro's recommended approach)
+
+Install nanostores: `npm install nanostores @nanostores/react`
+
+```typescript
+// src/stores/chatStore.ts
+import { atom } from "nanostores";
+
+export const $chatOpen = atom(false);
+export const $chatTargetUserId = atom<string | undefined>(undefined);
+```
+
+```tsx
+// NavbarIsland.tsx
+import { useStore } from "@nanostores/react";
+import { $chatOpen, $chatTargetUserId } from "../stores/chatStore";
+
+function NavbarIsland() {
+  function openChat() {
+    $chatTargetUserId.set("uid-123");
+    $chatOpen.set(true);
+  }
+
+  return <button onClick={openChat}>Messages</button>;
+}
+```
+
+```tsx
+// ChatIsland.tsx
+import { useStore } from "@nanostores/react";
+import { $chatOpen, $chatTargetUserId } from "../stores/chatStore";
+
+function ChatIsland() {
+  const isOpen = useStore($chatOpen);
+  const targetUserId = useStore($chatTargetUserId);
+
+  // ... render chat drawer when isOpen
+}
+```
+
+Nanostores work across framework boundaries -- if the project also has Svelte or Vue islands, they can all share the same store.
+
+### Option C: URL-based state
+
+Navigate to a chat page with query parameters:
+
+```astro
+<!-- In the navbar (static HTML or any island) -->
+<a href="/messages?user=uid-123">Message this user</a>
+```
+
+```tsx
+// ChatView.tsx -- reads user from URL
+function ChatView() {
+  const params = new URLSearchParams(window.location.search);
+  const targetUserId = params.get("user");
+
+  // ... resolve and render chat for this user
+}
+```
+
+---
+
+## 7. Environment variables
+
+### Astro env var conventions
+
+Astro uses Vite under the hood. Client-side variables must have the `PUBLIC_` prefix:
+
+```env
+PUBLIC_COMETCHAT_APP_ID=your_app_id
+PUBLIC_COMETCHAT_REGION=us
+PUBLIC_COMETCHAT_AUTH_KEY=your_auth_key
+```
+
+**Access in code:** `import.meta.env.PUBLIC_COMETCHAT_APP_ID`
+
+Variables without `PUBLIC_` prefix are server-only (available in Astro's frontmatter and API routes, but not in client islands).
+
+### .env file
+
+Create `.env` in the project root. Astro's `.env` is NOT gitignored by default -- add it:
+
+```bash
+echo ".env" >> .gitignore
+```
+
+### Server-only variables (for production auth)
+
+```env
+# Server-only (no PUBLIC_ prefix) -- for API endpoints
+COMETCHAT_AUTH_TOKEN=your_server_secret
+COMETCHAT_APP_ID=your_app_id
+COMETCHAT_REGION=us
+```
+
+Access in Astro API routes or server-side code:
+
+```typescript
+// src/pages/api/cometchat-token.ts
+import type { APIRoute } from "astro";
+
+export const POST: APIRoute = async ({ request }) => {
+  const { uid } = await request.json();
+  const appId = import.meta.env.COMETCHAT_APP_ID;
+  const region = import.meta.env.COMETCHAT_REGION;
+  const authToken = import.meta.env.COMETCHAT_AUTH_TOKEN;
+
+  const response = await fetch(
+    `https://${appId}.api-${region}.cometchat.io/v3/users/${uid}/auth_tokens`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        apiKey: authToken,
+        appId: appId,
+      },
+      body: JSON.stringify({}),
+    }
+  );
+
+  const data = await response.json();
+  return new Response(JSON.stringify({ token: data.data.authToken }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+```
+
+**Note:** Astro API routes require on-demand rendering. In Astro 3: set `output: "server"` or `output: "hybrid"` in `astro.config.mjs`. In Astro 4+: the default is `output: "static"` with per-route opt-in — add `export const prerender = false;` at the top of the API route file. If the project is fully static, the auth endpoint must be hosted elsewhere.
+
+---
+
+## 8. CSS handling
+
+### The island CSS isolation problem
+
+Unlike other frameworks, Astro's `client:only` islands are completely isolated from the Astro CSS pipeline. CSS imported in `.astro` files, global stylesheets linked in `<head>`, and `<style>` tags in Astro layouts do NOT reach `client:only` React components.
+
+### Solution: import CSS inside the React component
+
+```tsx
+// src/components/ChatView.tsx
+import "@cometchat/chat-uikit-react/css-variables.css"; // MUST be here, not in .astro
+import { CometChatConversations } from "@cometchat/chat-uikit-react";
+
+export default function ChatView() {
+  return <CometChatConversations />;
+}
+```
+
+### Where NOT to import CSS
+
+```astro
+---
+// src/layouts/Layout.astro
+// WRONG -- this CSS won't reach client:only islands
+---
+<html>
+  <head>
+    <link rel="stylesheet" href="@cometchat/chat-uikit-react/css-variables.css" />
+  </head>
+  <body><slot /></body>
+</html>
+```
+
+```css
+/* src/styles/global.css */
+/* WRONG -- @import here won't reach client:only islands */
+@import "@cometchat/chat-uikit-react/css-variables.css";
+```
+
+### Theming overrides
+
+To override CometChat CSS variables in Astro, do it inside the React component:
+
+```tsx
+// src/components/ChatView.tsx
+import "@cometchat/chat-uikit-react/css-variables.css";
+import "./cometchat-overrides.css"; // your overrides, imported AFTER
+
+export default function ChatView() {
+  // ...
+}
+```
+
+```css
+/* src/components/cometchat-overrides.css */
+:root {
+  --cometchat-primary-color: #6851d6;
+  --cometchat-font-family: "Inter", sans-serif;
+}
+```
+
+---
+
+## 9. Common pitfalls
+
+### client:load vs client:only
+
+**Symptom:** `ReferenceError: window is not defined` during `astro build` or `astro dev`.
+
+**Cause:** Using `client:load` (or `client:visible`, `client:idle`) instead of `client:only="react"`. These directives attempt server-side rendering.
+
+**Fix:** Replace with `client:only="react"`. Always. For every CometChat component.
+
+### CSS not appearing
+
+**Symptom:** CometChat components render with no styling -- raw unstyled HTML, missing colors, broken layout.
+
+**Cause:** CSS imported in an Astro layout or global stylesheet does not reach `client:only` islands.
+
+**Fix:** Import `@cometchat/chat-uikit-react/css-variables.css` inside the React component file (section 8).
+
+### View Transitions
+
+Astro's View Transitions API enables smooth page transitions without full reloads. CometChat's WebSocket connection persists across view transitions (the connection is on `window`, which survives transitions). However, the React island REMOUNTS on each navigation because Astro replaces the DOM.
+
+To keep chat state across page navigations, add `transition:persist` to the island element:
+
+```astro
+<ChatView client:only="react" transition:persist />
+```
+
+With `transition:persist`, Astro keeps the same DOM element across navigations, so the React tree stays mounted and chat state is preserved. Without it, navigating away and back remounts the island, requiring re-initialization (the `initialized` flag prevents double-init, but the UI state resets).
+
+### Content Collections
+
+Astro's Content Collections are for static content (Markdown, MDX, JSON). Chat data is dynamic and comes from CometChat's SDK. Do not try to store or query chat data via Content Collections.
+
+### Multiple chat islands on one page
+
+If a page has multiple `client:only="react"` islands that use CometChat, each island is a separate React tree. The module-level `initialized` flag ensures CometChat only initializes once even with multiple islands (the flag is shared across imports of the same module).
+
+However, each island needs its own `CometChatProvider` wrapping its content. The provider's `isReady` state is local to each React tree.
+
+### Passing data from Astro to React islands
+
+Props passed to `client:only` components must be serializable (strings, numbers, booleans, plain objects, arrays). You cannot pass React components, functions, or class instances from Astro frontmatter:
+
+```astro
+---
+// CORRECT -- serializable props
+const userId = "cometchat-uid-1";
+---
+<ChatDrawerIsland client:only="react" targetUserId={userId} />
+
+---
+// WRONG -- function props are not serializable
+const handleClose = () => console.log("closed");
+---
+<ChatDrawerIsland client:only="react" onClose={handleClose} />
+```
+
+---
+
+## 10. Complete integration checklist
+
+1. Ensure `@astrojs/react` is installed: `npx astro add react`
+2. Install packages: `npm install @cometchat/chat-uikit-react @cometchat/chat-sdk-javascript`
+3. Create `.env` with `PUBLIC_COMETCHAT_APP_ID`, `PUBLIC_COMETCHAT_REGION`, `PUBLIC_COMETCHAT_AUTH_KEY`
+4. Add `.env` to `.gitignore`
+5. Create `src/components/CometChatProvider.tsx` with CSS import inside it (section 3)
+6. Create `src/components/ChatView.tsx` wrapping content in `CometChatProvider` (section 4)
+7. Create `src/pages/messages.astro` with `<ChatView client:only="react" />` (section 4)
+8. Add a "Messages" link to the Astro layout's nav
+9. Verify: `npm run build` should succeed without `window is not defined` errors
+
+**The three things to remember for Astro:**
+1. Always `client:only="react"` -- never `client:load`
+2. CSS imports go INSIDE the React component -- never in `.astro` files
+3. Each island wraps its own `CometChatProvider` -- there is no global provider at the Astro level

--- a/solutions/cometchat-chat/.agents/skills/cometchat-components/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-components/SKILL.md
@@ -1,0 +1,1002 @@
+---
+name: cometchat-components
+description: "Complete catalog of CometChat React UI Kit v6 components. Reference before writing integration code -- never invent component names."
+license: "MIT"
+compatibility: "@cometchat/chat-uikit-react ^6; @cometchat/chat-sdk-javascript ^4"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "chat cometchat react components catalog reference ui-kit"
+---
+
+## Purpose
+
+This is the single source of truth for CometChat React UI Kit v6 component names, props, and usage. **Check this catalog before writing any `<CometChat*>` JSX.** If a component is not listed here, it does not exist in the exported API.
+
+All components are imported from `@cometchat/chat-uikit-react`. All SDK types are imported from `@cometchat/chat-sdk-javascript`.
+
+### Importing `CometChat.User` / `CometChat.Group` / etc.
+
+`CometChat.User`, `CometChat.Group`, `CometChat.BaseMessage`, `CometChat.Conversation`, `CometChat.GroupMember`, `CometChat.TextMessage` are **classes** (runtime values), not pure types. That means the import strategy depends on how you use them:
+
+**Pattern A — you call the class as a value or use it with `instanceof`.** Use a plain value import:
+
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+if (entity instanceof CometChat.User) { ... }
+const user = await CometChat.getUser(uid);
+```
+
+**Pattern B — you use it only as a type annotation, nowhere else.** Two options:
+
+```tsx
+// Option 1: value import, reference the type via the namespace — TS lets this slide
+// because CometChat is a class-namespace
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+function renderHeader(user: CometChat.User) { ... }
+
+// Option 2: explicit type-only import
+import type { CometChat } from "@cometchat/chat-sdk-javascript";
+function renderHeader(user: CometChat.User) { ... }
+```
+
+**Do NOT mix these.** If you write `import type { CometChat }` and then try `entity instanceof CometChat.User`, TypeScript strips the import at compile time and the code throws at runtime. If you write `import { CometChat }` but only reference `CometChat.User` as a type, `noUnusedLocals` can flag it (TS6133).
+
+**Safest default:** use the plain value import (`import { CometChat }`). It always works; the TS6133 warning only fires in strict `noUnusedLocals` configs and can be fixed by actually using the runtime value (e.g. `instanceof CometChat.User`) or by adding an `eslint-disable-next-line` if you truly only need the type.
+
+---
+
+## 1. Core messaging
+
+These are the components you use to build a chat experience. Most integrations use some combination of these seven.
+
+### CometChatConversations
+
+Renders a scrollable list of the logged-in user's conversations (both 1:1 and group).
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `activeConversation` | `CometChat.Conversation` | Highlights the currently selected conversation |
+| `onItemClick` | `(conversation: CometChat.Conversation) => void` | Called when the user taps a conversation |
+| `showSearchBar` | `boolean` | Shows a basic name-filter search bar above the list |
+| `onSearchBarClicked` | `() => void` | Called when the search bar is clicked (use to swap in `CometChatSearch` for full search) |
+| `conversationsRequestBuilder` | `CometChat.ConversationsRequestBuilder` | Customize which conversations to fetch (filters, limits) |
+
+**Usage:**
+```tsx
+<CometChatConversations
+  activeConversation={activeConversation}
+  onItemClick={(conversation) => setActiveConversation(conversation)}
+/>
+```
+
+**Works with:** CometChatMessageHeader, CometChatMessageList, CometChatMessageComposer (two-pane layout)
+
+---
+
+### CometChatMessageList
+
+Renders messages for a specific user or group conversation. Supports threaded views via `parentMessageId`.
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `user` | `CometChat.User` | Show messages with this user (mutually exclusive with `group`) |
+| `group` | `CometChat.Group` | Show messages in this group (mutually exclusive with `user`) |
+| `parentMessageId` | `number` | If set, shows only replies to this message (thread view) |
+| `templates` | `CometChatMessageTemplate[]` | Custom message bubble templates |
+| `messagesRequestBuilder` | `CometChat.MessagesRequestBuilder` | Customize message fetching |
+
+**Usage:**
+```tsx
+<CometChatMessageList user={selectedUser} />
+```
+
+**Works with:** CometChatMessageHeader (above), CometChatMessageComposer (below)
+
+---
+
+### CometChatMessageComposer
+
+A text input with send button, attachment options, and emoji support. Sends messages to the specified user or group.
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `user` | `CometChat.User` | Send messages to this user (mutually exclusive with `group`) |
+| `group` | `CometChat.Group` | Send messages to this group (mutually exclusive with `user`) |
+| `parentMessageId` | `number` | If set, sends replies to this message (thread mode) |
+| `onSendButtonClick` | `(message: CometChat.BaseMessage) => void` | Called when send is clicked |
+
+**Usage:**
+```tsx
+<CometChatMessageComposer user={selectedUser} />
+```
+
+**Works with:** CometChatMessageList (above), CometChatMessageHeader (at top of message area)
+
+---
+
+### CometChatCompactMessageComposer
+
+A rich-text variant of the message composer with formatting toolbar (bold, italic, code, etc.). Same props as CometChatMessageComposer.
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `user` | `CometChat.User` | Send messages to this user |
+| `group` | `CometChat.Group` | Send messages to this group |
+| `parentMessageId` | `number` | Thread mode |
+| `onSendButtonClick` | `(message: CometChat.BaseMessage) => void` | Called on send |
+
+**Usage:**
+```tsx
+<CometChatCompactMessageComposer user={selectedUser} />
+```
+
+**Works with:** Same as CometChatMessageComposer -- drop-in replacement for rich text
+
+---
+
+### CometChatMessageHeader
+
+Displays the name, avatar, and status of the user or group at the top of a message view. Supports a menu slot and search.
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `user` | `CometChat.User` | Show header for this user |
+| `group` | `CometChat.Group` | Show header for this group |
+| `onItemClick` | `() => void` | Called when the header info area is clicked (use to open details panel) |
+| `onBack` | `() => void` | Called when back button is clicked |
+| `auxiliaryButtonView` | `JSX.Element` | Custom button area (e.g., CometChatCallButtons) |
+| `showBackButton` | `boolean` | Show a back button (for mobile/nested views) |
+| `showSearchOption` | `boolean` | Show a search icon in the header |
+| `onSearchOptionClicked` | `() => void` | Called when search icon is clicked |
+| `hideVideoCallButton` | `boolean` | Hide the video call button |
+| `hideVoiceCallButton` | `boolean` | Hide the voice call button |
+
+**Usage:**
+```tsx
+<CometChatMessageHeader
+  user={selectedUser}
+  onItemClick={() => setShowDetails(true)}
+  auxiliaryButtonView={<CometChatCallButtons user={selectedUser} />}
+/>
+```
+
+**Works with:** CometChatMessageList (below), CometChatCallButtons (in auxiliaryButtonView slot)
+
+---
+
+### CometChatSearch
+
+Full-featured dual-scope search: searches across conversations AND messages with filter chips. This is the primary search component.
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `onConversationClicked` | `(conversation: CometChat.Conversation) => void` | Called when a conversation result is clicked |
+| `onMessageClicked` | `(message: CometChat.BaseMessage) => void` | Called when a message result is clicked |
+
+**Usage:**
+```tsx
+<CometChatSearch
+  onConversationClicked={(conv) => navigateToConversation(conv)}
+  onMessageClicked={(msg) => scrollToMessage(msg)}
+/>
+```
+
+**Works with:** CometChatConversations (replaces the list when search is active)
+
+> **Hard rule — never roll your own search.** Any request involving
+> "search", "find messages", "search conversations", or "search across
+> conversations" MUST use `<CometChatSearch>` (or `showSearchBar={true}`
+> + `onSearchBarClicked` on `CometChatConversations` to swap into
+> `<CometChatSearch>` on click). Do NOT build custom `<input type="search">`
+> bars, hand-rolled result lists, or filter UIs — they bypass the SDK's
+> pagination, highlighting, and dual-scope (conversations + messages)
+> matching that ship with the built-in component.
+
+---
+
+### CometChatThreadHeader
+
+Header bar for a threaded message view. Shows the parent message and a close button.
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `parentMessage` | `CometChat.BaseMessage` | The message that started the thread |
+| `onClose` | `() => void` | Called when the user closes the thread view |
+
+**Usage:**
+```tsx
+<CometChatThreadHeader
+  parentMessage={threadParentMessage}
+  onClose={() => setThreadParent(null)}
+/>
+```
+
+**Works with:** CometChatMessageList (with `parentMessageId`), CometChatMessageComposer (with `parentMessageId`)
+
+---
+
+## 2. Lists and selection
+
+Components for browsing and selecting users, groups, and group members.
+
+### CometChatUsers
+
+A scrollable list of users. Used for starting new conversations or browsing the user directory.
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `onItemClick` | `(user: CometChat.User) => void` | Called when a user is selected |
+| `usersRequestBuilder` | `CometChat.UsersRequestBuilder` | Customize which users to fetch |
+
+**Usage:**
+```tsx
+<CometChatUsers onItemClick={(user) => startConversation(user)} />
+```
+
+**Works with:** CometChatMessageHeader, CometChatMessageList, CometChatMessageComposer (after selection)
+
+---
+
+### CometChatGroups
+
+A scrollable list of groups. Used for browsing and joining groups.
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `onItemClick` | `(group: CometChat.Group) => void` | Called when a group is selected |
+| `groupsRequestBuilder` | `CometChat.GroupsRequestBuilder` | Customize which groups to fetch |
+
+**Usage:**
+```tsx
+<CometChatGroups onItemClick={(group) => openGroup(group)} />
+```
+
+**Works with:** CometChatMessageHeader, CometChatMessageList, CometChatMessageComposer (after selection)
+
+---
+
+### CometChatGroupMembers
+
+Displays members of a specific group with their roles (owner, admin, member).
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `group` | `CometChat.Group` | The group whose members to display (required) |
+| `onItemClick` | `(member: CometChat.GroupMember) => void` | Called when a member is selected |
+
+**Usage:**
+```tsx
+<CometChatGroupMembers group={selectedGroup} />
+```
+
+**Works with:** Group details panel, CometChatGroups
+
+---
+
+### CometChatSearchBar
+
+A standalone search input component. Used for filtering within other components.
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `onSearch` | `(text: string) => void` | Called as the user types |
+| `text` | `string` | Controlled input value |
+
+**Usage:**
+```tsx
+<CometChatSearchBar onSearch={(text) => filterUsers(text)} />
+```
+
+**Works with:** Any list component for client-side filtering
+
+---
+
+## 3. Calls
+
+Components for voice and video calling.
+
+### CometChatCallButtons
+
+Renders voice and video call buttons. Typically placed in the `auxiliaryButtonView` prop of CometChatMessageHeader.
+
+**Key props:**
+| Prop | Type | Description |
+|---|---|---|
+| `user` | `CometChat.User` | Call this user |
+| `group` | `CometChat.Group` | Call this group |
+| `hideVideoCallButton` | `boolean` | Hide the video call button |
+| `hideVoiceCallButton` | `boolean` | Hide the voice call button |
+
+**Usage:**
+```tsx
+<CometChatCallButtons user={selectedUser} />
+```
+
+**Works with:** CometChatMessageHeader (in `menu` prop), CometChatIncomingCall (at app root)
+
+---
+
+### CometChatIncomingCall
+
+Renders an incoming call notification overlay. Mount this at the app root so it can show incoming calls from any screen.
+
+**Key props:** None required -- it auto-listens for incoming call events.
+
+**Usage:**
+```tsx
+// At your app root, always mounted:
+<CometChatIncomingCall />
+```
+
+**Works with:** CometChatCallButtons (triggers outgoing calls that the other user sees as incoming)
+
+---
+
+### CometChatOutgoingCall
+
+Renders the outgoing call screen (ringing state). Automatically shown when the user initiates a call.
+
+**Key props:** None required -- auto-triggered by call initiation.
+
+**Usage:**
+```tsx
+<CometChatOutgoingCall />
+```
+
+**Works with:** CometChatCallButtons
+
+---
+
+### CometChatOngoingCall
+
+Renders the active call screen with video feeds, mute/unmute, and hang-up controls.
+
+**Key props:** None required -- auto-triggered when a call connects.
+
+**Usage:**
+```tsx
+<CometChatOngoingCall />
+```
+
+**Works with:** CometChatIncomingCall, CometChatOutgoingCall
+
+---
+
+### CometChatCallLogs
+
+Displays a history of past voice and video calls.
+
+**Key props:** None required for basic usage.
+
+**Usage:**
+```tsx
+<CometChatCallLogs />
+```
+
+**Works with:** Tab-based layouts (as one of the tabs alongside Conversations, Users, Groups)
+
+---
+
+## 4. Interactions
+
+Components for message reactions and emoji.
+
+### CometChatReactions
+
+Displays reaction badges on a message (e.g., thumbs-up x3). Automatically rendered inside message bubbles when reactions are enabled.
+
+**Key props:** Typically used internally by the message list. Not usually instantiated directly.
+
+---
+
+### CometChatReactionList
+
+Shows a detailed list of who reacted with what emoji on a specific message.
+
+**Key props:** Used internally. Shown when the user clicks on a reaction badge.
+
+---
+
+### CometChatEmojiKeyboard
+
+A full emoji picker. Automatically rendered inside the message composer when the emoji button is clicked.
+
+**Key props:** Used internally by CometChatMessageComposer. Not usually instantiated directly.
+
+---
+
+### CometChatReactionInfo
+
+Tooltip or popover showing reaction details on hover.
+
+**Key props:** Used internally by the message list. Not usually instantiated directly.
+
+---
+
+## 5. AI
+
+AI-powered assistant components. These require AI features (Smart Chat Features) to be enabled in your CometChat dashboard at **Chat & Messaging → Features → Smart Chat Features**.
+
+### CometChatAIAssistantChat
+
+An AI chatbot interface that users can interact with for automated responses. Typically rendered inside a panel or modal triggered from the message header.
+
+**Prerequisites:** Enable "Conversation Starter" and/or "Smart Replies" in the dashboard.
+
+**Usage:**
+```tsx
+<CometChatAIAssistantChat />
+```
+
+---
+
+### CometChatAIAssistantChatHistory
+
+Displays past AI assistant interactions. Used alongside `CometChatAIAssistantChat` to show conversation history with the AI.
+
+**Usage:**
+```tsx
+<CometChatAIAssistantChatHistory />
+```
+
+---
+
+### CometChatAIAssistantTools
+
+Renders AI tool options (summarize conversation, translate message, etc.) that can be applied to messages or conversations.
+
+**Prerequisites:** Enable "Conversation Summary" and/or other AI tools in the dashboard.
+
+**Usage:**
+```tsx
+<CometChatAIAssistantTools />
+```
+
+> **Note:** For detailed props, configuration options, and customization of AI components, query the docs MCP — these components' APIs evolve with CometChat's AI feature releases.
+
+### CometChatStreamMessageBubble
+
+Renders a streaming AI message with a typing animation effect. Used internally by AI assistant features.
+
+### CometChatAIAssistantMessageBubble
+
+Renders AI assistant response bubbles with special formatting. Used internally by AI features.
+
+---
+
+## 5b. Moderation and utility components
+
+These are exported but typically rendered internally by the kit. You may need them for advanced customization.
+
+### CometChatFlagMessageDialog
+
+A dialog for reporting/flagging messages. Rendered internally when a user reports a message.
+
+### CometChatMessageInformation
+
+Shows message delivery and read receipt details (who received, who read, timestamps). Useful for building a message info panel.
+
+---
+
+## 5c. Text formatters
+
+These are not React components — they are formatter classes that customize how text is rendered in message bubbles. Pass them via the `textFormatters` prop on `CometChatMessageList`.
+
+| Formatter | Purpose |
+|---|---|
+| `CometChatTextFormatter` | Base class for custom formatters |
+| `CometChatUrlsFormatter` | Auto-links URLs in messages |
+| `CometChatMentionsFormatter` | Renders @mentions with styling + click handlers |
+| `CometChatTextHighlightFormatter` | Highlights search terms in messages |
+| `CometChatRichTextFormatter` | Renders rich text (bold, italic, etc.) |
+| `CometChatMarkdownFormatter` | Renders markdown syntax in messages |
+
+All imported from `@cometchat/chat-uikit-react`. To customize text rendering, create a class extending `CometChatTextFormatter` and pass it in the `textFormatters` array.
+
+---
+
+## 6. Infrastructure
+
+These are not visual components -- they handle initialization, login state, and configuration.
+
+### CometChatUIKit
+
+The main entry point for initialization and authentication. This is a static class, not a React component.
+
+**Key methods:**
+| Method | Description |
+|---|---|
+| `CometChatUIKit.init(settings)` | Initialize the SDK. Returns a Promise. Must be called once before any component renders. |
+| `CometChatUIKit.login(uid)` | Log in with a user ID (dev mode). Returns `Promise<CometChat.User>`. Safe to call after a prior login completes (no-op), but **not concurrently** — two overlapping calls throw *"Please wait until the previous login request ends."* Use `cometchat-core`'s `ensureLoggedIn` helper to dedupe. |
+| `CometChatUIKit.loginWithAuthToken(token)` | Log in with an auth token (production). Returns `Promise<CometChat.User>`. |
+| `CometChatUIKit.getLoggedinUser()` | Get the currently logged-in user. Returns `Promise<CometChat.User \| null>`. |
+| `CometChatUIKit.logout()` | Log out the current user. Returns a Promise. |
+| `CometChatUIKit.createUser(user)` | Create a CometChat user (requires Auth Key). For server-side user management, see `cometchat-production`. |
+| `CometChatUIKit.updateUser(user)` | Update a CometChat user (requires Auth Key). |
+| `CometChatUIKit.isInitialized()` | Returns `boolean` — whether `init()` has been called. |
+
+**Usage** (bare-API illustration — in real code, wrap `login` in an
+in-flight guard so React StrictMode doesn't fire it twice; see
+`cometchat-core` § 2 for the `ensureLoggedIn` helper):
+```typescript
+import { CometChatUIKit } from "@cometchat/chat-uikit-react";
+
+await CometChatUIKit.init(settings);
+await CometChatUIKit.login("cometchat-uid-1");
+```
+
+---
+
+### CometChatUIKitLoginListener
+
+Tracks the logged-in user synchronously. Unlike `CometChatUIKit.getLoggedinUser()` (which is async/Promise-based), this provides **synchronous** access to the current user — useful for guards and conditional rendering.
+
+**Key methods:**
+| Method | Description |
+|---|---|
+| `CometChatUIKitLoginListener.getLoggedInUser()` | Returns the currently logged-in `CometChat.User` synchronously, or `null` |
+
+**When to use which:**
+- `CometChatUIKit.getLoggedinUser()` — async, returns a Promise. Use in `useEffect` or async functions.
+- `CometChatUIKitLoginListener.getLoggedInUser()` — synchronous. Use for immediate checks (e.g., redirect if not logged in, guard a route).
+
+---
+
+### UIKitSettingsBuilder
+
+Builder class for creating the settings object passed to `CometChatUIKit.init()`.
+
+**Key methods:**
+| Method | Description |
+|---|---|
+| `.setAppId(appId: string)` | Set the CometChat app ID (required) |
+| `.setRegion(region: string)` | Set the region: `"us"`, `"eu"`, or `"in"` (required) |
+| `.setAuthKey(authKey: string)` | Set the auth key (required for `login(uid)` in dev mode) |
+| `.subscribePresenceForAllUsers()` | Enable presence (online/offline) for all users |
+| `.subscribePresenceForFriends()` | Enable presence only for friends list |
+| `.subscribePresenceForRoles(roles)` | Enable presence for specific user roles |
+| `.setAutoEstablishSocketConnection(bool)` | Control WebSocket auto-connect (default: true) |
+| `.setAdminHost(host)` | Override admin URL (dedicated deployments only) |
+| `.setClientHost(host)` | Override client URL (dedicated deployments only) |
+| `.build()` | Returns the settings object |
+
+**Usage:**
+```typescript
+import { UIKitSettingsBuilder } from "@cometchat/chat-uikit-react";
+
+const settings = new UIKitSettingsBuilder()
+  .setAppId("your-app-id")
+  .setRegion("us")
+  .setAuthKey("your-auth-key")
+  .subscribePresenceForAllUsers()
+  .build();
+```
+
+---
+
+## Composition patterns
+
+These are the standard ways to combine CometChat components into complete
+experiences. Use these as starting points, then customize with props.
+
+> **Composer note:** Both `CometChatMessageComposer` and
+> `CometChatCompactMessageComposer` exist. The compact variant includes
+> rich text editing by default. The sample app uses the compact variant
+> everywhere. Use whichever fits — the props are identical.
+
+### Multi-conversation (two-pane)
+
+The most common pattern. A conversation list on the left, message view on the right.
+
+**Key details from the v6 sample app:**
+- Store the full `CometChat.Conversation` object (not just user/group) — you need it for `activeConversation` highlighting and conversation-level operations
+- Pass `activeConversation` to `CometChatConversations` so the selected item is visually highlighted
+- Derive user/group from the conversation at render time using `getConversationWith()`
+
+```tsx
+import { useState } from "react";
+import {
+  CometChatConversations,
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+function MultiConversation() {
+  const [activeConversation, setActiveConversation] = useState<CometChat.Conversation>();
+
+  // Derive user/group from the active conversation
+  const entity = activeConversation?.getConversationWith();
+  const selectedUser = entity instanceof CometChat.User ? entity : undefined;
+  const selectedGroup = entity instanceof CometChat.Group ? entity : undefined;
+
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <div style={{ width: "360px", borderRight: "1px solid #eee" }}>
+        <CometChatConversations
+          activeConversation={activeConversation}
+          onItemClick={(conv) => setActiveConversation(conv)}
+        />
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        {selectedUser && (
+          <>
+            <CometChatMessageHeader user={selectedUser} />
+            <CometChatMessageList user={selectedUser} />
+            <CometChatMessageComposer user={selectedUser} />
+          </>
+        )}
+        {selectedGroup && (
+          <>
+            <CometChatMessageHeader group={selectedGroup} />
+            <CometChatMessageList group={selectedGroup} />
+            <CometChatMessageComposer group={selectedGroup} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+### Single thread
+
+One chat window for a known user or group. No conversation list.
+
+```tsx
+import {
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+interface SingleThreadProps {
+  user?: CometChat.User;
+  group?: CometChat.Group;
+}
+
+function SingleThread({ user, group }: SingleThreadProps) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      {user && <CometChatMessageHeader user={user} />}
+      {group && <CometChatMessageHeader group={group} />}
+      {user && <CometChatMessageList user={user} />}
+      {group && <CometChatMessageList group={group} />}
+      {user && <CometChatMessageComposer user={user} />}
+      {group && <CometChatMessageComposer group={group} />}
+    </div>
+  );
+}
+```
+
+To target a specific user, resolve them first:
+
+```tsx
+const [targetUser, setTargetUser] = useState<CometChat.User>();
+
+useEffect(() => {
+  CometChat.getUser("seller-uid-123").then(setTargetUser);
+}, []);
+
+if (!targetUser) return null;
+return <SingleThread user={targetUser} />;
+```
+
+---
+
+### Full messenger (tab-based)
+
+A tab bar with Chats, Calls, Users, and Groups. Users can browse, start conversations, and make calls.
+
+```tsx
+import { useState } from "react";
+import {
+  CometChatConversations,
+  CometChatCallLogs,
+  CometChatUsers,
+  CometChatGroups,
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+type Tab = "chats" | "calls" | "users" | "groups";
+
+function FullMessenger() {
+  const [activeTab, setActiveTab] = useState<Tab>("chats");
+  const [activeConversation, setActiveConversation] = useState<CometChat.Conversation>();
+  const [selectedUser, setSelectedUser] = useState<CometChat.User>();
+  const [selectedGroup, setSelectedGroup] = useState<CometChat.Group>();
+
+  function selectUser(user: CometChat.User) {
+    setSelectedUser(user);
+    setSelectedGroup(undefined);
+  }
+
+  function selectGroup(group: CometChat.Group) {
+    setSelectedUser(undefined);
+    setSelectedGroup(group);
+  }
+
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <div style={{ width: "360px", display: "flex", flexDirection: "column" }}>
+        {/* Tab content */}
+        <div style={{ flex: 1 }}>
+          {activeTab === "chats" && (
+            <CometChatConversations
+              activeConversation={activeConversation}
+              onItemClick={(conv) => {
+                setActiveConversation(conv);
+                const entity = conv.getConversationWith();
+                if (entity instanceof CometChat.User) selectUser(entity);
+                else if (entity instanceof CometChat.Group) selectGroup(entity);
+              }}
+            />
+          )}
+          {activeTab === "calls" && (
+            <CometChatCallLogs
+              onItemClick={(call) => {
+                // Call log items show call details, not a message view.
+                // Use the call's participants to start a new call or
+                // navigate to the conversation.
+              }}
+            />
+          )}
+          {activeTab === "users" && (
+            <CometChatUsers
+              activeUser={selectedUser}
+              onItemClick={selectUser}
+            />
+          )}
+          {activeTab === "groups" && (
+            <CometChatGroups
+              activeGroup={selectedGroup}
+              onItemClick={selectGroup}
+            />
+          )}
+        </div>
+        {/* Tab bar at the bottom */}
+        <div style={{ display: "flex", borderTop: "1px solid #eee" }}>
+          {(["chats", "calls", "users", "groups"] as Tab[]).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              style={{ flex: 1, padding: 12, fontWeight: activeTab === tab ? "bold" : "normal" }}
+            >
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        {selectedUser && (
+          <>
+            <CometChatMessageHeader user={selectedUser} />
+            <CometChatMessageList user={selectedUser} />
+            <CometChatMessageComposer user={selectedUser} />
+          </>
+        )}
+        {selectedGroup && (
+          <>
+            <CometChatMessageHeader group={selectedGroup} />
+            <CometChatMessageList group={selectedGroup} />
+            <CometChatMessageComposer group={selectedGroup} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+### Threading
+
+Threading is NOT automatic. The kit's **default** is `hideReplyInThreadOption={false}` — so a "Reply in Thread" entry shows up in every message's action menu out of the box, **even when the integrator hasn't wired a thread panel**. A user who clicks it sees nothing happen. That's why every `<CometChatMessageList>` in the `cometchat-placement` patterns uses `hideReplyInThreadOption` by default.
+
+**To enable threading** in an experience that has room for a thread panel (typically a two-pane messenger or route-based chat — not a compact drawer or widget):
+
+1. Remove the `hideReplyInThreadOption` prop from the main `CometChatMessageList`.
+2. Wire `onThreadRepliesClick` to capture the thread message (pattern below).
+3. Render the thread panel as a side panel or overlay. The thread panel has its OWN `CometChatMessageList` + `CometChatMessageComposer` scoped via `parentMessageId`.
+
+Full pattern:
+
+```tsx
+import { useState } from "react";
+import {
+  CometChatMessageList,
+  CometChatMessageComposer,
+  CometChatThreadHeader,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+// 1. In your main message view, capture the thread click:
+<CometChatMessageList
+  user={selectedUser}
+  onThreadRepliesClick={(message: CometChat.BaseMessage) => {
+    setThreadMessage(message);
+    setShowThread(true);
+  }}
+/>
+
+// 2. Render the thread panel as a side panel:
+interface ThreadPanelProps {
+  parentMessage: CometChat.BaseMessage;
+  user?: CometChat.User;
+  group?: CometChat.Group;
+  onClose: () => void;
+}
+
+function ThreadPanel({ parentMessage, user, group, onClose }: ThreadPanelProps) {
+  const parentId = parentMessage.getId();
+
+  return (
+    <div style={{ width: "400px", display: "flex", flexDirection: "column", borderLeft: "1px solid #eee" }}>
+      <CometChatThreadHeader parentMessage={parentMessage} onClose={onClose} />
+      {user && <CometChatMessageList user={user} parentMessageId={parentId} />}
+      {group && <CometChatMessageList group={group} parentMessageId={parentId} />}
+      {user && <CometChatMessageComposer user={user} parentMessageId={parentId} />}
+      {group && <CometChatMessageComposer group={group} parentMessageId={parentId} />}
+    </div>
+  );
+}
+```
+
+**Key details:**
+- `onThreadRepliesClick` receives the full `CometChat.BaseMessage` (not just an ID)
+- `CometChatThreadHeader` shows the parent message content + close button
+- The scoped `CometChatMessageList` with `parentMessageId` shows only thread replies
+- The scoped `CometChatMessageComposer` with `parentMessageId` sends replies to the thread
+
+---
+
+### Search integration
+
+Search overlays **alongside** the conversation list — it does NOT replace it. The conversations list stays mounted; search appears as a sibling panel.
+
+**Global search (across all conversations):**
+
+```tsx
+import { useState } from "react";
+import { CometChatConversations, CometChatSearch } from "@cometchat/chat-uikit-react";
+
+function ConversationsWithSearch({ onSelectConversation }) {
+  const [showSearch, setShowSearch] = useState(false);
+
+  return (
+    <div style={{ position: "relative" }}>
+      {/* Conversations always stay mounted */}
+      <CometChatConversations
+        showSearchBar={true}
+        onSearchBarClicked={() => setShowSearch(true)}
+        activeConversation={activeConversation}
+        onItemClick={onSelectConversation}
+      />
+
+      {/* Search overlays on top when active */}
+      {showSearch && (
+        <div style={{ position: "absolute", inset: 0, zIndex: 10, background: "#fff" }}>
+          <CometChatSearch
+            onConversationClicked={(conv) => {
+              setShowSearch(false);
+              onSelectConversation(conv);
+            }}
+            onMessageClicked={(msg) => {
+              setShowSearch(false);
+              // navigate to the message's conversation
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+**In-conversation search (within the active chat):**
+
+```tsx
+// Add search button to the message header:
+<CometChatMessageHeader
+  user={selectedUser}
+  showSearchOption={true}
+  onSearchOptionClicked={() => setShowMessageSearch(true)}
+/>
+
+// Show CometChatSearch scoped to the current user/group:
+{showMessageSearch && (
+  <CometChatSearch
+    uid={selectedUser?.getUid()}
+    guid={selectedGroup?.getGuid()}
+    onMessageClicked={(msg) => {
+      setShowMessageSearch(false);
+      // scroll to the message in the message list
+    }}
+  />
+)}
+```
+
+---
+
+### Details panel
+
+User and group detail panels are **custom-built** — there is no pre-built `CometChatUserDetails` or `CometChatGroupDetails` export in the UI Kit. The v6 sample app has reference implementations at `sample-app/src/components/CometChatDetails/`.
+
+**For user details:** build a custom component using `CometChatAvatar` + user info + action buttons (block/unblock). Fetch the pattern from the sample app's `CometChatUserDetails.tsx`.
+
+**For group details:** build a custom component and use these real UI Kit components inside it:
+
+```tsx
+// Open details from the message header:
+<CometChatMessageHeader
+  user={selectedUser}
+  group={selectedGroup}
+  onItemClick={() => setShowDetails(true)}
+/>
+
+// Group details panel uses real kit components:
+{showDetails && selectedGroup && (
+  <div style={{ width: "320px", borderLeft: "1px solid #eee" }}>
+    {/* CometChatGroupMembers is a real kit component */}
+    <CometChatGroupMembers
+      group={selectedGroup}
+      onItemClick={(member) => {
+        // Switch to 1:1 chat with this member
+      }}
+    />
+    {/* CometChatBannedMembers is a real kit component */}
+  </div>
+)}
+```
+
+**Important:** `CometChatGroupMembers` requires the `group` prop (it's the only required prop). The component handles member listing, search, scope changes, kick, and ban actions internally.
+
+---
+
+### Calls integration
+
+Add voice/video calling to your message view, plus incoming call handling at the app root.
+
+```tsx
+// 1. Add call buttons to the message header:
+<CometChatMessageHeader
+  user={selectedUser}
+  auxiliaryButtonView={<CometChatCallButtons user={selectedUser} />}
+/>
+
+// 2. Mount incoming call handler at the app root (outside any route):
+function App() {
+  return (
+    <>
+      <CometChatIncomingCall />
+      <Routes>
+        {/* your routes */}
+      </Routes>
+    </>
+  );
+}
+```
+
+`CometChatIncomingCall` must be mounted at the top level so it can show the incoming call overlay regardless of which page the user is on. `CometChatOutgoingCall` and `CometChatOngoingCall` are automatically rendered by the call flow.

--- a/solutions/cometchat-chat/.agents/skills/cometchat-core/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-core/SKILL.md
@@ -1,0 +1,642 @@
+---
+name: cometchat-core
+description: "Shared rules for CometChat React UI Kit v6. Always loaded alongside framework + placement skills. Read this first."
+license: "MIT"
+compatibility: "Node.js >=18; React >=18; @cometchat/chat-uikit-react ^6; @cometchat/chat-sdk-javascript ^4"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "chat cometchat react core rules initialization patterns"
+---
+
+## Purpose
+
+This is the foundational skill for every CometChat React UI Kit v6 integration. It teaches Claude HOW CometChat works -- initialization, login, CSS, environment variables, SSR safety, and the provider pattern -- so Claude can write project-appropriate code instead of relying on templates.
+
+**Read this skill first, before any framework or placement skill.**
+
+---
+
+## 1. Initialization
+
+CometChat must be initialized exactly once before any UI component renders. Initialization is asynchronous and must complete fully before mounting any `CometChat*` component.
+
+### The UIKitSettingsBuilder
+
+```typescript
+import { CometChatUIKit, UIKitSettingsBuilder } from "@cometchat/chat-uikit-react";
+
+const settings = new UIKitSettingsBuilder()
+  .setAppId(APP_ID)       // Required. String from the CometChat dashboard.
+  .setRegion(REGION)       // Required. "us", "eu", "in", etc.
+  .setAuthKey(AUTH_KEY)    // Required for dev mode. Omit in production (use auth tokens).
+  .subscribePresenceForAllUsers() // Optional but recommended -- enables online/offline indicators.
+  .build();
+```
+
+### Init must happen once
+
+Use a module-level flag to prevent double-init. This is critical because React StrictMode in development calls effects twice:
+
+```typescript
+let initialized = false;
+
+async function initCometChat(): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+
+  const settings = new UIKitSettingsBuilder()
+    .setAppId(APP_ID)
+    .setRegion(REGION)
+    .setAuthKey(AUTH_KEY)
+    .subscribePresenceForAllUsers()
+    .build();
+
+  await CometChatUIKit.init(settings);
+}
+```
+
+### Init must be in useEffect (React components) or before mount (entry files)
+
+**In a useEffect (Next.js, Astro, React Router SSR):**
+
+```typescript
+useEffect(() => {
+  initCometChat()
+    .then(() => loginUser())
+    .then(() => setReady(true))
+    .catch((e) => setError(String(e)));
+}, []);
+```
+
+**At the entry point (Vite/CRA -- no SSR):**
+
+```typescript
+// main.tsx -- runs once, before React mounts
+CometChatUIKit.init(settings)
+  ?.then(() => CometChatUIKit.login("cometchat-uid-1"))
+  .then(() => mount())
+  .catch((e) => mountError(String(e)));
+```
+
+The init-at-entry pattern works for Vite/CRA because `main.tsx` only runs in the browser. For frameworks with SSR (Next.js, Astro, React Router v7 SSR), you MUST use the useEffect pattern because the module runs on the server first.
+
+---
+
+## 2. Login
+
+### Development mode
+
+Use `CometChatUIKit.login(uid)` with a test UID. Every new CometChat app comes with five pre-created test users: `cometchat-uid-1` through `cometchat-uid-5`.
+
+```typescript
+const user = await CometChatUIKit.getLoggedinUser();
+if (!user) {
+  await CometChatUIKit.login("cometchat-uid-1");
+}
+```
+
+### ⚠️ `login()` is safe to call sequentially, NOT concurrently
+
+A subtle but important distinction:
+
+- **Sequential** (first `login()` completes, then second is called): the SDK's second call returns immediately with the already-logged-in user. Safe.
+- **Concurrent** (a second `login()` fires while the first is still in-flight): the SDK throws `"Please wait until the previous login request ends."` The user sees a red error on the page, has to refresh, and only then does it work (because the first session is now cached).
+
+This is exactly the case that React 18 StrictMode triggers in development: effects run mount → unmount → mount, so a `useEffect` that calls `login()` fires twice with no time for the first call to finish. Production builds don't double-mount, but any code path that can call `login()` from two places simultaneously hits the same error.
+
+**Guard concurrent login with a module-level in-flight promise:**
+
+```typescript
+let loginInFlight: Promise<unknown> | null = null;
+
+async function ensureLoggedIn(
+  uid: string,
+  authToken?: string,
+): Promise<void> {
+  const existing = await CometChatUIKit.getLoggedinUser();
+  if (existing) return;                 // sequential case — already logged in
+  if (loginInFlight) {                   // concurrent case — reuse pending promise
+    await loginInFlight;
+    return;
+  }
+  loginInFlight = authToken
+    ? CometChatUIKit.loginWithAuthToken(authToken)
+    : CometChatUIKit.login(uid);
+  try {
+    await loginInFlight;
+  } finally {
+    loginInFlight = null;
+  }
+}
+```
+
+Call `ensureLoggedIn()` from the provider / effect instead of `CometChatUIKit.login()` directly. Both StrictMode mounts resolve against the same promise, so only one login request actually hits the server.
+
+**Why not just a boolean flag?** A boolean would require extra wait-loop code to handle "login started but not finished yet." A cached promise handles that automatically — `await` on the same promise is free for all callers.
+
+### Getting the current logged-in UID in app code
+
+When your integration code needs the current user's UID (for example, to decide which conversation to target, or to filter by sender), **always fetch it from the SDK — never hardcode a UID like `"cometchat-uid-1"`**.
+
+Two getters, for different contexts:
+
+```typescript
+// Async — preferred for app logic, guaranteed correct after init completes
+const me = await CometChatUIKit.getLoggedinUser();
+const myUid = me?.getUid();
+
+// Sync — use inside render paths where you already know init is done
+import { CometChatUIKitLoginListener } from "@cometchat/chat-uikit-react";
+const me = CometChatUIKitLoginListener.getLoggedInUser();  // note capital `I` in `InUser`
+const myUid = me?.getUid();
+```
+
+Hardcoding `"cometchat-uid-1"` only works in the dev mode login call (`CometChatUIKit.login("cometchat-uid-1")`) because you're *choosing* who to log in as. Once logged in, the getters are the source of truth — useful when the logged-in user comes from production auth (a real user ID, not a test UID), or when the user logs out and logs in as someone else.
+
+### Production mode
+
+Use `CometChatUIKit.loginWithAuthToken(token)` with a token obtained from your backend. The backend generates the token using the CometChat REST API with your `AUTH_TOKEN` (not the client-side `AUTH_KEY`).
+
+```typescript
+// Fetch token from YOUR backend, which calls CometChat's REST API
+const response = await fetch("/api/cometchat-token", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ uid: currentUser.id }),
+});
+const { token } = await response.json();
+
+await CometChatUIKit.loginWithAuthToken(token);
+```
+
+For the full production auth setup, use `npx @cometchat/skills-cli production-auth`. Never hardcode auth keys in source code that ships to production.
+
+### Logout
+
+```typescript
+await CometChatUIKit.logout();
+```
+
+Call this when the user signs out of your application. This clears CometChat's local session.
+
+---
+
+## 3. CSS
+
+### Import once at the app root
+
+```typescript
+import "@cometchat/chat-uikit-react/css-variables.css";
+```
+
+This import MUST appear exactly once, at the highest level of your application:
+
+| Framework | Where to import |
+|---|---|
+| React (Vite) | `src/main.tsx` or `src/index.css` via `@import` |
+| Next.js (App Router) | `app/globals.css` via `@import` or `app/layout.tsx` |
+| Next.js (Pages Router) | `pages/_app.tsx` or `styles/globals.css` |
+| Astro | Global layout file or `src/styles/global.css` |
+| React Router | Root route module or `app/root.tsx` |
+
+### Theming with CSS variables
+
+All CometChat components respect `--cometchat-*` CSS variables. Override them on a parent element or `:root`:
+
+```css
+:root {
+  --cometchat-primary-color: #6851d6;
+  --cometchat-background-color-01: #ffffff;
+  --cometchat-text-color-primary: #141414;
+  --cometchat-font-family: "Inter", sans-serif;
+  --cometchat-border-radius-lg: 12px;
+}
+```
+
+### Never target internal class names
+
+CometChat's internal class names (like `.cometchat-message-bubble__wrapper`) are not part of the public API and may change between versions. Always use CSS variables for customization. The only exception is when explicitly copying patterns from the v6 sample app that use documented BEM class names.
+
+---
+
+## 4. Environment variables
+
+Each framework has its own convention for exposing env vars to client-side code. CometChat needs three variables: `APP_ID`, `REGION`, and `AUTH_KEY`.
+
+### Per-framework naming
+
+| Framework | Prefix | Example |
+|---|---|---|
+| React (Vite) | `VITE_` | `import.meta.env.VITE_COMETCHAT_APP_ID` |
+| Next.js | `NEXT_PUBLIC_` | `process.env.NEXT_PUBLIC_COMETCHAT_APP_ID` |
+| Astro | `PUBLIC_` | `import.meta.env.PUBLIC_COMETCHAT_APP_ID` |
+| React Router (Vite) | `VITE_` | `import.meta.env.VITE_COMETCHAT_APP_ID` |
+| CRA | `REACT_APP_` | `process.env.REACT_APP_COMETCHAT_APP_ID` |
+
+### The three variables
+
+| Variable suffix | Required | Description |
+|---|---|---|
+| `COMETCHAT_APP_ID` | Yes | Your app ID from the CometChat dashboard |
+| `COMETCHAT_REGION` | Yes | Region code: `"us"`, `"eu"`, `"in"`, etc. |
+| `COMETCHAT_AUTH_KEY` | Dev only | Client-side auth key. Replace with auth tokens for production. |
+
+### .env file placement
+
+| Framework | File | Gitignored by default |
+|---|---|---|
+| Vite / React Router | `.env` | No -- add to `.gitignore` |
+| Next.js | `.env.local` | Yes |
+| Astro | `.env` | No -- add to `.gitignore` |
+| CRA | `.env` | No -- add to `.gitignore` |
+
+---
+
+## 5. SSR safety
+
+All CometChat UI Kit components are browser-only. They access `window`, `document`, and browser APIs during import. Rendering them on the server will crash.
+
+### Framework-specific SSR prevention
+
+**Next.js (App Router):**
+
+Mark the file containing CometChat components with `"use client"` at the top. Use `next/dynamic` with `ssr: false` if the component is imported from a server component:
+
+```typescript
+"use client";
+// This entire file only runs in the browser
+
+import { CometChatConversations } from "@cometchat/chat-uikit-react";
+```
+
+Or from a server component:
+
+```typescript
+import dynamic from "next/dynamic";
+
+const ChatView = dynamic(() => import("./ChatView"), { ssr: false });
+```
+
+**Next.js (Pages Router):**
+
+Use `next/dynamic` with `ssr: false`:
+
+```typescript
+import dynamic from "next/dynamic";
+
+const CometChatNoSSR = dynamic(() => import("../components/CometChatNoSSR"), {
+  ssr: false,
+});
+```
+
+**Astro:**
+
+Use the `client:only="react"` directive. This prevents the component from rendering during Astro's static build:
+
+```astro
+---
+import ChatPanel from "../components/ChatPanel";
+---
+<ChatPanel client:only="react" />
+```
+
+**React Router v7 (SSR mode):**
+
+Use `React.lazy()` with `Suspense` in a `clientLoader` or `useEffect` guard:
+
+```typescript
+import { lazy, Suspense } from "react";
+
+const ChatView = lazy(() => import("./ChatView"));
+
+export default function ChatRoute() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+  return (
+    <Suspense fallback={<div>Loading chat...</div>}>
+      <ChatView />
+    </Suspense>
+  );
+}
+```
+
+**React (Vite / CRA):**
+
+No SSR concerns. These are client-only by nature. Import and use directly.
+
+---
+
+## 6. Provider pattern
+
+Instead of inlining init/login logic in every component, create a reusable `CometChatProvider` that handles initialization, login, and ready-state gating. Wrap your chat UI with it.
+
+```typescript
+// CometChatProvider.tsx
+"use client"; // Required for Next.js App Router; harmless in other frameworks
+
+import React, { useEffect, useState, createContext, useContext } from "react";
+import { CometChatUIKit, UIKitSettingsBuilder } from "@cometchat/chat-uikit-react";
+
+interface CometChatContextValue {
+  isReady: boolean;
+  error: string | null;
+}
+
+const CometChatContext = createContext<CometChatContextValue>({
+  isReady: false,
+  error: null,
+});
+
+export const useCometChat = () => useContext(CometChatContext);
+
+// Module-level state: shared across all mounts so React 18 StrictMode's
+// double-invocation of effects doesn't fire init or login twice.
+let initialized = false;
+let loginInFlight: Promise<unknown> | null = null;
+
+async function ensureLoggedIn(
+  uid: string,
+  authToken?: string,
+): Promise<void> {
+  const existing = await CometChatUIKit.getLoggedinUser();
+  if (existing) return;
+  if (loginInFlight) {
+    // A prior StrictMode mount (or another effect) already started login —
+    // reuse its promise instead of calling login() a second time, which
+    // throws "Please wait until the previous login request ends."
+    await loginInFlight;
+    return;
+  }
+  loginInFlight = authToken
+    ? CometChatUIKit.loginWithAuthToken(authToken)
+    : CometChatUIKit.login(uid);
+  try {
+    await loginInFlight;
+  } finally {
+    loginInFlight = null;
+  }
+}
+
+interface CometChatProviderProps {
+  appId: string;
+  region: string;
+  authKey?: string;
+  authToken?: string;
+  uid?: string;
+  children: React.ReactNode;
+}
+
+export function CometChatProvider({
+  appId,
+  region,
+  authKey,
+  authToken,
+  uid = "cometchat-uid-1",
+  children,
+}: CometChatProviderProps) {
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function setup() {
+      try {
+        if (!initialized) {
+          initialized = true;
+          const builder = new UIKitSettingsBuilder()
+            .setAppId(appId)
+            .setRegion(region)
+            .subscribePresenceForAllUsers();
+
+          if (authKey) {
+            builder.setAuthKey(authKey);
+          }
+
+          const settings = builder.build();
+          await CometChatUIKit.init(settings);
+        }
+
+        await ensureLoggedIn(uid, authToken);
+
+        setIsReady(true);
+      } catch (e) {
+        setError(String(e));
+      }
+    }
+
+    setup();
+  }, [appId, region, authKey, authToken, uid]);
+
+  if (error) {
+    return (
+      <div style={{ color: "red", padding: 16, fontFamily: "monospace" }}>
+        CometChat Error: {error}
+      </div>
+    );
+  }
+
+  if (!isReady) {
+    return null; // Or a loading spinner
+  }
+
+  return (
+    <CometChatContext.Provider value={{ isReady, error }}>
+      {children}
+    </CometChatContext.Provider>
+  );
+}
+```
+
+### Usage
+
+```typescript
+// In your app layout or route wrapper:
+<CometChatProvider
+  appId={import.meta.env.VITE_COMETCHAT_APP_ID}
+  region={import.meta.env.VITE_COMETCHAT_REGION}
+  authKey={import.meta.env.VITE_COMETCHAT_AUTH_KEY}
+>
+  <ChatPage />
+</CometChatProvider>
+```
+
+The provider pattern keeps init/login logic in one place. Chat components inside `<CometChatProvider>` are guaranteed to render only after init and login succeed.
+
+---
+
+## 7. RTL, i18n, and accessibility
+
+These three concerns share one property: the UI Kit handles them out of the box, but a careless customization can break them. Read this before writing custom views, composer actions, or header replacements.
+
+### RTL (right-to-left)
+
+The UI Kit reads `dir="rtl"` from the document root. If the project already sets `<html dir="rtl">` (or toggles it dynamically for Arabic/Hebrew locales), **CometChat components flip automatically** — message bubbles mirror, avatars swap sides, icons rotate where appropriate. No CometChat-specific config needed.
+
+**To test:** add `<html dir="rtl">` to `index.html` (or set it via JS in Next.js App Router: `<html dir="rtl">` in `app/layout.tsx`). Reload — the conversation list avatar + text should render on the right, message bubbles mirror, the composer input aligns right.
+
+**When customizing:** if you replace a default view (e.g. a custom message bubble), test it in both LTR and RTL. The UI Kit's components use logical properties (`margin-inline-start`, `padding-inline-end`) — your custom components should too, or they'll break RTL.
+
+### i18n (translations)
+
+The UI Kit has a built-in `CometChatLocalize` utility that covers ~40 languages out of the box. Initialize it once, alongside `CometChatUIKit.init()`:
+
+```typescript
+import { CometChatLocalize } from "@cometchat/chat-uikit-react";
+
+CometChatLocalize.init({
+  language: "es",  // or "fr", "de", "ar", "hi", etc.
+});
+```
+
+For a dynamic language switcher, call `CometChatLocalize.setLocale(newLang)` when the user picks a language. The UI Kit re-renders with the new strings.
+
+**To override a string:** the `resources` option accepts custom translations merged over the defaults. Useful for brand-specific terms:
+
+```typescript
+CometChatLocalize.init({
+  language: "en",
+  resources: {
+    en: {
+      "type a message": "Write your message…",
+      "start a conversation": "Say hi 👋",
+    },
+  },
+});
+```
+
+**Full translation key list** lives in `node_modules/@cometchat/chat-uikit-react/dist/resources/` or the docs MCP. Don't invent keys — unknown keys fall through to the default.
+
+### Accessibility
+
+Default components ship with:
+- `aria-label` on icon-only buttons (send, attach, call, etc.)
+- `role="listbox"` + `role="option"` on conversation / user / group lists
+- Keyboard navigation: `Tab` to focus, `Enter` to activate, `Esc` to close modals
+- Focus management: opening a thread view moves focus to the thread header; closing returns focus to the trigger
+
+**Rules when customizing:**
+
+1. **Replacing an icon-only button?** Add `aria-label="<verb>"` (e.g. `aria-label="Send message"`).
+2. **Replacing a list item?** Keep `role="option"` + `aria-selected` on the wrapping element.
+3. **Replacing the composer?** Preserve the `<textarea>` with an accessible `<label>` (visible or `aria-label`), and keep `Enter`/`Shift+Enter` behavior.
+4. **Replacing a modal?** Trap focus inside the modal while open, restore focus to the trigger on close, and add `role="dialog"` + `aria-modal="true"` + a labelled heading.
+5. **Color contrast:** when theming with custom colors, verify text contrast ≥ 4.5:1 against background. A low-saturation primary color on a white background breaks AA contrast.
+
+For deep customization (e.g. a fully custom message bubble), the a11y responsibility shifts to the custom component — the UI Kit only guarantees it for its own defaults. Test with a screen reader (VoiceOver on macOS, NVDA on Windows) and keyboard-only navigation before shipping.
+
+---
+
+## 8. Anti-patterns
+
+These are specific things NOT to do. Each one causes real bugs that are hard to debug.
+
+1. **Do NOT call `CometChatUIKit.init()` during render.** Init is async and has side effects. Calling it during render causes infinite re-render loops. Always call in `useEffect` or before `createRoot`.
+
+2. **Do NOT import `css-variables.css` in multiple files.** Duplicate imports cause CSS specificity conflicts and doubled variable declarations. Import it exactly once at the app root.
+
+3. **Do NOT render CometChat components before init completes.** Components assume the SDK is initialized. Rendering before init finishes causes "CometChat is not initialized" runtime errors. Use the provider pattern or a ready-state gate.
+
+4. **Do NOT hardcode `AUTH_KEY` in source files.** The auth key is a secret. Use environment variables during development. Use auth tokens in production.
+
+5. **Guard concurrent `login()` calls with a module-level in-flight promise.** `login()` is only safe to call sequentially. Two `login()` calls overlapping (e.g. React 18 StrictMode's double effect) throw *"Please wait until the previous login request ends."* Cache the first login's promise at module scope and `await` that from subsequent callers. See the `ensureLoggedIn` helper in section 2 and section 6's provider pattern.
+
+6. **Do NOT render CometChat components in a server-side context.** All components require browser APIs. In Next.js, always use `"use client"`. In Astro, always use `client:only="react"`.
+
+7. **Do NOT target CometChat's internal CSS class names for styling.** These are not part of the public API. Use `--cometchat-*` CSS variables instead. Internal classes change between minor versions.
+
+8. **Do NOT create CometChat components without a container that has explicit dimensions.** CometChat components fill 100% of their container. If the container has no height, the components collapse to zero height. Always set `height`, `min-height`, or use flexbox/grid to give the container dimensions.
+
+9. **Do NOT re-initialize CometChat when navigating between routes.** Init should happen once at the app level (in the provider or entry file), not per-route. Re-initializing causes flickering and dropped WebSocket connections.
+
+10. **Do NOT invent component names.** CometChat exports specific components with specific names. Check the `cometchat-components` skill before writing any `<CometChat*>` JSX. Using a wrong name (e.g., `<CometChatChat>`, `<CometChatMessenger>`) causes a build error.
+
+11. **Do NOT wrap CometChat components in a `transform`ed container.** Per the CSS spec, any non-`none` `transform` on an element creates a new containing block for `position: fixed` descendants. CometChat UI Kit renders several overlays as `position: fixed` (message options menu, emoji picker, file preview, reactions popover, thread panel) and expects them to anchor to the viewport. Wrapping the chat in a container that uses `transform: translateX(...)` — a common pattern for slide-in drawers / sidebars — reparents those overlays to the drawer, causing them to appear clipped, offset, or drift mid-animation.
+
+    **This includes Tailwind's `translate-x-*` utilities — `translate-x-full`, `-translate-x-full`, `translate-x-0`, `translate-x-[420px]`, etc. all compile to `transform: translateX(...)` and trigger the same bug.** Same for `-translate-y-*`, `translate-*`, `scale-*`, `rotate-*`, `skew-*`, `transform-*`, and any `transition-transform` utility applied to a container wrapping CometChat components. If you see yourself reaching for any Tailwind class in the `transform:` family on a drawer/sidebar/modal that contains chat UI, stop.
+
+    **Animate the `right` / `left` offset instead**, or use `margin-right: isOpen ? 0 : -<width>`. In Tailwind: toggle between `right-0` and a negative `right-[-420px]` with `transition-[right]` instead of `transition-transform`.
+
+    Same rule applies to `filter`, `perspective`, `backdrop-filter`, and `will-change: transform` — any of those also trigger the containing-block takeover. See `cometchat-placement`'s drawer and widget patterns for the correct right-offset animation.
+
+---
+
+## 9. Docs MCP (recommended, not required)
+
+The CometChat docs MCP provides runtime access to the latest documentation, including prop types, callback signatures, request builder methods, SDK events, CSS variable names, and error decoders.
+
+### Installation
+
+```bash
+claude mcp add --transport http cometchat-docs https://www.cometchat.com/docs/mcp
+```
+
+For other clients, see: https://www.cometchat.com/docs/mcp-server
+
+### When to use
+
+- Looking up a prop's exact type or default value
+- Finding callback signatures (e.g., what `onItemClick` passes)
+- Checking request builder methods (e.g., `ConversationsRequestBuilder.setLimit`)
+- Understanding SDK events (e.g., `CometChatMessageEvents.ccMessageSent`)
+- Verifying CSS variable names before writing overrides
+- Decoding error messages (e.g., "INVALID_AUTH_KEY")
+
+### When NOT to use
+
+- For component names and basic props -- use the `cometchat-components` skill instead (it works offline)
+- For init/login/CSS patterns -- they are in this skill
+- For placement patterns -- they are in the `cometchat-placement` skill
+- For anything the CLI handles -- the CLI templates are the source of truth for those paths
+
+### Fallback when not installed
+
+If the docs MCP is not installed and you need information beyond what the component and core skills contain, check the installed TypeScript definitions:
+
+```bash
+grep -A 80 "interface CometChat<ComponentName>Props" \
+  node_modules/@cometchat/chat-uikit-react/dist/index.d.ts \
+  2>/dev/null | head -80
+```
+
+This is faster and more accurate than guessing from training data. Never invent SDK signatures from memory.
+
+---
+
+## 10. Package dependencies
+
+Every CometChat React integration requires these two packages:
+
+```json
+{
+  "@cometchat/chat-uikit-react": "^6",
+  "@cometchat/chat-sdk-javascript": "^4"
+}
+```
+
+The UI Kit (`@cometchat/chat-uikit-react`) provides all the React components. The SDK (`@cometchat/chat-sdk-javascript`) provides the `CometChat` namespace with types (`CometChat.User`, `CometChat.Group`, `CometChat.Conversation`, `CometChat.BaseMessage`) and methods.
+
+Install with your project's package manager:
+
+```bash
+npm install @cometchat/chat-uikit-react @cometchat/chat-sdk-javascript
+```
+
+### SDK types you will use
+
+```typescript
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+// Common types:
+CometChat.User        // A chat user
+CometChat.Group       // A chat group
+CometChat.Conversation // A conversation (wraps User or Group)
+CometChat.BaseMessage  // A message (text, media, custom, etc.)
+CometChat.TextMessage  // A text message specifically
+
+// Common static methods:
+CometChat.getUser(uid: string): Promise<CometChat.User>
+CometChat.getGroup(guid: string): Promise<CometChat.Group>
+```

--- a/solutions/cometchat-chat/.agents/skills/cometchat-customization/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-customization/SKILL.md
@@ -1,0 +1,555 @@
+---
+name: cometchat-customization
+description: Customize a CometChat React UI Kit integration beyond what `cometchat init` and `cometchat apply-feature` produce — custom message bubbles, custom header views, custom subtitle views, custom empty/loading states, custom action menus, request builder filters, event listeners, and component composition. Picks up where the framework skills end (after Phase A init succeeds).
+license: "MIT"
+compatibility: "Node.js >=18; @cometchat/chat-uikit-react ^6"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory, grepSearch"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "cometchat react customization custom-view message-bubble header-view subtitle-view request-builder events"
+---
+
+> **Companion skills:** `cometchat-components` provides the component
+> catalog (what exists); this skill provides the customization workflow
+> (how to modify what exists). Use `cometchat-components` to look up
+> component names and props, then use this skill to plan and execute
+> the customization. For any pattern not covered below, the docs MCP
+> at `cometchat-docs` is the source of truth — query it before
+> generating any code.
+
+## Use this skill when
+
+The user has already run `/cometchat` (Phase A complete — there's a
+working integration with `.cometchat/state.json`) and wants to **change
+how a component looks or behaves** beyond what the CLI's deterministic
+commands handle.
+
+Trigger phrases:
+- "customize the message list"
+- "filter the conversations to only show X"
+- "change the message bubble color/shape/layout"
+- "add a custom header above the chat"
+- "subscribe to message-received events"
+- "show a custom loading state"
+- "add a custom action to the message options menu"
+- "I want to inject my own UI into CometChatX"
+- `/cometchat customize`
+
+## Do not use this skill when
+
+- The user wants to enable a **packaged feature** (calls, polls, AI smart
+  replies, etc.) → use `cometchat-features` instead
+- The user wants to change **theme tokens** (primary color, font,
+  border radius) → use `cometchat-theming` instead — `cometchat
+  apply-theme` is deterministic and doesn't need this skill
+- The user wants to **start a new integration** → use the `cometchat`
+  dispatcher skill to run Phase A first
+- The user wants to **fix something broken** → use
+  `cometchat-troubleshooting` and run `cometchat doctor`
+
+## Docs MCP contract
+
+This skill is **fundamentally docs-driven** — every customization
+question requires a fact (prop name, callback signature, builder method,
+event topic, CSS selector) that lives in the canonical CometChat docs,
+not in this skill's text. Embedding examples here would create drift
+the moment the SDK changes.
+
+The CometChat docs MCP at `cometchat-docs` is a **hard requirement**
+for this skill. It's the source of truth for:
+
+- Component prop tables (every component, every prop, every default)
+- Custom view slots: `headerView`, `subtitleView`, `tailView`,
+  `optionsView`, `bubbleView`, `emptyStateView`, `loadingStateView`,
+  `errorStateView` (which components support which slots)
+- Message template overrides (`CometChatMessageTemplate.type`,
+  `category`, `contentView`, `headerView`, `footerView`)
+- Request builders for filtering data: `ConversationsRequestBuilder`,
+  `MessagesRequestBuilder`, `UsersRequestBuilder`, `GroupsRequestBuilder`,
+  `CallLogsRequestBuilder` and their methods
+- SDK events: `CometChatMessageEvents`, `CometChatUserEvents`,
+  `CometChatGroupEvents`, `CometChatCallEvents`, `CometChatUIEvents`
+  and the topic names
+- CSS selectors for component-level styling overrides
+  (`.cometchat-message-bubble-incoming`, `.cometchat-conversations-header`,
+  etc.)
+
+**Hard rules:**
+
+1. **Always query the docs MCP first** before generating any
+   customization code. Never invent prop names, builder methods, event
+   topics, or CSS classes from training-data memory.
+2. **If the docs MCP is not installed**, STOP. Tell the user:
+   "Customization needs the CometChat docs MCP because every prop +
+   builder + event signature is canonical. Install it with
+   `claude mcp add --transport http cometchat-docs https://www.cometchat.com/docs/mcp`
+   and re-run."
+3. **Prefer composition (custom view props) over CSS overrides** when
+   both are options — composition is more stable across SDK versions.
+4. **Canonical reference URLs:**
+   - Components overview: https://www.cometchat.com/docs/ui-kit/react/components-overview
+   - Theming + styling: https://www.cometchat.com/docs/ui-kit/react/theme
+   - Events: https://www.cometchat.com/docs/ui-kit/react/events
+   - Methods: https://www.cometchat.com/docs/ui-kit/react/methods
+
+## Steps
+
+### Step 1 — Verify Phase A is done
+
+```bash
+npx @cometchat/skills-cli info --json
+```
+
+If `integrated` is `false`, **stop** and tell the user to run
+`/cometchat` first to create the base integration. Customization
+modifies an existing integration; it doesn't create one.
+
+Note the `framework`, `experience`, `files_owned`, and `applied_features`
+from the response — you'll need them in the next steps.
+
+### Step 2 — Four-tier discovery: existing-component prop, new component, stylesheet, sample app
+
+> **START HERE:** Read the **component catalog** at
+> `references/component-catalog.md` (in this skill's directory). It has
+> the canonical list of all 88 exported symbols, all 14 sample-app
+> patterns, and a 40-row task→component lookup table. If the user's
+> request maps to an entry in the catalog, use that entry directly —
+> skip the rest of this step.
+
+**If the catalog doesn't have a match (or you need prop-level detail),
+walk these FOUR discovery checks in this exact order:**
+
+1. **Existing-component prop check (2a):** does a component the
+   integration ALREADY mounts have a prop that does what the user is
+   asking for? **The kit follows a "props over components" philosophy
+   — most additions are props on existing components, not new
+   components.** This check goes FIRST.
+2. **New-component check (2b):** if 2a turned up nothing, is there a
+   built-in `CometChat<X>` component in `@cometchat/chat-uikit-react`'s
+   exports?
+3. **Stylesheet check (2c):** is there a `--cometchat-<x>` CSS
+   variable for any styling you'd write?
+4. **Sample app check (2d):** is there a reference implementation in
+   the sample app at
+   `github.com/cometchat/cometchat-uikit-react/tree/v6/sample-app/src/components`
+   for the user's pattern?
+
+The CometChat React UI Kit ships FOUR things, not one:
+- A "props over components" API where most features (search bar,
+  filters, custom views, click handlers, disable flags) are PROPS on
+  existing components — NOT new components
+- 60+ named React components in the npm package
+- A 200+ CSS variable system at
+  `@cometchat/chat-uikit-react/css-variables.css`
+- A reference sample app on GitHub with implementations for common
+  chat UX patterns (user/group details, threaded messages layout,
+  top-level home layout, multi-tab chat, notifications, new chat
+  dialog, etc.) that combine multiple kit components but aren't
+  shipped as single named exports
+
+**Critical:** the docs MCP does NOT index the sample app. When the MCP
+says *"no `CometChat<X>` component exists"*, that only covers the npm
+package — you must still check the sample app via GitHub before
+concluding the user needs hand-rolled code.
+
+Hand-rolling something the kit, the variable system, OR the sample
+app already provides means missing the kit's theming, accessibility,
+i18n, error handling, and every future SDK update.
+
+#### 2a. Existing-component prop check (do this FIRST)
+
+**Most chat features are already props on the components you have.**
+A user asking for "add search", "filter conversations", "custom empty
+state", or "click handler on a message" is almost always asking for a
+prop, not a new component or custom code.
+
+**Process:**
+
+1. **List the CometChat components currently mounted in the
+   integration.** Read the integration's owned files (from
+   `state.json`) and grep for `<CometChat` JSX usage:
+   ```bash
+   grep -hoE '<CometChat[A-Z][a-zA-Z]*' \
+     $(jq -r '.files_owned[]' .cometchat/state.json 2>/dev/null) \
+     2>/dev/null | sort -u
+   ```
+2. **Query the docs MCP for the props of each mounted component:**
+   - `"CometChatConversations props"`
+   - `"CometChatMessageList props"`
+   - `"CometChatMessageHeader props"`
+   - `"CometChatMessageComposer props"`
+3. **Look for a prop that maps to the user's intent.** Common
+   mappings:
+
+| User asks for | Likely prop on which component |
+|---|---|
+| Search bar / "add search" | `showSearchBar` on `CometChatConversations` (or `onSearchBarClicked` to swap in `<CometChatSearch>` for advanced dual-scope search) |
+| Filter conversations | `conversationsRequestBuilder` on `CometChatConversations` |
+| Filter messages | `messagesRequestBuilder` on `CometChatMessageList` |
+| Filter users / groups | `usersRequestBuilder` / `groupsRequestBuilder` |
+| Custom empty state | `emptyStateView` on most list components |
+| Custom error UI | `errorStateView` |
+| Custom loading UI | `loadingStateView` |
+| Custom header above the list | `headerView` |
+| Custom message bubble | `templates` prop on `CometChatMessageList` (not a custom bubble component) |
+| Click handler on item / message / search bar / back button | `onItemClick`, `onMessageClick`, `onBack`, `onSearchBarClicked` |
+| Hide / disable a sub-feature | `disable*` boolean props (e.g. `disableTyping`, `disableReactions`) |
+| Custom subtitle / status / timestamp | `subtitleView`, `statusView`, `timestampView` |
+| Show / hide receipts | `hideReceipts` |
+| Selection mode | `selectionMode` on list components |
+
+If you find a matching prop, **just add the prop and stop**. No new
+components. No custom CSS. No new files. Surface to the user: *"The
+`<X>` you already have supports this via the `<propName>` prop. Adding
+that single prop."*
+
+If 2a turns up nothing, proceed to 2b.
+
+#### 2b. New-component check (do this only if 2a turned up nothing)
+
+**Common requests that look like "customization" but are actually
+"use the existing component":**
+
+| User asks for | Use this built-in component |
+|---|---|
+| Threaded replies / "wire up threads" | `CometChatThreadHeader` + scope a `CometChatMessageList` and `CometChatMessageComposer` with `parentMessageId` |
+| Group members panel / "list group members" | `CometChatGroupMembers` |
+| Add members to a group | `CometChatAddMembers` |
+| Transfer group ownership | `CometChatTransferOwnership` |
+| Banned users management | `CometChatBannedMembers` |
+| Block/unblock users panel | `CometChatBlockedUsers` |
+| New chat / "start a new conversation" dialog | `CometChatNewChat` |
+| Create new group dialog | `CometChatCreateGroup` |
+| User / group details panel | `CometChatDetails` |
+| Mentions popover in composer | `CometChatMentionsFormatter` (already wired into the composer) |
+| Voice / video call buttons in header | `CometChatCallButtons` |
+| Outgoing call screen | `CometChatOutgoingCall` |
+| Incoming call notification | `CometChatIncomingCall` |
+| Ongoing call UI | `CometChatOngoingCall` |
+| Call logs list | `CometChatCallLogs` |
+| Reactions on messages | Already built into `CometChatMessageList` — check if it's just disabled |
+| Message bubble customization | Use the `templates` prop on `CometChatMessageList`, not a custom bubble component |
+
+**Search strategies, in this order:**
+
+1. **Query the docs MCP** with the user's intent in plain English.
+   Examples:
+   - `"thread reply UI react ui kit"` → finds `CometChatThreadHeader`
+   - `"new chat dialog"` → finds `CometChatNewChat`
+   - `"group transfer ownership"` → finds `CometChatTransferOwnership`
+   - `"block user list"` → finds `CometChatBlockedUsers`
+2. **Grep the user's installed package** for matching exports:
+   ```bash
+   grep -E "^export.*CometChat[A-Z][a-zA-Z]+" \
+     node_modules/@cometchat/chat-uikit-react/dist/index.d.ts \
+     2>/dev/null | head -50
+   ```
+3. **Browse the v6 components reference** at
+   https://www.cometchat.com/docs/ui-kit/react/components-overview
+
+If you find a built-in component that matches, **use it as-is**.
+Surface to the user: *"The kit already ships `CometChat<X>` for this.
+I'll wire it up directly."*
+
+#### 2c. Stylesheet check (do this even when you DO need custom layout glue)
+
+Even when you have to write some CSS for layout glue (positioning a
+panel, sizing a container, wiring up the height chain that
+`.cometchat-message-list` requires), **never hand-pick colors, fonts,
+borders, spacings, or radii from your head**. The kit ships a
+canonical CSS variable system. Use it.
+
+**The rule:**
+- ✅ **OK:** custom CSS for layout glue (positioning, sizing, flex
+  containers, the height chain). Example: `.thread-wrapper { width:
+  400px; height: 100vh; display: flex; flex-direction: column; }`
+- ✅ **OK:** custom CSS that consumes kit variables. Example:
+  `.thread-wrapper { border-left: 1px solid var(--cometchat-border-color-light); background: var(--cometchat-background-color-01); }`
+- ❌ **NOT OK:** custom CSS for any header / button / icon / panel /
+  badge / divider that the kit already provides as a component.
+  Example: a hand-rolled `.thread-header` + `.thread-close` button when
+  `CometChatThreadHeader` exists.
+- ❌ **NOT OK:** hardcoded colors / fonts / borders / radii / spacings
+  that don't reference the `--cometchat-*` variables. Example:
+  `border: 1px solid #E8E8E8` instead of
+  `border: 1px solid var(--cometchat-border-color-light)`.
+
+**Discovery commands for the variable system:**
+```bash
+# List every --cometchat-* variable the kit defines
+grep -oE '\-\-cometchat-[a-z0-9-]+' \
+  node_modules/@cometchat/chat-uikit-react/css-variables.css \
+  2>/dev/null | sort -u | head -60
+
+# Or search for a specific token category
+grep -E '\-\-cometchat-(border|background|text|primary|font)' \
+  node_modules/@cometchat/chat-uikit-react/css-variables.css \
+  2>/dev/null | head -40
+```
+
+**Common variable categories** (query the docs MCP for the canonical
+list — these change between SDK versions):
+
+| Category | Example variables |
+|---|---|
+| Brand colors | `--cometchat-primary-color`, `--cometchat-error-color`, `--cometchat-success-color` |
+| Backgrounds | `--cometchat-background-color-01` (white), `--cometchat-background-color-02`, `--cometchat-background-color-03` (light grey) |
+| Text | `--cometchat-text-color-primary`, `--cometchat-text-color-secondary`, `--cometchat-text-color-tertiary` |
+| Borders | `--cometchat-border-color-light`, `--cometchat-border-color-default`, `--cometchat-border-color-dark` |
+| Radii | `--cometchat-radius-1`, `--cometchat-radius-2`, `--cometchat-radius-3`, `--cometchat-radius-max` |
+| Fonts | `--cometchat-font-heading1-bold`, `--cometchat-font-heading4-medium`, `--cometchat-font-body-regular`, `--cometchat-font-caption2-regular` |
+| Spacing | `--cometchat-spacing-1` through `--cometchat-spacing-10` |
+| Shadows | `--cometchat-shadow-1`, `--cometchat-shadow-2`, `--cometchat-shadow-3` |
+
+#### 2d. Sample app reference check (do this when 2a + 2b turned up nothing)
+
+If 2b didn't find a `CometChat<X>` component for the user's request,
+**don't immediately conclude they need custom code**. The kit ships a
+**reference sample app** at:
+
+> https://github.com/cometchat/cometchat-uikit-react/tree/v6/sample-app/src/components
+
+with implementations for common chat UX patterns that combine multiple
+kit components but aren't shipped as single named exports. Examples
+that look like "missing components" but are in the sample app:
+
+| User asks for | Sample app reference path |
+|---|---|
+| User / group details panel | `sample-app/src/components/CometChatDetails/CometChatUserDetails.tsx` (group details is inline in `CometChatHome.tsx`'s `SideComponentGroup`) |
+| Threaded messages panel layout | `sample-app/src/components/CometChatDetails/CometChatThreadedMessages.tsx` |
+| Top-level chat layout (left pane + main + side rail) | `sample-app/src/components/CometChatHome/CometChatHome.tsx` |
+| Multi-tab chat (Chats / Calls / Users / Groups) | `sample-app/src/components/CometChatSelector/CometChatTabs.tsx` |
+| New conversation dialog with user/group picker | Inline in `CometChatHome.tsx` as `CometChatNewChatView` (CSS: `sample-app/src/styles/CometChatNewChat/CometChatNewChatView.css`) |
+| Search view (conversations + messages) | `sample-app/src/components/CometChatSearchView/` |
+| Call log details / history / recordings | `sample-app/src/components/CometChatCallLog/` (5 sub-files: Details, History, Info, Participants, Recordings) |
+| App state / active-chat React context | `sample-app/src/context/AppContext.jsx` + `appReducer.ts` |
+| Group ownership transfer modal | `sample-app/src/components/CometChatTransferOwnership/` |
+
+These patterns include matching CSS at
+`sample-app/src/styles/<ComponentName>/` using BEM-style class names
+that are already wired to the kit's CSS variable system.
+
+**Discovery commands:**
+
+```bash
+# List the sample app's components directory via the GitHub API
+curl -s "https://api.github.com/repos/cometchat/cometchat-uikit-react/contents/sample-app/src/components?ref=v6" \
+  | grep -oE '"name":\s*"[^"]+"' | head -30
+
+# Fetch a specific component file directly
+curl -s "https://raw.githubusercontent.com/cometchat/cometchat-uikit-react/v6/sample-app/src/components/CometChatDetails/CometChatUserDetails.tsx"
+
+# Fetch its matching stylesheet
+curl -s "https://raw.githubusercontent.com/cometchat/cometchat-uikit-react/v6/sample-app/src/styles/CometChatDetails/CometChatUserDetails.css"
+```
+
+You can also use WebFetch on the URLs above. The docs MCP does NOT
+index the sample app — you must fetch it from GitHub directly.
+
+**If you find a matching reference implementation:**
+
+1. Read BOTH the `.tsx` file AND its matching `.css` file (at
+   `sample-app/src/styles/<ComponentName>/`)
+2. Mirror the sample app's file/folder structure in the user's project,
+   e.g. `src/cometchat/CometChatDetails/CometChatUserDetails.tsx` plus
+   `src/cometchat/CometChatDetails/CometChatDetails.css`
+3. Match the **exact BEM class names** from the sample
+   (`.cometchat-user-details__header`,
+   `.cometchat-user-details__content-avatar`, etc.) — they're already
+   integrated with the kit's CSS variable system
+4. Strip the sample app's local dependencies that the user's project
+   doesn't have:
+   - `useContext(AppContext)` → inline the values
+   - `getLocalizedString(...)` → inline the English strings
+   - `cometchat-resources/` SVG icons → use Unicode equivalents or
+     strip them
+5. Tell the user: *"The kit doesn't export this as a single component,
+   but the official sample app has the reference implementation at
+   `cometchat/cometchat-uikit-react/v6/sample-app/.../CometChat<X>`.
+   I'm adapting it to your project."*
+
+#### 2e. After discovery — decide what to do
+
+In strict order, take the FIRST option that applies:
+
+1. **An existing component prop matches (2a):** add the prop. Done.
+   No new files. Most chat features land here.
+2. **A new component matches (2b) AND has its own styling:** use the
+   component as-is. Zero custom CSS.
+3. **A new component matches (2b) but you need layout glue:** use the
+   component; write minimal layout-only CSS that consumes
+   `--cometchat-*` variables (per 2c).
+4. **Sample app has a reference implementation (2d):** adapt the
+   sample app pattern, mirroring its file structure and BEM class
+   names.
+5. **None of the above:** then (and only then) proceed to Step 3 to
+   classify the request as a true customization.
+
+### Step 3 — Classify the customization
+
+Read the user's request and place it into one of these buckets. The
+right approach is different per bucket:
+
+| Bucket | Examples | Approach |
+|---|---|---|
+| **A. Custom view slot** | "add a custom header above the conversation list", "show a custom empty state", "render messages with my own bubble" | Use the corresponding `*View` prop (`headerView`, `emptyStateView`, `bubbleView`, etc.) — query the MCP for which prop the target component supports |
+| **B. Filter / pagination** | "only show conversations with VIP users", "load 10 messages at a time", "show only joined groups" | Use the corresponding RequestBuilder (`ConversationsRequestBuilder.setTags`, `setLimit`, `setUserAndGroupTags`, etc.) — query the MCP for the builder methods |
+| **C. Action / callback** | "do X when a user clicks a conversation", "intercept message send", "log every search" | Use the corresponding `on*` callback prop (`onItemClick`, `onSendButtonClick`, `onSearch`, etc.) — query the MCP for the callback signature |
+| **D. Event subscription** | "show a toast when a new message arrives", "update my unread count when someone reads a message", "track typing indicators" | Subscribe to the corresponding `CometChat*Events` topic (`CometChatMessageEvents.ccMessageSent`, `ccMessageRead`, `CometChatUserEvents.ccUserOnline`, etc.) — query the MCP for the event topic |
+| **E. Component-level CSS** | "make incoming bubbles green", "hide the conversation timestamps", "compact the message list spacing" | Add a CSS rule under `.cometchat <selector>` in the integration's global stylesheet — query the MCP for the right selector class. NEVER invent class names; the SDK's selectors are namespaced and prefix-protected. |
+| **F. Component composition** | "wrap CometChatConversations with my own search bar", "render two CometChatGroups side by side", "embed CometChatMessageList inside my own card layout" | Standard React composition. The CometChat components are React components — use them like any other component. Query the MCP for which props are required vs optional. |
+
+If the user's request doesn't fit any bucket, **ask them to clarify** —
+don't guess. Customization is the place where ambiguous requests
+produce wrong code most often.
+
+### Step 4 — Query the docs MCP for the canonical pattern (only if Step 2 turned up nothing)
+
+Once you've classified the request, query the docs MCP with a specific
+search:
+
+| Bucket | MCP query example |
+|---|---|
+| A. Custom view slot | "headerView prop CometChatConversations" |
+| B. Filter / pagination | "ConversationsRequestBuilder methods setTags" |
+| C. Action / callback | "CometChatMessageList onMessageClick callback signature" |
+| D. Event subscription | "CometChatMessageEvents ccMessageSent subscribe" |
+| E. Component-level CSS | "CSS selector cometchat-message-bubble-incoming" |
+| F. Component composition | "CometChatConversations props required" |
+
+The MCP returns canonical, current docs. Read them BEFORE writing any
+code. If multiple results come back, prefer the React UI Kit v6 result
+over older versions.
+
+### Step 5 — Identify the file to modify
+
+Use the framework + experience you noted in Step 1 to find the right
+file. The integration's primary client file is conventional per
+framework:
+
+| Framework | Primary client file |
+|---|---|
+| reactjs (Vite) | `src/App.tsx` (renders the conversation list / messages) + `src/cometchat/CometChatSelector.tsx` (the selector) |
+| nextjs (App Router) | `src/app/cometchat/CometChatNoSSR.tsx` (renders the chat) + `src/app/cometchat/CometChatSelector.tsx` (the selector) |
+| nextjs (Pages Router) | `src/cometchat/CometChatNoSSR.tsx` + `src/cometchat/CometChatSelector.tsx` |
+| react-router (v6 + v7) | `app/cometchat/CometChatNoSSR.tsx` + `app/cometchat/CometChatSelector.tsx` |
+| astro | `src/cometchat/ChatApp.tsx` (the React island) + `src/cometchat/CometChatSelector.tsx` |
+
+For CSS overrides (bucket E), the global stylesheet is:
+- reactjs → `src/index.css`
+- nextjs (App Router) → `src/app/globals.css`
+- nextjs (Pages Router) → `src/styles/globals.css`
+- react-router → `app/app.css`
+- astro → inside `src/cometchat/ChatApp.tsx` (NOT a global stylesheet)
+
+These are also in `state.json` under `files_owned` if you need to verify.
+
+### Step 6 — Write the customization
+
+Generate the code based on the docs MCP response from Step 4. Show the
+user:
+
+1. **What you're going to change** (which file, which lines, the new
+   code)
+2. **Why** (which prop/builder/event the docs say to use)
+3. **A preview of the diff** (just the changed region, not the whole
+   file)
+
+**Wait for the user to confirm** before writing. Customization edits
+the integration's owned files — drift detection will show this on the
+next `cometchat info`. The user should know.
+
+If the user confirms, write the change. If they don't, surface what
+they'd want to change and stop.
+
+### Step 7 — Verify
+
+```bash
+npx @cometchat/skills-cli verify --json
+```
+
+The 5 AST checks still apply to customized files. If anything fails,
+surface verbatim and offer to revert.
+
+```bash
+npx @cometchat/skills-cli info --json
+```
+
+The customized file will now show as drifted (its checksum no longer
+matches the original template). This is expected — it's the
+**explicit** drift the user just asked for. Not a bug.
+
+### Step 8 — Tell the user what to do next
+
+The dev server picks up React changes via HMR. Tell the user:
+1. Save the file (if their editor doesn't auto-save)
+2. Refresh the browser tab
+3. Test the customization
+
+Then offer to do another customization OR to return to the framework
+skill's Phase B menu.
+
+## Hard rules
+
+- **Always do the FOUR-tier discovery before adding any new component
+  or hand-rolled UI.** The kit follows a "props over components"
+  philosophy and ships FOUR things, not one:
+  (0) **props** on already-mounted components for most features
+      (search bar, filters, custom views, click handlers, disable
+      flags) — check this FIRST,
+  (1) 60+ named React components in `@cometchat/chat-uikit-react`,
+  (2) a 200+ CSS variable system in `css-variables.css`,
+  (3) a reference sample app at
+      `github.com/cometchat/cometchat-uikit-react/tree/v6/sample-app/src/components`
+      with implementations for common chat UX patterns that combine
+      multiple kit components but aren't shipped as single named
+      exports (user/group details panels, thread layouts, top-level
+      home layout, notifications, new chat dialog, etc.).
+  The docs MCP does NOT index the sample app — fetch it from GitHub
+  directly. Adding a new component when an existing one's prop would
+  do, or hand-rolling something the kit, the variable system, or the
+  sample app already provides, means missing the kit's theming, i18n,
+  accessibility, and every future SDK update. Step 2 (subsections 2a
+  + 2b + 2c + 2d) is mandatory — do NOT skip it. **2a
+  (existing-component prop check) goes FIRST** because most features
+  are props on already-mounted components, not new components.
+- **Custom CSS is allowed ONLY for layout glue** (positioning,
+  sizing, flex/grid containers, the height chain). Even there, never
+  hardcode colors / fonts / borders / radii / spacings — always
+  reference `--cometchat-*` variables. Hand-rolled headers, buttons,
+  icons, panels, badges, dividers, etc. are NEVER OK if the kit
+  already provides them.
+- **Always query the docs MCP first** for any prop, builder, event, or
+  CSS selector. Never invent SDK API from memory.
+- **Verify Phase A is done** before customizing. This skill modifies
+  existing integration files; it does not create new ones.
+- **Show the user the change before writing**. Customization is
+  user-side intent — they need visibility.
+- **Drift detection is expected after customization**, not a bug.
+  The user's customizations live in `state.files_owned` and will
+  show up in `cometchat info` as modified. That's correct.
+- **Prefer composition over CSS overrides** when both are options —
+  composition is stable across SDK versions; CSS selectors are not.
+- **Never invent CSS class names** — query the MCP. The SDK's class
+  prefix is `.cometchat-` but the leaf names (`-message-bubble-incoming`,
+  `-conversations-header`, etc.) MUST come from the docs.
+- **If the docs MCP is not installed**, refuse to continue and tell
+  the user how to install it.
+- **Always use `npx @cometchat/skills-cli`** for any CLI commands.
+
+## What this skill does NOT do
+
+- It does not write **template** files (that's `cometchat init`)
+- It does not **enable packaged features** (that's `cometchat-features`
+  + `cometchat apply-feature`)
+- It does not **change theme tokens** (that's `cometchat-theming` +
+  `cometchat apply-theme`)
+- It does not **fix broken integrations** (that's
+  `cometchat-troubleshooting` + `cometchat doctor`)
+- It does not **add new components from scratch** — it customizes
+  components that the integration already uses
+
+For anything in the "does not" list, route the user to the right
+skill/command instead of attempting it here.
+

--- a/solutions/cometchat-chat/.agents/skills/cometchat-customization/references/component-catalog.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-customization/references/component-catalog.md
@@ -1,0 +1,236 @@
+# CometChat React UI Kit v6 — Component Catalog
+
+> **Validated against:** `@cometchat/chat-uikit-react@6.x` (April 2026)
+> **Drift test:** `packages/cli/test/component-catalog.test.ts` fails
+> if any component in this catalog no longer exists in the installed
+> package, or if the installed package exports components not listed here.
+
+**Read this file BEFORE writing any code.** If the user's request maps
+to an entry in this catalog, use it. Don't hand-roll, don't query the
+docs MCP, just use the component listed here.
+
+---
+
+## A. Exported components from `@cometchat/chat-uikit-react`
+
+### Core — the building blocks of a chat integration
+
+| Component | What it renders | Key props / notes |
+|---|---|---|
+| `CometChatConversations` | Conversation list (left panel) | `showSearchBar`, `onSearchBarClicked`, `onItemClick`, `conversationsRequestBuilder`, `headerView`, `emptyStateView`, `activeConversation` |
+| `CometChatMessageList` | Message thread (the main chat area) | `user` / `group`, `parentMessageId` (for threads), `messagesRequestBuilder`, `onThreadRepliesClick`, `templates` (custom bubbles), `emptyStateView`, `goToMessageId` (scroll to a message), `textFormatters` (e.g. `CometChatTextHighlightFormatter` for search highlighting), `startFromUnreadMessages`, `showMarkAsUnreadOption` |
+| `CometChatMessageComposer` | Message input + send button | `user` / `group`, `parentMessageId` (for threads), `text`, `onSendButtonClick`, `headerView`, `secondaryButtonView` |
+| `CometChatCompactMessageComposer` | Rich-text-enabled message composer | Same props as `CometChatMessageComposer` but includes rich text editing |
+| `CometChatMessageHeader` | Header bar above message list | `user` / `group`, `onItemClick` (opens details panel), `onBack`, `auxiliaryButtonView` (custom buttons e.g. CometChatCallButtons), `showSearchOption`, `onSearchOptionClicked` |
+| `CometChatUsers` | Users list | `usersRequestBuilder`, `onItemClick`, `selectionMode`, `showSearchBar` |
+| `CometChatGroups` | Groups list | `groupsRequestBuilder`, `onItemClick`, `selectionMode`, `showSearchBar` |
+| `CometChatGroupMembers` | Members list for a group | `group`, `onItemClick`, `selectionMode` |
+| `CometChatSearch` | Advanced dual-scope search (conversations + messages with filter chips) | `onConversationClicked`, `onMessageClicked`, `onBack`, `searchIn`, `searchFilters` |
+| `CometChatSearchBar` | Standalone search input (the bar itself, no results) | `onSearch`, `text`, `placeholderText` |
+| `CometChatThreadHeader` | Thread header with parent message preview + reply count | `parentMessage`, `onClose` |
+
+### Calls
+
+| Component | What it renders |
+|---|---|
+| `CometChatCallButtons` | Voice + video call buttons (placed inside message header or standalone) |
+| `CometChatIncomingCall` | Incoming call notification banner with accept/reject |
+| `CometChatOutgoingCall` | Outgoing call screen with ringing indicator |
+| `CometChatOngoingCall` | Active call view (video/audio, controls) |
+| `CometChatCallLogs` | List of past calls with duration, type, timestamp |
+
+### Reactions / Interactions
+
+| Component | What it renders |
+|---|---|
+| `CometChatReactions` | Emoji reaction strip below a message bubble |
+| `CometChatReactionList` | Full reaction list with who-reacted |
+| `CometChatReactionInfo` | Tooltip/popover showing reaction details |
+| `CometChatEmojiKeyboard` | Emoji picker grid |
+
+### Message bubbles (used inside `CometChatMessageList` via `templates`)
+
+| Bubble component | Content type |
+|---|---|
+| `CometChatTextBubble` | Text message |
+| `CometChatImageBubble` | Image attachment |
+| `CometChatVideoBubble` | Video attachment |
+| `CometChatAudioBubble` | Audio attachment |
+| `CometChatFileBubble` | Generic file attachment |
+| `CometChatDocumentBubble` | Collaborative document |
+| `CometChatCallBubble` | Call event message (missed, answered, etc.) |
+| `CometChatActionBubble` | Action message (user joined, left, etc.) |
+| `CometChatDeleteBubble` | Deleted message placeholder |
+| `CometChatStreamMessageBubble` | Streaming / AI-generated message in progress |
+| `CometChatAIAssistantMessageBubble` | AI assistant response bubble |
+
+### AI features
+
+| Component | What it renders |
+|---|---|
+| `CometChatAIAssistantChat` | AI assistant chat panel |
+| `CometChatAIAssistantChatHistory` | Previous AI assistant conversations |
+| `CometChatAIAssistantTools` | AI tool selection / function calling UI |
+
+### Primitives / building blocks
+
+| Component | What it renders |
+|---|---|
+| `CometChatAvatar` | User / group avatar (image + fallback initials) |
+| `CometChatListItem` | Single row in any list (avatar + title + subtitle + tail) |
+| `CometChatList` | Base scrollable list with loading/empty/error states |
+| `CometChatDate` | Formatted date/time label |
+| `CometChatButton` | Styled button |
+| `CometChatCheckbox` | Checkbox input |
+| `CometChatRadioButton` | Radio input |
+| `CometChatDropDown` | Dropdown selector |
+
+### Overlays / dialogs
+
+| Component | What it renders |
+|---|---|
+| `CometChatActionSheet` | Bottom sheet with action list |
+| `CometChatActions` | Inline action buttons |
+| `CometChatActionsIcon` | Icon-triggered action menu |
+| `CometChatActionsView` | View-slot for custom actions |
+| `CometChatContextMenu` | Right-click / long-press context menu |
+| `CometChatPopover` | Popover container |
+| `CometChatConfirmDialog` | Confirmation dialog (OK / Cancel) |
+| `CometChatFlagMessageDialog` | Report/flag message dialog |
+| `CometChatToast` | Toast notification |
+| `CometChatErrorView` | Error state view |
+| `CometChatFullScreenViewer` | Full-screen media viewer (images, videos) |
+
+### Group management
+
+| Component | What it renders |
+|---|---|
+| `CometChatChangeScope` | Change a member's role (admin, moderator, member) |
+| `CometChatUserMemberWrapper` | Wrapper for user+member context |
+
+### Composer add-ons
+
+| Component | What it renders |
+|---|---|
+| `CometChatEditPreview` | Edit-message preview above composer |
+| `CometChatMessagePreview` | Reply-to-message preview above composer |
+| `CometChatMediaRecorder` | Voice message recorder |
+| `CometChatMessageInformation` | Message info (delivery, read receipts per-recipient) |
+
+### Infrastructure (not rendered directly, but configured)
+
+| Export | Purpose |
+|---|---|
+| `CometChatUIKit` | Initialization singleton: `CometChatUIKit.init()`, `.login()`, `.logout()` |
+| `CometChatUIKitLoginListener` | Login state listener: `.getLoggedInUser()` |
+| `CometChatUIKitCalls` | Calls plugin initialization |
+| `CometChatLocalize` | i18n: `CometChatLocalize.setLanguage("fr")` |
+| `CometChatFrameProvider` / `CometChatFrameContext` | React context for theme/locale propagation |
+
+### Event emitters (subscribe to real-time updates)
+
+| Export | Events for |
+|---|---|
+| `CometChatMessageEvents` | `ccMessageSent`, `ccMessageEdited`, `ccMessageDeleted`, `ccMessageRead` |
+| `CometChatConversationEvents` | `ccConversationDeleted` |
+| `CometChatGroupEvents` | `ccGroupMemberAdded`, `ccGroupMemberBanned`, `ccGroupLeft`, `ccOwnershipChanged` |
+| `CometChatUserEvents` | `ccUserBlocked`, `ccUserUnblocked` |
+| `CometChatCallEvents` | `ccCallAccepted`, `ccCallRejected`, `ccCallEnded`, `ccOutgoingCall` |
+| `CometChatUIEvents` | UI-level events: `ccToggleBottomSheet`, `ccShowPanel`, etc. |
+
+### Formatters (text processing for the composer + message list)
+
+| Export | Purpose |
+|---|---|
+| `CometChatTextFormatter` | Base formatter class |
+| `CometChatMarkdownFormatter` | Markdown → rich text |
+| `CometChatMentionsFormatter` | @mention detection + popover |
+| `CometChatRichTextFormatter` | Rich text rendering |
+| `CometChatTextHighlightFormatter` | Keyword highlighting in search |
+| `CometChatUrlsFormatter` | URL → clickable link |
+
+### Config / template classes (not components, but used to configure them)
+
+| Export | Purpose |
+|---|---|
+| `CometChatMessageTemplate` | Defines how a message type is rendered in the list |
+| `CometChatMessageComposerAction` | Defines an action button in the composer |
+| `CometChatMessageOption` | Defines a message-level option (reply, edit, delete, etc.) |
+| `CometChatOption` | Generic option config |
+| `CometChatSearchFilter` / `CometChatSearchScope` | Search filter + scope config for `CometChatSearch` |
+| `CometChatUIKitConstants` / `CometChatUtilityConstants` | Constant enums (message types, categories, etc.) |
+
+---
+
+## B. Reference implementations in the v6 sample app
+
+> **URL:** https://github.com/cometchat/cometchat-uikit-react/tree/v6/sample-app/src/components
+> **CSS:** `sample-app/src/styles/<ComponentName>/`
+> **CRITICAL:** the docs MCP does NOT index the sample app. Fetch from GitHub.
+
+| Sample app component | What it implements | Files |
+|---|---|---|
+| `CometChatDetails/CometChatUserDetails.tsx` | User details panel (avatar, name, status, action items) | + `styles/CometChatDetails/CometChatUserDetails.css` |
+| `CometChatDetails/CometChatThreadedMessages.tsx` | Threaded messages layout (header + nested message list + composer) | + `styles/CometChatDetails/CometChatThreadedMessages.css` |
+| `CometChatHome/CometChatHome.tsx` | Top-level three-column layout assembling conversations + messages + side panels (details, threads) | + `styles/CometChatHome/CometChatHome.css` |
+| `CometChatSelector/` | Left-panel selector (Chats / Calls / Users / Groups tabs) | + `styles/CometChatSelector/` |
+| `CometChatMessages/` | Right-panel messages wrapper (header + list + composer) | + `styles/CometChatMessages/` |
+| `CometChatSearchView/` | Full search view with filter chips | + `styles/CometChatSearchView/` |
+| `CometChatCreateGroup/` | Create new group dialog (name, type, description, members) | + `styles/CometChatCreateGroup/` |
+| `CometChatAddMembers/` | Add members to an existing group | + `styles/CometChatAddMembers/` |
+| `CometChatBannedMembers/` | View/unban banned members of a group | + `styles/CometChatBannedMembers/` |
+| `CometChatTransferOwnership/` | Transfer group ownership to another member | + `styles/CometChatTransferOwnership/` |
+| `CometChatJoinGroup/` | Join a group with password prompt | + `styles/CometChatJoinGroup/` |
+| `CometChatLogin/` | Login screen (UID input + submit) | + `styles/CometChatLogin/` |
+| `CometChatCallLog/` | Call logs wrapper | + `styles/CometChatCallLog/` |
+| `CometChatAlertPopup/` | Generic alert/confirmation modal | + `styles/CometChatAlertPopup/` |
+
+---
+
+## C. Task → component lookup
+
+| User asks for | Use this (tier) | Notes |
+|---|---|---|
+| "conversation list" / "chat list" | `CometChatConversations` (A) | Already mounted in experience 1 template |
+| "search conversations" / "add search bar" / "conversation search" | `showSearchBar={true}` + `onSearchBarClicked` on `CometChatConversations` (prop), swap in `<CometChatSearch>` when clicked | Always wire both props + the `CometChatSearch` swap for full dual-scope search. `showSearchBar` alone is only a basic name filter — not real search. |
+| "message list" / "chat thread" | `CometChatMessageList` (A) | Already mounted in experience 1 template |
+| "message input" / "composer" | `CometChatMessageComposer` (A) | Already mounted in experience 1 template |
+| "rich text editing" | `CometChatCompactMessageComposer` (A) | Or use `apply-feature rich-text-formatting` CLI command |
+| "header bar" / "conversation header" | `CometChatMessageHeader` (A) | Already mounted in experience 1 template |
+| "user details panel" | `CometChatDetails/CometChatUserDetails.tsx` (B) | Wire via `onItemClick` on `CometChatMessageHeader` |
+| "group details panel" | Group details inline in `CometChatHome.tsx` SideComponentGroup (B) | Wire via `onItemClick` on `CometChatMessageHeader` |
+| "threaded replies" / "reply in thread" | `CometChatThreadHeader` (A) + `CometChatMessageList` with `parentMessageId` + `CometChatMessageComposer` with `parentMessageId` | Wire via `onThreadRepliesClick` on `CometChatMessageList` |
+| "thread layout" (full panel) | `CometChatDetails/CometChatThreadedMessages.tsx` (B) | The sample app's threaded messages wrapper |
+| "group members list" | `CometChatGroupMembers` (A) | Already exported |
+| "add members to group" | `CometChatAddMembers/` (B) | Sample app pattern |
+| "banned members" | `CometChatBannedMembers/` (B) | Sample app pattern; also uses `CometChatBannedMembers` (A) internally |
+| "transfer group ownership" | `CometChatTransferOwnership/` (B) | Sample app pattern; also uses `CometChatTransferOwnership` (A) internally |
+| "create group" | `CometChatCreateGroup/` (B) | Sample app pattern |
+| "join group" | `CometChatJoinGroup/` (B) | Sample app pattern |
+| "users list" / "browse users" | `CometChatUsers` (A) | With `usersRequestBuilder` for filtering |
+| "groups list" / "browse groups" | `CometChatGroups` (A) | With `groupsRequestBuilder` for filtering |
+| "voice / video call buttons" | `CometChatCallButtons` (A) | Place inside `CometChatMessageHeader`'s `auxiliaryButtonView` prop, or standalone |
+| "incoming call notification" | `CometChatIncomingCall` (A) | Render at app root, always-mounted |
+| "outgoing call screen" | `CometChatOutgoingCall` (A) | Triggered by `CometChatCallButtons` |
+| "ongoing call / active call" | `CometChatOngoingCall` (A) | Full-screen call view |
+| "call history" / "call logs" | `CometChatCallLogs` (A) + `CometChatCallLog/` (B) | |
+| "emoji picker" | `CometChatEmojiKeyboard` (A) | Usually auto-rendered by `CometChatMessageComposer` |
+| "reactions on messages" | `CometChatReactions` (A) | Already auto-rendered in `CometChatMessageList` — check `disableReactions` if missing |
+| "message info" / "delivery receipts" | `CometChatMessageInformation` (A) | Triggered from message options menu |
+| "filter conversations" | `conversationsRequestBuilder` prop on `CometChatConversations` (prop) | |
+| "filter messages" | `messagesRequestBuilder` prop on `CometChatMessageList` (prop) | |
+| "custom empty state" | `emptyStateView` prop on any list component (prop) | |
+| "custom error state" | `errorStateView` prop on any list component (prop) | |
+| "custom header above the list" | `headerView` prop on list components (prop) | |
+| "custom message bubble" | `templates` prop on `CometChatMessageList` (prop) | NOT a custom bubble component — use `CometChatMessageTemplate` |
+| "click handler on item / message" | `onItemClick` / `onMessageClick` / `onBack` / `onSearchBarClicked` (prop) | |
+| "hide / disable a feature" | `disable*` boolean props on the relevant component (prop) | e.g. `disableReactions`, `disableTyping`, `disableMentions` |
+| "mentions in composer" | `CometChatMentionsFormatter` (A) | Already wired into `CometChatMessageComposer` by default |
+| "AI smart replies" / "AI assistant" | `CometChatAIAssistantChat` (A) | Requires dashboard toggle + extension |
+| "top-level layout" / "home screen" | `CometChatHome/CometChatHome.tsx` (B) | The canonical three-column layout |
+| "login screen" | `CometChatLogin/` (B) | Sample app pattern |
+| "avatar" | `CometChatAvatar` (A) | Used inside many components; also usable standalone |
+| "flag / report message" | `CometChatFlagMessageDialog` (A) | |
+| "confirm dialog" / "are you sure" | `CometChatConfirmDialog` (A) | |
+| "full-screen image / video viewer" | `CometChatFullScreenViewer` (A) | |
+| "voice message recorder" | `CometChatMediaRecorder` (A) | |

--- a/solutions/cometchat-chat/.agents/skills/cometchat-features/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-features/SKILL.md
@@ -1,0 +1,514 @@
+---
+name: cometchat-features
+description: Add features (calls, reactions, polls, file sharing, presence, etc.) to an already-integrated CometChat project. Routes to the right sub-flow based on feature type — default features (already enabled), dashboard-toggle features (extensions + AI), package-install features (calls), or component-swap features (rich text).
+license: "MIT"
+compatibility: "Node.js >=18; @cometchat/chat-uikit-react ^6; integration must already be applied"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "cometchat features extensions calls reactions polls ai-features"
+---
+
+> **Companion skills:** `cometchat-core` covers initialization and the
+> provider pattern; `cometchat-customization` is the next step when a
+> feature is enabled but needs visual customization;
+> `cometchat-troubleshooting` handles post-feature-enable failures.
+
+## Purpose
+
+This skill teaches Claude how CometChat features are structured and
+what work is actually required to enable each one. Most features require
+**zero code** — they are either already built into the UI Kit, enabled
+via a dashboard toggle, or activated by a single npm install.
+Understanding which type a feature is prevents unnecessary work.
+
+---
+
+## 1. Use this skill when
+
+The user wants to add a specific feature to an already-integrated CometChat
+project. Trigger phrases:
+
+- `/cometchat features`
+- `/cometchat features <name>` (e.g. `/cometchat features reactions`)
+- `/cometchat <feature>` (e.g. `/cometchat polls`, `/cometchat calls`)
+- "add reactions to my chat"
+- "add video calling"
+- "enable polls"
+- "add file sharing"
+- "enable smart replies"
+- "add typing indicators"
+
+## 2. Preconditions
+
+The user must have an existing integration:
+
+```bash
+npx @cometchat/skills-cli info --json
+```
+
+If `integrated` is `false`, **stop** and tell the user to run `/cometchat`
+first to create the integration.
+
+## 3. Why features fall into each type
+
+CometChat features split into 4 types based on their architecture:
+
+- **Type 1 — Default (compiled-in):** These are shipped inside the UI
+  Kit component bundle unconditionally. CometChat builds reactions,
+  typing indicators, mentions, etc. into `CometChatMessageList` and
+  `CometChatMessageComposer` at compile time. The feature is always
+  present; the only question is whether the prop that surfaces it is
+  enabled. No code or dashboard changes needed.
+
+- **Type 2 — Dashboard-toggle (backend extensions):** These are
+  backend services hosted by CometChat's infrastructure. The UI Kit
+  polls which extensions are enabled via the app's init response. When
+  you flip the dashboard toggle, the backend returns a different
+  feature flag, and the UI Kit renders the corresponding UI
+  automatically. No client code change is needed — the rendering logic
+  is already in the UI Kit, just gated on the flag.
+
+- **Type 3 — Package-install (separate SDK):** Voice/video calling
+  requires a separate WebRTC SDK (`@cometchat/calls-sdk-javascript`)
+  because it links against browser media APIs that would bloat every
+  integration if bundled unconditionally. Once installed, the UI Kit
+  detects it via dynamic import and enables the call UI.
+
+- **Type 4 — Component-swap (variant component):** Some features
+  require a different component variant because the base component has
+  a hard-coded behavior that can't be toggled via props. The CLI does
+  a safe word-boundary replace of the component name in your owned
+  files. If CometChat adds new variant components in future SDK
+  releases, they will follow this same pattern.
+
+---
+
+## 4. The feature catalog
+
+### Type 1 — Default features (~14, already enabled in UI Kit)
+
+These are already part of the components your integration uses. The skill's
+job is to **tell the user they're already there** and point at the relevant
+component:
+
+- Instant Messaging
+- Media Sharing (file/image/audio/video)
+- Read Receipts
+- Mark as Unread
+- Typing Indicator
+- User Presence (online/offline)
+- Reactions
+- Mentions (incl. @all)
+- Threaded Conversations
+- Quoted Replies
+- Group Chat
+- Report Message
+- Conversation/Advanced Search
+
+For these: query the docs MCP for the feature's component/usage docs, show
+the user where it is in their integration. **No code changes needed.**
+
+### Type 2 — Dashboard-toggle features (~40+, no code needed)
+
+These require flipping a toggle in the [CometChat Dashboard](https://app.cometchat.com).
+Once enabled, the UI Kit auto-integrates them. **No code changes needed.**
+
+> **Note:** The dashboard features page also shows the Type 1 features
+> (Instant Messaging, Reactions, Mentions, etc.) as always-on toggles
+> at the top. Those are already enabled — no action needed. The
+> features below are the ones that actually require toggling on.
+
+> **Note:** Conversation and Advanced Search has its own toggle on the
+> Features page. It is on by default but can be disabled. If a user
+> reports that search is missing, check this toggle.
+
+**Extensions — User Experience:**
+Avatar, Bitly, Link Preview, Message Shortcuts, Pin Message, Rich
+Media Preview, Save Message, Thumbnail Generation, TinyURL, Voice
+Transcription
+
+**Extensions — User Engagement:**
+Broadcast, Giphy, Gfycat, Message Translation, Polls, Reminders,
+Stickers, Stipop, Tenor
+
+**Extensions — Collaboration:**
+Collaborative Document, Collaborative Whiteboard
+
+**Extensions — Security:**
+Disappearing Messages, E2E Encryption (Enterprise plan only)
+
+**Extensions — Moderation** (on the separate Extensions page, not Features):
+Data Masking, Image Moderation, Profanity Filter, Sentiment Analysis,
+XSS Filter, Human Moderation, Report User, Slow Mode,
+Virus/Malware Scanner
+
+**Extensions — Notifications** (on the separate Extensions page):
+Email Notification, Push Notification, SMS Notification
+
+**Extensions — Customer Support:**
+Chatwoot, Intercom
+
+**Smart Chat Features (AI):**
+Conversation Starter, Smart Replies, Conversation Summary
+(AI features are fetched dynamically from the API — the exact list
+depends on your plan and backend configuration.)
+
+**Exact dashboard path (give this to the user verbatim):**
+
+> **For most features (User Experience, User Engagement, Collaboration, Security, AI):**
+> 1. Open https://app.cometchat.com
+> 2. Select your app
+> 3. In the left sidebar: **Chat & Messaging** → **Features**
+> 4. Find the feature and flip its **Status** toggle to ON
+> 5. Some extensions have a settings icon — click it if the feature
+>    needs configuration (e.g. API keys for Giphy)
+> 6. Changes take effect immediately — refresh the chat in the browser
+>
+> **For Moderation and Notification extensions:**
+> These are NOT on the Features page. Navigate to:
+> **Left sidebar → Extensions** (the separate Extensions page)
+> Find the extension and enable it there.
+
+After enabling, run `cometchat verify` to ensure the existing
+integration still passes. No code changes are needed — the UI Kit
+picks up enabled features automatically.
+
+### Type 3 — Package-install features (4, calls)
+
+These require installing `@cometchat/calls-sdk-javascript`. Once installed,
+the UI Kit auto-detects it and surfaces the call UI in CometChatMessageHeader,
+CometChatConversations, etc.
+
+- Call Buttons (in message headers)
+- Incoming Call notifications
+- Outgoing Call interface
+- Call Logs (call history)
+
+For these, the user opting in IS consent — run the install directly:
+
+```bash
+npm install @cometchat/calls-sdk-javascript
+npx @cometchat/skills-cli verify --json
+```
+
+The UI Kit's `initiateAfterLogin()` auto-calls `enableCalling()` after the
+package is installed. No manual wiring needed for default call buttons in
+CometChatMessageHeader. Restart the dev server.
+
+### Type 4 — Component-swap features (drop-in variant)
+
+Some features require swapping one component for a variant that has
+different default behavior. The CLI handles the swap automatically —
+it walks `state.files_owned`, performs a word-boundary regex replace,
+updates `state.json` checksums, and records the applied feature so
+re-runs are no-ops. Idempotent.
+
+Currently available:
+
+- `rich-text-formatting` — swaps `CometChatMessageComposer` →
+  `CometChatCompactMessageComposer` (the compact variant enables rich
+  text formatting by default; the regular composer has
+  `enableRichTextEditor=false` baked in)
+
+```bash
+npx @cometchat/skills-cli apply-feature rich-text-formatting
+```
+
+Do NOT hand-edit the swap. The CLI is the source of truth. If future
+SDK releases add new variant components, they will follow this same
+`apply-feature <id>` pattern.
+
+---
+
+## 4b. Deep patterns for three most-requested features
+
+For calls, AI smart replies, and presence, the catalog above only says "install a package" or "toggle in dashboard." Here are the concrete compositional patterns so common requests don't require a docs MCP round-trip.
+
+### Calls (audio + video)
+
+After `npm install @cometchat/calls-sdk-javascript`, call buttons auto-appear in `CometChatMessageHeader` and the call UI renders in place. **No manual wiring needed** for basic 1:1 audio/video calls.
+
+For custom integration — e.g. putting a "Start video call" button outside the message header, or handling an incoming call notification in a custom way — use `CometChatCallButtons` + `CometChatIncomingCall` + `CometChatOngoingCall`:
+
+```tsx
+import { useState, useEffect } from "react";
+import {
+  CometChatCallButtons,
+  CometChatIncomingCall,
+  CometChatOngoingCall,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+export function CustomCallUI({ targetUser }: { targetUser: CometChat.User }) {
+  const [ongoingCall, setOngoingCall] = useState<CometChat.Call>();
+
+  useEffect(() => {
+    // Listen for call state changes
+    const listenerId = "custom-call-listener";
+    CometChat.addCallListener(
+      listenerId,
+      new CometChat.CallListener({
+        onOutgoingCallAccepted: (call: CometChat.Call) => setOngoingCall(call),
+        onIncomingCallCancelled: () => setOngoingCall(undefined),
+        onCallEnded: () => setOngoingCall(undefined),
+      }),
+    );
+    return () => CometChat.removeCallListener(listenerId);
+  }, []);
+
+  return (
+    <>
+      <CometChatCallButtons user={targetUser} />
+      <CometChatIncomingCall />
+      {ongoingCall && <CometChatOngoingCall call={ongoingCall} />}
+    </>
+  );
+}
+```
+
+**Common gotchas:**
+- Calls require a logged-in CometChat user on *both* sides. Test from two browsers (or incognito) logged in as different UIDs.
+- `CometChatIncomingCall` must be mounted globally (e.g. in your provider or layout) so incoming calls ring on every page.
+- Group calls use `CometChat.Group` instead of `CometChat.User` on `CometChatCallButtons`.
+
+### AI smart replies
+
+Smart replies is a dashboard-toggle feature (Type 2). After enabling it in the dashboard (Extensions → Smart Replies → Toggle on), **no code changes are required** — the `CometChatMessageComposer` automatically renders suggested replies as chips above the input when there's a recent incoming message.
+
+For a custom UI — e.g. showing smart replies inline instead of above the composer, or only for certain conversation types — you read the extension data from the incoming message and render your own chips:
+
+```tsx
+function SmartReplyChips({ message }: { message: CometChat.BaseMessage }) {
+  const metadata = message.getMetadata() as Record<string, unknown> | undefined;
+  const extensions = (metadata?.["@injected"] as Record<string, unknown>)?.["extensions"] as
+    | Record<string, unknown>
+    | undefined;
+  const smartReply = extensions?.["smart-reply"] as { reply_positive?: string; reply_neutral?: string; reply_negative?: string } | undefined;
+
+  if (!smartReply) return null;
+
+  const replies = [smartReply.reply_positive, smartReply.reply_neutral, smartReply.reply_negative].filter(Boolean) as string[];
+  return (
+    <div style={{ display: "flex", gap: 8, padding: 8 }}>
+      {replies.map((r) => (
+        <button key={r} onClick={() => sendTextMessage(r)}>{r}</button>
+      ))}
+    </div>
+  );
+}
+```
+
+Smart replies are server-generated and attached to messages via the `@injected.extensions.smart-reply` metadata path — the AI feature runs on CometChat's backend, not in your code.
+
+### Presence (online / offline status)
+
+Presence is a **default feature** (Type 1) — online status indicators appear automatically on user avatars in `CometChatConversations`, `CometChatUsers`, and `CometChatGroupMembers`. Nothing to install, nothing to enable.
+
+For custom UI that needs to know a specific user's online state — e.g. a "Sold by Aria Chen · online now" label on a product page — subscribe to user events:
+
+```tsx
+import { useEffect, useState } from "react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+export function useUserPresence(uid: string): "online" | "offline" | "unknown" {
+  const [status, setStatus] = useState<"online" | "offline" | "unknown">("unknown");
+
+  useEffect(() => {
+    // 1. Fetch initial state
+    CometChat.getUser(uid).then((u) => {
+      setStatus(u.getStatus() === "online" ? "online" : "offline");
+    });
+
+    // 2. Subscribe to live changes
+    const listenerId = `presence-${uid}`;
+    CometChat.addUserListener(
+      listenerId,
+      new CometChat.UserListener({
+        onUserOnline: (user: CometChat.User) => {
+          if (user.getUid() === uid) setStatus("online");
+        },
+        onUserOffline: (user: CometChat.User) => {
+          if (user.getUid() === uid) setStatus("offline");
+        },
+      }),
+    );
+    return () => CometChat.removeUserListener(listenerId);
+  }, [uid]);
+
+  return status;
+}
+```
+
+**Common gotchas:**
+- Presence events only fire for users the current user has interacted with (conversation exists, in same group, etc.). For arbitrary UIDs with no prior interaction, you may need to call `CometChat.getUser(uid)` periodically instead.
+- `getStatus()` returns `"online"` or `"offline"` — also check `getLastActiveAt()` for a "last seen X ago" timestamp.
+- "Last seen" is disabled by default on free-tier apps. Enable it in the dashboard (Settings → Chat → Last Seen).
+
+---
+
+## 5. Docs MCP contract
+
+The CometChat docs MCP at `cometchat-docs` is a **hard requirement** for
+this skill. It's the canonical source for:
+
+- Per-feature SDK reference (props, callbacks, builders, events)
+- Per-feature configuration details beyond the dashboard path above
+- Feature compatibility notes (which features need backend setup,
+  which auto-wire, which require explicit `setExtensions([...])`)
+
+**Hard rules:**
+
+1. **Always query the docs MCP first** before answering any feature
+   question that's not in our local catalog (`cometchat features info`).
+2. **If the docs MCP is not installed**, STOP. Tell the user:
+   "I need the CometChat docs MCP to walk you through this feature.
+   Install it with `claude mcp add --transport http cometchat-docs
+   https://www.cometchat.com/docs/mcp` and re-run."
+3. **Use the dashboard path from this skill** (Chat & Messaging →
+   Features) for all toggle features. Query the docs MCP for
+   per-feature configuration details beyond the basic toggle.
+4. **Canonical reference URLs** (use as starting points if the agent
+   doesn't have an MCP query handy):
+   - Extensions: https://www.cometchat.com/docs/ui-kit/react/extensions
+   - AI features: https://www.cometchat.com/docs/ui-kit/react/ai-features
+   - Calls: https://www.cometchat.com/docs/ui-kit/react/call-features
+   - Core features: https://www.cometchat.com/docs/ui-kit/react/core-features
+
+---
+
+## 6. Steps
+
+### Step 1 — Read state
+
+```bash
+npx @cometchat/skills-cli info --json
+```
+
+If not integrated, stop. Otherwise note the framework + experience so you
+can find the right files.
+
+### Step 2 — Determine feature
+
+If the user named a feature, use it. Otherwise list the categories above
+and ask which feature they want.
+
+### Step 3 — Classify the feature
+
+Match the feature name against the 4 types in section 4. If you don't know
+the type, query the docs MCP first.
+
+### Step 4 — Execute the right sub-flow
+
+- **Default:** show the user it's already there. Point at the component.
+  Use `npx @cometchat/skills-cli features info <id>` to surface
+  the walkthrough verbatim.
+  - **CRITICAL — if the user explicitly wants a UI element to surface
+    the default feature** (e.g. "implement conversation search",
+    "add a search bar", "show typing indicators in the header",
+    "expose mentions in the composer"), **do NOT add a new component
+    yet**. Most default features are exposed via PROPS on the
+    components your integration already mounts:
+    - "search bar" → `showSearchBar` on `CometChatConversations`
+      (and `onSearchBarClicked` to swap in `<CometChatSearch>` for
+      advanced dual-scope search if the user wants that)
+    - "filter conversations / messages" → `conversationsRequestBuilder`
+      / `messagesRequestBuilder`
+    - "custom empty / error / loading state" → `emptyStateView`,
+      `errorStateView`, `loadingStateView`
+    - "custom message bubble" → `templates` prop on
+      `CometChatMessageList` (NOT a custom bubble component)
+    - "hide / disable a sub-feature" → `disable*` boolean props
+    - "click handler" → `onItemClick`, `onMessageClick`,
+      `onSearchBarClicked`, `onBack`
+    - "custom subtitle / status / timestamp" → `subtitleView`,
+      `statusView`, `timestampView`
+    Process before any code change:
+    1. Read the files in `.cometchat/state.json` `files_owned` and
+       grep for the `<CometChat[A-Z]` JSX components actually in use:
+       ```bash
+       grep -hoE '<CometChat[A-Z][a-zA-Z]*' \
+         $(jq -r '.files_owned[]' .cometchat/state.json 2>/dev/null) \
+         2>/dev/null | sort -u
+       ```
+    2. Query the docs MCP for `"<ComponentName> props"` for each one.
+    3. If a prop matches the user's intent, **add the prop and stop**.
+       No new components, no custom CSS, no new files.
+    4. Only if no prop matches, route to the `cometchat-customization`
+       skill for the full four-tier discovery.
+- **Dashboard-toggle:** prefer the CLI — it flips the toggle via the
+  same API the dashboard UI uses, so the user doesn't leave the
+  terminal:
+  ```bash
+  npx @cometchat/skills-cli features enable <id> --json
+  # to turn it off:
+  npx @cometchat/skills-cli features disable <id> --json
+  ```
+  The CLI reads the app id from `.cometchat/config.json` and the
+  bearer token from the OS keychain (requires a prior
+  `cometchat auth login`). Response shape:
+  - `"status": "enabled"` / `"disabled"` → done. Tell the user to
+    hard-refresh (Cmd+Shift+R) the browser tab running their dev
+    server.
+  - `"status": "no-op"` → already in the desired state.
+  - `"status": "not-logged-in"` → run `cometchat auth login` first.
+  - `"status": "no-app"` → run `/cometchat` or
+    `cometchat provision setup` first so `.cometchat/config.json`
+    has the app id.
+  - `"status": "error"` → surface `next_steps` verbatim. Includes
+    the dashboard URL as a manual fallback.
+
+  **Only fall back to the dashboard walkthrough** (app.cometchat.com
+  → Chat & Messaging → Features → flip Status toggle) if the CLI
+  returns `error` or isn't available. Run
+  `cometchat features info <id>` for per-feature configuration
+  details (Giphy API keys, translation languages, etc.) beyond the
+  basic toggle.
+
+  **Note:** if the feature has `auto_wired_in_uikit: false` in the
+  catalog (most non-default extensions), the toggle alone isn't
+  enough — you also need to register the extension via
+  `UIKitSettingsBuilder.setExtensions([...])` before `init`. The
+  CLI's success output flags this; query the docs MCP for the exact
+  builder syntax.
+- **Package-install (calls):** run `npm install @cometchat/calls-sdk-javascript`
+  directly. The user opted in, that IS consent.
+- **Component-swap:** run `npx @cometchat/skills-cli apply-feature <id>`.
+  The CLI handles the swap deterministically. Do NOT hand-edit.
+
+### Step 5 — Verify
+
+```bash
+npx @cometchat/skills-cli verify --json
+```
+
+Surface any failed checks verbatim. If anything looks off after enabling
+a feature (drift, unexpected build error, env warning), run
+`cometchat doctor` for combined drift + env + AST diagnostics with
+per-issue fix instructions, or route to the `cometchat-troubleshooting`
+skill for deeper triage.
+
+## Hard rules
+
+- Never modify a project without an existing CometChat integration.
+- Always query the docs MCP for SDK reference (do not invent function names).
+- For component-swap features, always use `cometchat apply-feature <id>` —
+  the CLI is the source of truth, never hand-edit.
+- For package-install features (calls), the user opting in IS consent —
+  run `npm install <package>` directly.
+- For dashboard-toggle features, walk the user through the dashboard
+  activation steps from `cometchat features info <id>` — the dashboard
+  flip is something only the human can do.
+- For dashboard-toggle features, always give the canonical path:
+  **app.cometchat.com → select app → Chat & Messaging → Features →
+  toggle ON.** Query the docs MCP for per-feature config details
+  (e.g. Giphy API key, Translation language settings).
+- Always use `npx @cometchat/skills-cli`.
+
+## Sources
+
+- [Core features](https://www.cometchat.com/docs/ui-kit/react/core-features)
+- [Extensions](https://www.cometchat.com/docs/ui-kit/react/extensions)
+- [AI features](https://www.cometchat.com/docs/ui-kit/react/ai-features)
+- [Call features](https://www.cometchat.com/docs/ui-kit/react/call-features)

--- a/solutions/cometchat-chat/.agents/skills/cometchat-nextjs-patterns/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-nextjs-patterns/SKILL.md
@@ -1,0 +1,857 @@
+---
+name: cometchat-nextjs-patterns
+description: "Framework-specific patterns for integrating CometChat React UI Kit v6 into Next.js projects (App Router and Pages Router). Covers SSR prevention, provider setup, route placement, API routes, and common pitfalls."
+license: "MIT"
+compatibility: "Node.js >=18; React >=18; Next.js >=13; @cometchat/chat-uikit-react ^6; @cometchat/chat-sdk-javascript ^4"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "chat cometchat nextjs next react ssr app-router pages-router patterns"
+---
+
+## Purpose
+
+This skill teaches Claude how to integrate CometChat into a Next.js project. Next.js is the most complex framework to integrate with because of Server-Side Rendering (SSR) and the Server Component / Client Component boundary. Every CometChat component is browser-only -- getting this wrong is the #1 source of integration failures.
+
+**Read these companion skills first:**
+- `cometchat-core` -- initialization, login, CSS, provider pattern, anti-patterns
+- `cometchat-components` -- component catalog and composition patterns
+- `cometchat-placement` -- WHERE to put chat (route, modal, drawer, embedded)
+
+This skill covers the HOW for Next.js specifically.
+
+---
+
+## 1. Project detection
+
+A project uses Next.js when `package.json` has `next` as a dependency.
+
+### Detecting App Router vs Pages Router
+
+Both may coexist in a project. Check which is primary:
+
+```bash
+# App Router: look for app/ directory with layout.tsx
+ls app/layout.tsx app/layout.jsx 2>/dev/null
+
+# Pages Router: look for pages/ directory with _app.tsx
+ls pages/_app.tsx pages/_app.jsx pages/_app.js 2>/dev/null
+```
+
+**If `app/layout.tsx` exists, treat the project as App Router.** Even if `pages/` also exists, App Router is the primary routing mechanism in modern Next.js.
+
+**If only `pages/` exists, treat the project as Pages Router.**
+
+---
+
+## 2. Critical: SSR prevention
+
+**Every file that imports from `@cometchat/chat-uikit-react` MUST prevent server-side rendering.** CometChat components access `window`, `document`, and WebSocket APIs during import -- not just during render, but at import time. If Next.js tries to import these modules on the server, the build crashes with `ReferenceError: window is not defined`.
+
+### App Router: "use client" directive
+
+Add `"use client"` as the FIRST line of every file that imports CometChat:
+
+```tsx
+"use client";
+
+import { CometChatConversations } from "@cometchat/chat-uikit-react";
+// This file only runs in the browser
+```
+
+**Common mistake:** Putting `"use client"` AFTER imports. It must be the very first line, before any import statements.
+
+```tsx
+// WRONG -- "use client" is not the first line
+import React from "react";
+"use client"; // too late, has no effect
+
+// CORRECT
+"use client";
+import React from "react";
+```
+
+### App Router: dynamic import from Server Components
+
+If you need to render a CometChat component inside a Server Component (e.g., a page that does data fetching), use `next/dynamic` with `ssr: false`:
+
+```tsx
+// app/messages/page.tsx (this is a Server Component)
+import dynamic from "next/dynamic";
+
+const ChatView = dynamic(() => import("../../components/ChatView"), {
+  ssr: false,
+  loading: () => <div>Loading chat...</div>,
+});
+
+export default function MessagesPage() {
+  return <ChatView />;
+}
+```
+
+The `ChatView` component itself must still have `"use client"` at the top.
+
+### Pages Router: dynamic import
+
+In the Pages Router, every page can potentially run on the server. Use `next/dynamic`:
+
+```tsx
+// pages/messages.tsx
+import dynamic from "next/dynamic";
+
+const ChatView = dynamic(() => import("../components/ChatView"), {
+  ssr: false,
+  loading: () => <div>Loading chat...</div>,
+});
+
+export default function MessagesPage() {
+  return <ChatView />;
+}
+```
+
+---
+
+## 3. CometChatProvider for Next.js (App Router)
+
+### Full implementation
+
+```tsx
+// app/providers/CometChatProvider.tsx
+"use client";
+
+import React, { useEffect, useState, createContext, useContext } from "react";
+import { CometChatUIKit, UIKitSettingsBuilder } from "@cometchat/chat-uikit-react";
+
+interface CometChatContextValue {
+  isReady: boolean;
+  error: string | null;
+}
+
+const CometChatContext = createContext<CometChatContextValue>({
+  isReady: false,
+  error: null,
+});
+
+export const useCometChat = () => useContext(CometChatContext);
+
+// Module-level state prevents both double-init AND double-login in React
+// StrictMode. Without the loginInFlight guard, a second mount calls
+// login() while the first is still pending and the SDK throws
+// "Please wait until the previous login request ends."
+let initialized = false;
+let loginInFlight: Promise<unknown> | null = null;
+
+async function ensureLoggedIn(
+  uid: string,
+  authToken?: string,
+): Promise<void> {
+  const existing = await CometChatUIKit.getLoggedinUser();
+  if (existing) return;
+  if (loginInFlight) {
+    await loginInFlight;
+    return;
+  }
+  loginInFlight = authToken
+    ? CometChatUIKit.loginWithAuthToken(authToken)
+    : CometChatUIKit.login(uid);
+  try {
+    await loginInFlight;
+  } finally {
+    loginInFlight = null;
+  }
+}
+
+interface CometChatProviderProps {
+  children: React.ReactNode;
+}
+
+export function CometChatProvider({ children }: CometChatProviderProps) {
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function setup() {
+      try {
+        if (!initialized) {
+          initialized = true;
+
+          const settings = new UIKitSettingsBuilder()
+            .setAppId(process.env.NEXT_PUBLIC_COMETCHAT_APP_ID!)
+            .setRegion(process.env.NEXT_PUBLIC_COMETCHAT_REGION!)
+            .setAuthKey(process.env.NEXT_PUBLIC_COMETCHAT_AUTH_KEY!)
+            .subscribePresenceForAllUsers()
+            .build();
+
+          await CometChatUIKit.init(settings);
+        }
+
+        await ensureLoggedIn("cometchat-uid-1"); // DEVELOPMENT ONLY — see cometchat-production skill
+
+        setIsReady(true);
+      } catch (e) {
+        setError(String(e));
+      }
+    }
+
+    setup();
+  }, []);
+
+  if (error) {
+    return (
+      <div style={{ color: "red", padding: 16, fontFamily: "monospace" }}>
+        CometChat Error: {error}
+      </div>
+    );
+  }
+
+  if (!isReady) return null;
+
+  return (
+    <CometChatContext.Provider value={{ isReady, error }}>
+      {children}
+    </CometChatContext.Provider>
+  );
+}
+```
+
+### Where to mount: Option A -- Global (chat available everywhere)
+
+Wrap the entire app in `app/layout.tsx`. The layout itself is a Server Component, but the provider is a Client Component via `"use client"` in its file:
+
+```tsx
+// app/layout.tsx (Server Component)
+import { CometChatProvider } from "./providers/CometChatProvider";
+import "./globals.css";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <CometChatProvider>
+          {children}
+        </CometChatProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+**Note:** Importing a `"use client"` component from a Server Component is fine. Next.js renders the Server Component on the server and defers the Client Component to the browser. The `CometChatProvider` only runs its `useEffect` (and init) in the browser.
+
+### Where to mount: Option B -- Scoped (chat only on chat routes)
+
+Use a route group to scope the provider to chat-related routes:
+
+```
+app/
+  layout.tsx          <-- no CometChat here
+  page.tsx            <-- home page, no chat overhead
+  (chat)/
+    layout.tsx        <-- CometChatProvider wraps only this group
+    messages/
+      page.tsx        <-- chat page
+    inbox/
+      page.tsx        <-- another chat page
+```
+
+```tsx
+// app/(chat)/layout.tsx
+import { CometChatProvider } from "../providers/CometChatProvider";
+
+export default function ChatLayout({ children }: { children: React.ReactNode }) {
+  return <CometChatProvider>{children}</CometChatProvider>;
+}
+```
+
+Option B is better for performance: CometChat's SDK and WebSocket connection are only loaded when the user visits a chat route. Option A is simpler and ensures incoming call notifications work everywhere.
+
+---
+
+## 4. CometChatProvider for Next.js (Pages Router)
+
+In the Pages Router, mount the provider in `_app.tsx`. Use dynamic import to prevent SSR:
+
+```tsx
+// pages/_app.tsx
+import type { AppProps } from "next/app";
+import dynamic from "next/dynamic";
+import "../styles/globals.css";
+
+const CometChatProvider = dynamic(
+  () => import("../components/CometChatProvider").then((mod) => mod.CometChatProvider),
+  { ssr: false }
+);
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <CometChatProvider>
+      <Component {...pageProps} />
+    </CometChatProvider>
+  );
+}
+```
+
+The provider implementation is the same as section 3, but the file lives at `components/CometChatProvider.tsx` (no `"use client"` needed in Pages Router -- `ssr: false` handles SSR prevention).
+
+---
+
+## 5. Route placement (App Router)
+
+Next.js App Router uses file-system routing. Creating a file at the right path automatically creates the route.
+
+### Create the chat page
+
+```tsx
+// app/messages/page.tsx
+"use client";
+
+import { useState } from "react";
+import {
+  CometChatConversations,
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+export default function MessagesPage() {
+  const [selectedUser, setSelectedUser] = useState<CometChat.User>();
+  const [selectedGroup, setSelectedGroup] = useState<CometChat.Group>();
+
+  function handleConversationClick(conversation: CometChat.Conversation) {
+    const entity = conversation.getConversationWith();
+    if (entity instanceof CometChat.User) {
+      setSelectedUser(entity);
+      setSelectedGroup(undefined);
+    } else if (entity instanceof CometChat.Group) {
+      setSelectedUser(undefined);
+      setSelectedGroup(entity);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <div style={{ width: "360px", borderRight: "1px solid #eee" }}>
+        <CometChatConversations onItemClick={handleConversationClick} />
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        {(selectedUser || selectedGroup) ? (
+          <>
+            {selectedUser && <CometChatMessageHeader user={selectedUser} />}
+            {selectedGroup && <CometChatMessageHeader group={selectedGroup} />}
+            {selectedUser && <CometChatMessageList user={selectedUser} />}
+            {selectedGroup && <CometChatMessageList group={selectedGroup} />}
+            {selectedUser && <CometChatMessageComposer user={selectedUser} />}
+            {selectedGroup && <CometChatMessageComposer group={selectedGroup} />}
+          </>
+        ) : (
+          <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#999" }}>
+            Select a conversation to start chatting
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+This page is accessible at `/messages`. No router configuration needed -- Next.js handles it via the file system.
+
+### Add a navigation link
+
+Find the layout's nav component and add a link:
+
+```tsx
+import Link from "next/link";
+
+// In the nav, alongside existing links:
+<Link href="/messages">Messages</Link>
+```
+
+**Important:** Use Next.js's `<Link>` component (from `next/link`), not a plain `<a>` tag or React Router's `<Link>`. Next.js's Link handles client-side navigation and prefetching.
+
+---
+
+## 6. Route placement (Pages Router)
+
+### Create the chat page
+
+```tsx
+// pages/messages.tsx
+import dynamic from "next/dynamic";
+
+const ChatView = dynamic(() => import("../components/ChatView"), {
+  ssr: false,
+  loading: () => (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh" }}>
+      Loading chat...
+    </div>
+  ),
+});
+
+export default function MessagesPage() {
+  return <ChatView />;
+}
+```
+
+The `ChatView` component contains the actual CometChat composition (see `cometchat-placement` for patterns). It is dynamically imported with `ssr: false` to prevent server rendering.
+
+### ChatView implementation
+
+```tsx
+// components/ChatView.tsx
+import { useState } from "react";
+import {
+  CometChatConversations,
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+export default function ChatView() {
+  const [selectedUser, setSelectedUser] = useState<CometChat.User>();
+  const [selectedGroup, setSelectedGroup] = useState<CometChat.Group>();
+
+  function handleConversationClick(conversation: CometChat.Conversation) {
+    const entity = conversation.getConversationWith();
+    if (entity instanceof CometChat.User) {
+      setSelectedUser(entity);
+      setSelectedGroup(undefined);
+    } else if (entity instanceof CometChat.Group) {
+      setSelectedUser(undefined);
+      setSelectedGroup(entity);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <div style={{ width: "360px", borderRight: "1px solid #eee" }}>
+        <CometChatConversations onItemClick={handleConversationClick} />
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        {selectedUser && (
+          <>
+            <CometChatMessageHeader user={selectedUser} />
+            <CometChatMessageList user={selectedUser} />
+            <CometChatMessageComposer user={selectedUser} />
+          </>
+        )}
+        {selectedGroup && (
+          <>
+            <CometChatMessageHeader group={selectedGroup} />
+            <CometChatMessageList group={selectedGroup} />
+            <CometChatMessageComposer group={selectedGroup} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## 7. Modal/drawer placement
+
+### App Router
+
+Create a Client Component for the drawer:
+
+```tsx
+// components/ChatDrawer.tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+interface ChatDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  targetUserId?: string;
+}
+
+export function ChatDrawer({ isOpen, onClose, targetUserId }: ChatDrawerProps) {
+  const [user, setUser] = useState<CometChat.User>();
+
+  useEffect(() => {
+    if (!isOpen || !targetUserId) return;
+    CometChat.getUser(targetUserId).then(setUser);
+  }, [isOpen, targetUserId]);
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <div onClick={onClose} style={{ position: "fixed", inset: 0, zIndex: 999, backgroundColor: "rgba(0,0,0,0.3)" }} />
+      <div style={{
+        position: "fixed", top: 0, right: 0, bottom: 0, width: "400px", zIndex: 1000,
+        backgroundColor: "#fff", boxShadow: "-4px 0 20px rgba(0,0,0,0.15)",
+        display: "flex", flexDirection: "column",
+      }}>
+        <div style={{ display: "flex", justifyContent: "space-between", padding: "12px", borderBottom: "1px solid #eee" }}>
+          <span style={{ fontWeight: 600 }}>Chat</span>
+          <button onClick={onClose} style={{ background: "none", border: "none", cursor: "pointer" }}>X</button>
+        </div>
+        {user && (
+          <>
+            <CometChatMessageHeader user={user} />
+            <div style={{ flex: 1, overflow: "hidden" }}>
+              <CometChatMessageList user={user} />
+            </div>
+            <CometChatMessageComposer user={user} />
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+```
+
+**Mounting the drawer:** The drawer component has `"use client"`, so it can be imported from either Server or Client Components. Import it in the layout or any page:
+
+```tsx
+// In a Server Component layout -- this works because ChatDrawer is "use client"
+import { ChatDrawer } from "../components/ChatDrawer";
+
+// But state management (isOpen) must be in a Client Component.
+// Option 1: wrap in a small client component
+// Option 2: use a client-side context for drawer state
+```
+
+For state lifting across the Server/Client boundary, create a small Client Component wrapper:
+
+```tsx
+// components/ChatDrawerTrigger.tsx
+"use client";
+
+import { useState } from "react";
+import { ChatDrawer } from "./ChatDrawer";
+
+export function ChatDrawerTrigger({ targetUserId }: { targetUserId: string }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setIsOpen(true)}>Message</button>
+      <ChatDrawer isOpen={isOpen} onClose={() => setIsOpen(false)} targetUserId={targetUserId} />
+    </>
+  );
+}
+```
+
+### Pages Router
+
+Use `dynamic` import for the drawer/modal component:
+
+```tsx
+import dynamic from "next/dynamic";
+
+const ChatDrawer = dynamic(() => import("../components/ChatDrawer").then(m => m.ChatDrawer), {
+  ssr: false,
+});
+```
+
+See `cometchat-placement` for complete modal and drawer implementations.
+
+---
+
+## 8. API route for production auth
+
+Next.js can serve as both frontend and backend. Use an API route to generate CometChat auth tokens server-side.
+
+### App Router API route
+
+```tsx
+// app/api/cometchat-token/route.ts
+import { NextRequest, NextResponse } from "next/server";
+
+const COMETCHAT_APP_ID = process.env.COMETCHAT_APP_ID!;       // server-only, no NEXT_PUBLIC_ prefix
+const COMETCHAT_REGION = process.env.COMETCHAT_REGION!;        // server-only
+const COMETCHAT_AUTH_TOKEN = process.env.COMETCHAT_AUTH_TOKEN!; // server-only secret
+
+export async function POST(request: NextRequest) {
+  try {
+    const { uid } = await request.json();
+
+    if (!uid || typeof uid !== "string") {
+      return NextResponse.json({ error: "uid is required" }, { status: 400 });
+    }
+
+    const response = await fetch(
+      `https://${COMETCHAT_APP_ID}.api-${COMETCHAT_REGION}.cometchat.io/v3/users/${uid}/auth_tokens`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          apiKey: COMETCHAT_AUTH_TOKEN,
+          appId: COMETCHAT_APP_ID,
+        },
+        body: JSON.stringify({}),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      return NextResponse.json({ error }, { status: response.status });
+    }
+
+    const data = await response.json();
+    return NextResponse.json({ token: data.data.authToken });
+  } catch (error) {
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}
+```
+
+### Pages Router API route
+
+```tsx
+// pages/api/cometchat-token.ts
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const COMETCHAT_APP_ID = process.env.COMETCHAT_APP_ID!;
+const COMETCHAT_REGION = process.env.COMETCHAT_REGION!;
+const COMETCHAT_AUTH_TOKEN = process.env.COMETCHAT_AUTH_TOKEN!;
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const { uid } = req.body;
+
+    if (!uid || typeof uid !== "string") {
+      return res.status(400).json({ error: "uid is required" });
+    }
+
+    const response = await fetch(
+      `https://${COMETCHAT_APP_ID}.api-${COMETCHAT_REGION}.cometchat.io/v3/users/${uid}/auth_tokens`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          apiKey: COMETCHAT_AUTH_TOKEN,
+          appId: COMETCHAT_APP_ID,
+        },
+        body: JSON.stringify({}),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      return res.status(response.status).json({ error });
+    }
+
+    const data = await response.json();
+    return res.status(200).json({ token: data.data.authToken });
+  } catch (error) {
+    return res.status(500).json({ error: String(error) });
+  }
+}
+```
+
+### Environment variables for the API route
+
+Add server-only variables to `.env.local` (no `NEXT_PUBLIC_` prefix -- these must NOT be exposed to the browser):
+
+```env
+# .env.local -- server-only (no NEXT_PUBLIC_ prefix)
+COMETCHAT_APP_ID=your_app_id
+COMETCHAT_REGION=us
+COMETCHAT_AUTH_TOKEN=your_server_auth_token
+
+# Client-side (NEXT_PUBLIC_ prefix)
+NEXT_PUBLIC_COMETCHAT_APP_ID=your_app_id
+NEXT_PUBLIC_COMETCHAT_REGION=us
+NEXT_PUBLIC_COMETCHAT_AUTH_KEY=your_client_auth_key
+```
+
+**Note:** `COMETCHAT_AUTH_TOKEN` (server secret) and `COMETCHAT_AUTH_KEY` (client key) are different values from the CometChat dashboard. The auth token has higher privileges. Never prefix it with `NEXT_PUBLIC_`.
+
+---
+
+## 9. Environment variables
+
+### Next.js env var conventions
+
+| Variable | Prefix | Accessible from | File |
+|---|---|---|---|
+| Client-side vars | `NEXT_PUBLIC_` | Browser + Server | `.env.local` |
+| Server-only vars | None | Server only (API routes, Server Components) | `.env.local` |
+
+### .env.local file
+
+```env
+NEXT_PUBLIC_COMETCHAT_APP_ID=your_app_id
+NEXT_PUBLIC_COMETCHAT_REGION=us
+NEXT_PUBLIC_COMETCHAT_AUTH_KEY=your_auth_key
+```
+
+**Access in client code:** `process.env.NEXT_PUBLIC_COMETCHAT_APP_ID`
+
+**Important:** `.env.local` is gitignored by default in Next.js. Unlike Vite, you do not need to manually add it to `.gitignore`.
+
+---
+
+## 10. CSS import
+
+### App Router
+
+Import in `app/globals.css` or `app/layout.tsx`:
+
+```css
+/* app/globals.css */
+@import "@cometchat/chat-uikit-react/css-variables.css";
+
+/* your styles below */
+```
+
+Or as a JS import in the root layout:
+
+```tsx
+// app/layout.tsx
+import "@cometchat/chat-uikit-react/css-variables.css";
+import "./globals.css";
+```
+
+### Pages Router
+
+Import in `pages/_app.tsx` or `styles/globals.css`:
+
+```tsx
+// pages/_app.tsx
+import "@cometchat/chat-uikit-react/css-variables.css";
+import "../styles/globals.css";
+```
+
+---
+
+## 11. Common pitfalls
+
+### Missing "use client"
+
+**Symptom:** `ReferenceError: window is not defined` or `ReferenceError: document is not defined` during build or at runtime.
+
+**Cause:** A file imports from `@cometchat/chat-uikit-react` without `"use client"` at the top. Next.js tries to render it on the server.
+
+**Fix:** Add `"use client"` as the first line of the file.
+
+### Server/client code mixing
+
+**Symptom:** Build errors about `next/headers`, `cookies()`, or `generateMetadata` in the same file as CometChat imports.
+
+**Cause:** Server-only APIs and client-only APIs cannot coexist in the same file. CometChat requires `"use client"`, but `next/headers` and `cookies()` are server-only.
+
+**Fix:** Split the file. Keep server logic in a Server Component; keep CometChat in a separate `"use client"` component that the Server Component imports.
+
+```tsx
+// app/messages/page.tsx (Server Component -- does data fetching)
+import { cookies } from "next/headers";
+import dynamic from "next/dynamic";
+
+const ChatView = dynamic(() => import("../../components/ChatView"), { ssr: false });
+
+export default async function MessagesPage() {
+  const session = cookies().get("session"); // server-only
+  if (!session) redirect("/login");
+
+  return <ChatView />;
+}
+```
+
+### Image optimization
+
+CometChat renders avatars and media images via its own components. These do not conflict with `next/image`. Do not try to replace CometChat's internal images with `next/image` -- they are managed by the SDK.
+
+### Middleware
+
+CometChat has no middleware requirements. Do not add CometChat-related middleware. If the project has auth middleware (e.g., protecting routes), just ensure the chat route is behind the same auth as the rest of the app.
+
+### ISR/SSG pages with chat
+
+If a page uses static generation (`generateStaticParams`) or ISR, you can still add chat. Wrap the CometChat components in a Client Component. The page's static HTML ships without chat, and the Client Component hydrates and renders chat in the browser:
+
+```tsx
+// app/products/[id]/page.tsx
+export async function generateStaticParams() {
+  // ... returns product IDs for static generation
+}
+
+export default async function ProductPage({ params }: { params: { id: string } }) {
+  const product = await getProduct(params.id);
+
+  return (
+    <div>
+      <h1>{product.name}</h1>
+      <p>{product.description}</p>
+      {/* ChatPanel is "use client" -- renders only in the browser */}
+      <ChatPanel targetUserId={product.sellerId} />
+    </div>
+  );
+}
+```
+
+### Turbopack
+
+Next.js's Turbopack (dev mode with `next dev --turbo`) works with CometChat. No special configuration needed. If you encounter issues, fall back to the standard Webpack dev server (`next dev` without `--turbo`).
+
+### Pages Router: do NOT use CometChat from `getServerSideProps` / `getStaticProps` / `getInitialProps`
+
+**Symptom:** `ReferenceError: window is not defined` or cryptic SDK errors during `next build` or page rendering.
+
+**Cause:** The CometChat client SDK needs the browser (localStorage, WebSocket, etc.) and a logged-in user session. It cannot run inside `getServerSideProps`, `getStaticProps`, or `getInitialProps` — those execute on the Node.js server before the browser has hydrated.
+
+**Fix:** Do chat-related work in client components only. If you need to pre-seed a conversation from server data, pass just the primitive IDs (user UID, group GUID) as page props and let the client component fetch the CometChat entity on mount:
+
+```tsx
+// pages/products/[id].tsx — server-side data fetch, no CometChat
+export async function getServerSideProps({ params }) {
+  const product = await fetchProduct(params.id);
+  return { props: { product } }; // pass sellerId as string, not a CometChat.User
+}
+
+export default function ProductPage({ product }) {
+  return (
+    <>
+      <h1>{product.name}</h1>
+      <ChatWithSeller sellerUid={product.sellerId} /> {/* client component */}
+    </>
+  );
+}
+```
+
+### Pages Router: `_document.tsx` doesn't need CometChat changes
+
+If the project has a custom `pages/_document.tsx` for font preloading or third-party SSR CSS injection, leave it alone. CometChat CSS variables are client-side only — they don't need `_document.tsx` integration. Mount the CSS import in `_app.tsx` as shown in section 10; `_document.tsx` is the wrong layer.
+
+---
+
+## 12. Complete integration checklist (App Router)
+
+1. Install packages: `npm install @cometchat/chat-uikit-react @cometchat/chat-sdk-javascript`
+2. Create `.env.local` with `NEXT_PUBLIC_COMETCHAT_APP_ID`, `NEXT_PUBLIC_COMETCHAT_REGION`, `NEXT_PUBLIC_COMETCHAT_AUTH_KEY`
+3. Import `@cometchat/chat-uikit-react/css-variables.css` in `app/globals.css`
+4. Create `app/providers/CometChatProvider.tsx` with `"use client"` (section 3)
+5. Mount `CometChatProvider` in `app/layout.tsx` wrapping `{children}`
+6. Create `app/messages/page.tsx` with `"use client"` (section 5)
+7. Add a `<Link href="/messages">Messages</Link>` to the layout's nav
+8. Verify: `npm run build` should succeed without SSR errors
+
+## 13. Complete integration checklist (Pages Router)
+
+1. Install packages: `npm install @cometchat/chat-uikit-react @cometchat/chat-sdk-javascript`
+2. Create `.env.local` with `NEXT_PUBLIC_COMETCHAT_APP_ID`, `NEXT_PUBLIC_COMETCHAT_REGION`, `NEXT_PUBLIC_COMETCHAT_AUTH_KEY`
+3. Import `@cometchat/chat-uikit-react/css-variables.css` in `pages/_app.tsx`
+4. Create `components/CometChatProvider.tsx` (section 3 code, without `"use client"`)
+5. Dynamically import `CometChatProvider` in `pages/_app.tsx` with `ssr: false` (section 4)
+6. Create `pages/messages.tsx` with dynamic import (section 6)
+7. Add a `<Link href="/messages">Messages</Link>` to the layout's nav
+8. Verify: `npm run build` should succeed without SSR errors

--- a/solutions/cometchat-chat/.agents/skills/cometchat-placement/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-placement/SKILL.md
@@ -1,0 +1,1293 @@
+---
+name: cometchat-placement
+description: "Production integration patterns -- how to add CometChat as a route, modal, drawer, embedded panel, or widget in an existing project. Teaches Claude WHERE to put chat."
+license: "MIT"
+compatibility: "@cometchat/chat-uikit-react ^6; @cometchat/chat-sdk-javascript ^4"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "chat cometchat react placement route modal drawer widget embedded integration"
+---
+
+## Purpose
+
+This skill teaches you WHERE to put CometChat in an existing project. It covers five placement patterns: route, modal, drawer, embedded panel, and floating widget. Each pattern includes step-by-step instructions and complete code examples.
+
+**This skill is framework-AGNOSTIC.** It uses generic instructions like "create a page at the framework's route location" and "add a route entry to the project's router." The framework-specific details (file paths, SSR handling, env var prefixes) come from the framework skill and the `cometchat-core` skill.
+
+**Before using this skill:**
+- Read `cometchat-core` for initialization, login, CSS, and provider patterns
+- Read `cometchat-components` for component names, props, and composition patterns
+
+---
+
+## "What are you building?" -- placement recommendation
+
+Use this table to recommend a placement based on what the user is building. If the user says "add chat to my app" without specifying where, ask them what they are building and use this table.
+
+| User intent | Recommended placement | Experience composition |
+|---|---|---|
+| Messaging app | Route (full page) | Multi-conversation (CometChatConversations + MessageHeader + MessageList + MessageComposer) |
+| Marketplace / platform | Drawer on product page + `/messages` route | Single thread (drawer) + Multi-conversation (route) |
+| SaaS / dashboard | Modal from navbar + `/messages` route | Single thread (modal) + Multi-conversation (route) |
+| Social / community | Route (tabs) | Full messenger (CometChatConversations + CallLogs + Users + Groups with tabs) |
+| Support / helpdesk | Floating widget | Widget (use CLI) |
+| Just exploring | Demo (replace home page) | Multi-conversation |
+
+---
+
+## Visual reference — experience layouts
+
+When presenting experience options to the user, describe these layouts
+or share the ASCII art so they can visualize what each looks like.
+
+### Multi-conversation (Experience 1)
+
+Two-pane layout: conversation list on the left, active chat thread on the right.
+
+```
+┌─────────────────────────┬───────────────────────────────────────┐
+│ Chats               Q   │ Richard Ray               v  c  i     │
+├─────────────────────────┼───────────────────────────────────────┤
+│                         │                                       │
+│ (RR) Richard Ray  3:45  │           ╭─────────────────────╮     │
+│      Is it still up..   │           │ Hi, is the watch    │     │
+│                         │           │ still up for sale?  │     │
+│ (SB) Sarah Beth   3:40  │           ╰────────── 4:56 PM ─╯      │
+│      Sure! Sending ..   │                                       │
+│                         │ ╭─────────────────╮                   │
+│ (RA) Robert Allen 3:38  │ │ Yes, it is      │                   │
+│      Thanks! Looks ..   │ │ available.      │                   │
+│                         │ ╰─ 4:56 PM ──────╯                    │
+│ (SG) Sam Game     3:30  │                                       │
+│      Sending them ..    │           ╭─────────────────────╮     │
+│                         │           │ Can I see a couple  │     │
+│ (SF) Scott F.     3:22  │           │ of pictures?        │     │
+│      I will look ..     │           ╰────────── 4:56 PM ─╯      │
+│                         │                                       │
+│ (EP) Evan Parker  3:15  │ ╭─────────────────╮                   │
+│      Hey, did you ..    │ │ Sure! Sending   │                   │
+│                         │ │ them over now.  │                   │
+│ (JP) John Paul    3:10  │ ╰─ 4:56 PM ──────╯                    │
+│      Sounds good        │                                       │
+│                         │           ╭─────────────────────╮     │
+│ (LK) Linda Kay    3:05  │           │ Thanks! Looks good. │     │
+│      See you there      │           ╰────────── 4:56 PM ─╯      │
+│                         ├───────────────────────────────────────┤
+│                         │ Type a message...                 >   │
+└─────────────────────────┴───────────────────────────────────────┘
+```
+
+Best for: messaging apps, team chat, inboxes, dedicated chat sections.
+
+### Single thread (Experience 2)
+
+One chat window — no conversation list. Shows a direct chat with one user or group.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│ (RR) Richard Ray                              v    c    i       │
+│      . Online                                                   │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│                        ╭───────────────────────────────╮        │
+│                        │ Hi, is the watch still up     │        │
+│                        │ for sale?          4:56 PM vv │        │
+│                        ╰───────────────────────────────╯        │
+│                                                                 │
+│ ╭───────────────────────╮                                       │
+│ │ Yes, it is available. │                                       │
+│ ╰── 4:56 PM ───────────╯                                        │
+│                                                                 │
+│                        ╭───────────────────────────────╮        │
+│                        │ Awesome! Can I see a couple   │        │
+│                        │ of pictures?       4:56 PM vv │        │
+│                        ╰───────────────────────────────╯        │
+│                                                                 │
+│ ╭────────────────────────────────╮                              │
+│ │ Sure! Sending them over now.   │                              │
+│ ╰── 4:56 PM ────────────────────╯                               │
+│                                                                 │
+│                        ╭───────────────────────────────╮        │
+│                        │ Thanks! Looks good. 4:56 PM vv│        │
+│                        ╰───────────────────────────────╯        │
+│                                                                 │
+│ ╭─────────────╮                                                 │
+│ │ Thank you!  │                                                 │
+│ ╰── 4:56 PM ─╯                                                  │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│ +  m  e  a     Type a message...                            >   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Best for: marketplace chat, embedded consult, support, one-on-one conversations.
+
+### Full messenger (Experience 3)
+
+Two-pane layout like Experience 1, plus a bottom tab bar for switching
+between Chats, Calls, Users, and Groups.
+
+```
+┌─────────────────────────┬───────────────────────────────────────┐
+│ Chats               Q   │ Richard Ray               v  c  i     │
+├─────────────────────────┼───────────────────────────────────────┤
+│                         │                                       │
+│ (RR) Richard Ray  3:45  │           ╭─────────────────────╮     │
+│      How much extra..   │           │ How much extra are  │     │
+│                         │           │ we talking for the  │     │
+│ (SB) Sarah Beth   3:40  │           │ direct flight?      │     │
+│      That sounds w..    │           ╰────────── 4:56 PM ─╯      │
+│                         │                                       │
+│ (RA) Robert Allen 3:38  │ ╭──────────────────────╮              │
+│      4:56 PM            │ │ It is $50 more. Save │              │
+│                         │ │ a couple of hours.   │              │
+│ (SG) Sam Game     3:30  │ ╰─ 4:56 PM ───────────╯               │
+│      Sending them ..    │                                       │
+│                         │           ╭─────────────────────╮     │
+│ (SF) Scott F.     3:22  │           │ That sounds worth   │     │
+│      I will look ..     │           │ it. Let us do it.   │     │
+│                         │           ╰────────── 4:56 PM ─╯      │
+│ (EP) Evan Parker  3:15  │                                       │
+│      Hey, did you ..    │ ╭──────────────────────╮              │
+│                         │ │ Great, I will send   │              │
+│                         │ │ you the details.     │              │
+│                         │ ╰─ 4:56 PM ───────────╯               │
+│                         ├───────────────────────────────────────┤
+│                         │ Type a message...                 >   │
+├─────────────────────────┼───────────────────────────────────────┤
+│ Ch   Ca   Us   Gr       │                                       │
+└─────────────────────────┴───────────────────────────────────────┘
+```
+
+Best for: social apps, community platforms, dating apps, full-featured
+chat products.
+
+---
+
+## Thread replies — hidden by default in every example below
+
+Every `<CometChatMessageList ...>` in the placement patterns below
+includes `hideReplyInThreadOption`. The kit's default (`false`) puts a
+**"Reply in Thread"** entry in every message's action menu — but that
+entry only works if the integrator has wired up a thread panel
+(`CometChatThreadHeader` + a scoped `CometChatMessageList` +
+`CometChatMessageComposer` with `parentMessageId`). If the thread
+panel isn't wired (the case for a simple drawer, widget, modal, or
+single-thread experience), the option is still visible and clicking it
+silently does nothing — confusing UX.
+
+Default: **threads hidden**. To enable threads for an experience that
+actually has the side-panel plumbing:
+
+1. Remove `hideReplyInThreadOption` from the main `<CometChatMessageList>`
+2. Add `onThreadRepliesClick` to capture the thread message
+3. Render the thread panel (see `cometchat-components` § Threading for
+   the full pattern — `CometChatThreadHeader` + scoped `MessageList` +
+   scoped `MessageComposer` with `parentMessageId`)
+
+---
+
+## Route placement
+
+The most common pattern. Chat gets its own page in the app, accessible via navigation.
+
+### Steps
+
+#### 1. Set up CometChatProvider at the app root
+
+The provider (from `cometchat-core`) should wrap the entire app or the chat route's layout. This ensures init and login happen once, not per-navigation.
+
+- **Read the project's existing layout/root component first.** Look for the outermost wrapper (e.g., `App.tsx`, `layout.tsx`, `root.tsx`).
+- Add the `CometChatProvider` inside the existing layout, wrapping the router outlet or children.
+- Import `@cometchat/chat-uikit-react/css-variables.css` at the app root CSS file if not already imported.
+
+#### 2. Create a chat page component
+
+Create a new file (e.g., `ChatPage.tsx` or `MessagesPage.tsx`) at the framework's conventional page location:
+
+- React (Vite): `src/pages/ChatPage.tsx` or `src/ChatPage.tsx`
+- Next.js (App Router): `app/chat/page.tsx`
+- Next.js (Pages Router): `pages/chat.tsx`
+- Astro: `src/pages/chat.astro` (with a React island)
+- React Router: `app/routes/chat.tsx`
+
+#### 3. Implement the page
+
+Choose the experience composition from `cometchat-components`:
+
+**Two-pane (most common for routes):**
+
+```tsx
+// ChatPage.tsx
+import { useState } from "react";
+import {
+  CometChatConversations,
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+export default function ChatPage() {
+  const [selectedUser, setSelectedUser] = useState<CometChat.User>();
+  const [selectedGroup, setSelectedGroup] = useState<CometChat.Group>();
+
+  function handleConversationClick(conversation: CometChat.Conversation) {
+    const entity = conversation.getConversationWith();
+    if (entity instanceof CometChat.User) {
+      setSelectedUser(entity);
+      setSelectedGroup(undefined);
+    } else if (entity instanceof CometChat.Group) {
+      setSelectedUser(undefined);
+      setSelectedGroup(entity);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <div style={{ width: "360px", borderRight: "1px solid #eee" }}>
+        <CometChatConversations onItemClick={handleConversationClick} />
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        {(selectedUser || selectedGroup) ? (
+          <>
+            {selectedUser && <CometChatMessageHeader user={selectedUser} />}
+            {selectedGroup && <CometChatMessageHeader group={selectedGroup} />}
+            {selectedUser && <CometChatMessageList user={selectedUser} hideReplyInThreadOption />}
+            {selectedGroup && <CometChatMessageList group={selectedGroup} hideReplyInThreadOption />}
+            {selectedUser && <CometChatMessageComposer user={selectedUser} />}
+            {selectedGroup && <CometChatMessageComposer group={selectedGroup} />}
+          </>
+        ) : (
+          <div style={{
+            flex: 1,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "#999",
+          }}>
+            Select a conversation to start chatting
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+**Full messenger (tabs -- for standalone messaging sections):**
+
+```tsx
+// MessagesPage.tsx
+import { useState } from "react";
+import {
+  CometChatConversations,
+  CometChatCallLogs,
+  CometChatUsers,
+  CometChatGroups,
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+type Tab = "chats" | "calls" | "users" | "groups";
+
+export default function MessagesPage() {
+  const [activeTab, setActiveTab] = useState<Tab>("chats");
+  const [selectedUser, setSelectedUser] = useState<CometChat.User>();
+  const [selectedGroup, setSelectedGroup] = useState<CometChat.Group>();
+
+  function selectUser(user: CometChat.User) {
+    setSelectedUser(user);
+    setSelectedGroup(undefined);
+  }
+  function selectGroup(group: CometChat.Group) {
+    setSelectedUser(undefined);
+    setSelectedGroup(group);
+  }
+
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <div style={{ width: "360px", display: "flex", flexDirection: "column", borderRight: "1px solid #eee" }}>
+        <nav style={{ display: "flex", borderBottom: "1px solid #eee" }}>
+          {(["chats", "calls", "users", "groups"] as Tab[]).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              style={{
+                flex: 1,
+                padding: "12px 0",
+                border: "none",
+                background: "none",
+                cursor: "pointer",
+                fontWeight: activeTab === tab ? 700 : 400,
+                borderBottom: activeTab === tab ? "2px solid var(--cometchat-primary-color, #3399ff)" : "2px solid transparent",
+              }}
+            >
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </button>
+          ))}
+        </nav>
+        <div style={{ flex: 1, overflow: "hidden" }}>
+          {activeTab === "chats" && (
+            <CometChatConversations
+              onItemClick={(conv) => {
+                const entity = conv.getConversationWith();
+                if (entity instanceof CometChat.User) selectUser(entity);
+                else if (entity instanceof CometChat.Group) selectGroup(entity);
+              }}
+            />
+          )}
+          {activeTab === "calls" && <CometChatCallLogs />}
+          {activeTab === "users" && <CometChatUsers onItemClick={selectUser} />}
+          {activeTab === "groups" && <CometChatGroups onItemClick={selectGroup} />}
+        </div>
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        {selectedUser && (
+          <>
+            <CometChatMessageHeader user={selectedUser} />
+            <CometChatMessageList user={selectedUser} hideReplyInThreadOption />
+            <CometChatMessageComposer user={selectedUser} />
+          </>
+        )}
+        {selectedGroup && (
+          <>
+            <CometChatMessageHeader group={selectedGroup} />
+            <CometChatMessageList group={selectedGroup} hideReplyInThreadOption />
+            <CometChatMessageComposer group={selectedGroup} />
+          </>
+        )}
+        {!selectedUser && !selectedGroup && (
+          <div style={{
+            flex: 1,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "#999",
+          }}>
+            Select a conversation to start chatting
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+#### 4. Wire the route into the project's router
+
+**Read the project's existing routing setup first.** Do not assume a pattern. Look for:
+
+- **React Router:** `createBrowserRouter()`, `<Routes>`, `<Route>` in `App.tsx` or a routes file
+- **Next.js App Router:** `app/` directory -- just creating the page file at `app/chat/page.tsx` IS the route
+- **Next.js Pages Router:** `pages/` directory -- creating `pages/chat.tsx` IS the route
+- **Astro:** `src/pages/` directory -- creating `src/pages/chat.astro` IS the route
+- **React Router v7:** File-based routing in `app/routes/` or manual routes in `app/routes.ts`
+
+For manual routers (React Router), add a route entry:
+
+```tsx
+// Example: adding to an existing createBrowserRouter
+{
+  path: "/chat",
+  element: <ChatPage />,
+}
+```
+
+For file-based routers (Next.js, Astro, React Router v7), creating the file at the right path is sufficient.
+
+#### 5. Add a navigation link
+
+**Read the project's existing navbar/sidebar first.** Find the component that renders navigation links (could be `Navbar.tsx`, `Sidebar.tsx`, `Header.tsx`, `Nav.tsx`, or inline in a layout).
+
+Add a "Messages" or "Chat" link alongside the existing links:
+
+```tsx
+// Example: adding to an existing nav component
+<Link to="/chat">Messages</Link>
+// or
+<a href="/chat">Messages</a>
+```
+
+Match the existing link style. If the nav uses icons, add a chat/message icon. If it uses a specific `NavLink` or `Link` component, use the same one.
+
+#### 6. Import CSS
+
+Check if `@cometchat/chat-uikit-react/css-variables.css` is already imported at the app root. If not, add it to the root CSS file or root layout:
+
+```css
+/* In globals.css or index.css at the app root */
+@import "@cometchat/chat-uikit-react/css-variables.css";
+```
+
+---
+
+## Modal placement
+
+A centered overlay for quick one-off messages. Use when chat is a secondary action (e.g., "message this user" from a profile page).
+
+### When to use modal vs. drawer
+
+- **Modal:** Quick, one-off messages. User sends a message and closes. No ongoing conversation visible.
+- **Drawer:** Ongoing conversation. User keeps the drawer open while browsing the main app. Better for marketplace/support contexts.
+
+### Steps
+
+#### 1. Create a ChatModal component
+
+```tsx
+// ChatModal.tsx
+import { useEffect, useState } from "react";
+import {
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+interface ChatModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  targetUserId?: string;
+  targetGroupId?: string;
+}
+
+export function ChatModal({ isOpen, onClose, targetUserId, targetGroupId }: ChatModalProps) {
+  const [user, setUser] = useState<CometChat.User>();
+  const [group, setGroup] = useState<CometChat.Group>();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setLoading(true);
+
+    if (targetUserId) {
+      CometChat.getUser(targetUserId)
+        .then((u) => {
+          setUser(u);
+          setGroup(undefined);
+          setLoading(false);
+        })
+        .catch(() => setLoading(false));
+    } else if (targetGroupId) {
+      CometChat.getGroup(targetGroupId)
+        .then((g) => {
+          setUser(undefined);
+          setGroup(g);
+          setLoading(false);
+        })
+        .catch(() => setLoading(false));
+    }
+  }, [isOpen, targetUserId, targetGroupId]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 1000,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{
+          position: "absolute",
+          inset: 0,
+          backgroundColor: "rgba(0, 0, 0, 0.5)",
+        }}
+      />
+
+      {/* Modal content */}
+      <div
+        style={{
+          position: "relative",
+          width: "min(600px, 90vw)",
+          height: "min(700px, 80vh)",
+          backgroundColor: "var(--cometchat-background-color-01, #fff)",
+          borderRadius: "var(--cometchat-border-radius-lg, 12px)",
+          overflow: "hidden",
+          display: "flex",
+          flexDirection: "column",
+          boxShadow: "0 20px 60px rgba(0, 0, 0, 0.3)",
+        }}
+      >
+        {/* Close button */}
+        <button
+          onClick={onClose}
+          style={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            zIndex: 10,
+            background: "none",
+            border: "none",
+            fontSize: 20,
+            cursor: "pointer",
+            padding: "4px 8px",
+          }}
+          aria-label="Close chat"
+        >
+          X
+        </button>
+
+        {loading ? (
+          <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            Loading...
+          </div>
+        ) : (
+          <>
+            {user && <CometChatMessageHeader user={user} />}
+            {group && <CometChatMessageHeader group={group} />}
+            <div style={{ flex: 1, overflow: "hidden" }}>
+              {user && <CometChatMessageList user={user} hideReplyInThreadOption />}
+              {group && <CometChatMessageList group={group} hideReplyInThreadOption />}
+            </div>
+            {user && <CometChatMessageComposer user={user} />}
+            {group && <CometChatMessageComposer group={group} />}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+#### 2. Wire the trigger
+
+**Read the project's components to find the right trigger point.** This could be:
+
+- A "Message" button on a user profile page
+- A "Contact Seller" button on a product card
+- A chat icon in a navbar
+- A "Send Message" link in a user list
+
+```tsx
+// Example: adding a chat button to an existing product card
+import { useState } from "react";
+import { ChatModal } from "./ChatModal";
+
+function ProductCard({ product }) {
+  const [showChat, setShowChat] = useState(false);
+
+  return (
+    <div>
+      {/* existing product card content */}
+      <button onClick={() => setShowChat(true)}>
+        Message Seller
+      </button>
+      <ChatModal
+        isOpen={showChat}
+        onClose={() => setShowChat(false)}
+        targetUserId={product.sellerId}
+      />
+    </div>
+  );
+}
+```
+
+#### 3. CometChatProvider placement
+
+The `CometChatProvider` (or equivalent init logic) MUST be at the app root, NOT inside the modal. If init is inside the modal, it re-runs every time the modal opens, causing flicker and reconnection delays.
+
+---
+
+## Drawer placement
+
+A side panel that slides in from the right. Better than a modal for ongoing conversations because the user can keep it open while browsing.
+
+### Steps
+
+#### 1. Create a ChatDrawer component
+
+```tsx
+// ChatDrawer.tsx
+import { useEffect, useState } from "react";
+import {
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+interface ChatDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  targetUserId?: string;
+  targetGroupId?: string;
+}
+
+export function ChatDrawer({ isOpen, onClose, targetUserId, targetGroupId }: ChatDrawerProps) {
+  const [user, setUser] = useState<CometChat.User>();
+  const [group, setGroup] = useState<CometChat.Group>();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setLoading(true);
+
+    if (targetUserId) {
+      CometChat.getUser(targetUserId)
+        .then((u) => {
+          setUser(u);
+          setGroup(undefined);
+          setLoading(false);
+        })
+        .catch(() => setLoading(false));
+    } else if (targetGroupId) {
+      CometChat.getGroup(targetGroupId)
+        .then((g) => {
+          setUser(undefined);
+          setGroup(g);
+          setLoading(false);
+        })
+        .catch(() => setLoading(false));
+    }
+  }, [isOpen, targetUserId, targetGroupId]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      {isOpen && (
+        <div
+          onClick={onClose}
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 999,
+            backgroundColor: "rgba(0, 0, 0, 0.3)",
+          }}
+        />
+      )}
+
+      {/* Drawer */}
+      {/*
+        IMPORTANT: do NOT animate with `transform: translateX(...)`.
+        `transform` on an element creates a new containing block for
+        `position: fixed` descendants (per the CSS spec), so every
+        fixed-positioned popover that CometChat renders inside the drawer
+        — message options menu, emoji picker, file preview, reactions
+        popover, thread panel — becomes anchored to the transformed
+        drawer instead of the viewport. The result is popovers that
+        appear clipped, offset, or drift as the drawer animates. Animate
+        the `right` offset instead; no transform, no containing-block
+        takeover, fixed popovers stay anchored to the viewport.
+      */}
+      <div
+        style={{
+          position: "fixed",
+          top: 0,
+          right: isOpen ? 0 : "-400px",  // matches width; slides off-screen when closed
+          bottom: 0,
+          width: "400px",
+          maxWidth: "100vw",
+          zIndex: 1000,
+          backgroundColor: "var(--cometchat-background-color-01, #fff)",
+          boxShadow: "-4px 0 20px rgba(0, 0, 0, 0.15)",
+          display: "flex",
+          flexDirection: "column",
+          transition: "right 0.3s ease-in-out",
+        }}
+      >
+        {/* Header with close button */}
+        <div style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "8px 12px",
+          borderBottom: "1px solid #eee",
+        }}>
+          <span style={{ fontWeight: 600 }}>Chat</span>
+          <button
+            onClick={onClose}
+            style={{
+              background: "none",
+              border: "none",
+              fontSize: 18,
+              cursor: "pointer",
+              padding: "4px 8px",
+            }}
+            aria-label="Close chat"
+          >
+            X
+          </button>
+        </div>
+
+        {/* Chat content */}
+        {loading ? (
+          <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            Loading...
+          </div>
+        ) : (
+          <>
+            {user && <CometChatMessageHeader user={user} />}
+            {group && <CometChatMessageHeader group={group} />}
+            <div style={{ flex: 1, overflow: "hidden" }}>
+              {user && <CometChatMessageList user={user} hideReplyInThreadOption />}
+              {group && <CometChatMessageList group={group} hideReplyInThreadOption />}
+            </div>
+            {user && <CometChatMessageComposer user={user} />}
+            {group && <CometChatMessageComposer group={group} />}
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+```
+
+#### 2. Wire the trigger
+
+Same approach as the modal -- find the right trigger point in the existing project:
+
+```tsx
+import { useState } from "react";
+import { ChatDrawer } from "./ChatDrawer";
+
+function UserProfile({ userId }) {
+  const [showChat, setShowChat] = useState(false);
+
+  return (
+    <div>
+      {/* existing profile content */}
+      <button onClick={() => setShowChat(true)}>
+        Chat with this user
+      </button>
+      <ChatDrawer
+        isOpen={showChat}
+        onClose={() => setShowChat(false)}
+        targetUserId={userId}
+      />
+    </div>
+  );
+}
+```
+
+#### 3. Multi-conversation drawer variant
+
+For a drawer that shows the full conversation list (not just a single thread):
+
+```tsx
+// ConversationDrawer.tsx -- shows conversation list + message view
+import { useState } from "react";
+import {
+  CometChatConversations,
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+interface ConversationDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ConversationDrawer({ isOpen, onClose }: ConversationDrawerProps) {
+  const [selectedUser, setSelectedUser] = useState<CometChat.User>();
+  const [selectedGroup, setSelectedGroup] = useState<CometChat.Group>();
+
+  function handleConversationClick(conversation: CometChat.Conversation) {
+    const entity = conversation.getConversationWith();
+    if (entity instanceof CometChat.User) {
+      setSelectedUser(entity);
+      setSelectedGroup(undefined);
+    } else if (entity instanceof CometChat.Group) {
+      setSelectedUser(undefined);
+      setSelectedGroup(entity);
+    }
+  }
+
+  const hasSelection = selectedUser || selectedGroup;
+
+  return (
+    <>
+      {isOpen && (
+        <div
+          onClick={onClose}
+          style={{ position: "fixed", inset: 0, zIndex: 999, backgroundColor: "rgba(0,0,0,0.3)" }}
+        />
+      )}
+      {/*
+        Animate the `right` offset, never `transform: translateX(...)` —
+        `transform` creates a new containing block, which re-anchors
+        CometChat's fixed-positioned popovers (emoji picker, message
+        options, file preview, thread panel) to the drawer instead of
+        the viewport and makes them misalign.
+      */}
+      <div
+        style={{
+          position: "fixed",
+          top: 0,
+          right: isOpen ? 0 : "-720px",  // off-screen by widest width when closed
+          bottom: 0,
+          width: hasSelection ? "720px" : "360px",
+          maxWidth: "100vw",
+          zIndex: 1000,
+          backgroundColor: "var(--cometchat-background-color-01, #fff)",
+          boxShadow: "-4px 0 20px rgba(0,0,0,0.15)",
+          display: "flex",
+          transition: "right 0.3s ease-in-out, width 0.3s ease-in-out",
+        }}
+      >
+        {/* Conversation list */}
+        <div style={{ width: "360px", borderRight: hasSelection ? "1px solid #eee" : "none", display: "flex", flexDirection: "column" }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "8px 12px", borderBottom: "1px solid #eee" }}>
+            <span style={{ fontWeight: 600 }}>Messages</span>
+            <button onClick={onClose} style={{ background: "none", border: "none", fontSize: 18, cursor: "pointer" }} aria-label="Close">&times;</button>
+          </div>
+          <div style={{ flex: 1 }}>
+            <CometChatConversations onItemClick={handleConversationClick} />
+          </div>
+        </div>
+
+        {/* Message view */}
+        {hasSelection && (
+          <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+            {selectedUser && <CometChatMessageHeader user={selectedUser} />}
+            {selectedGroup && <CometChatMessageHeader group={selectedGroup} />}
+            <div style={{ flex: 1, overflow: "hidden" }}>
+              {selectedUser && <CometChatMessageList user={selectedUser} hideReplyInThreadOption />}
+              {selectedGroup && <CometChatMessageList group={selectedGroup} hideReplyInThreadOption />}
+            </div>
+            {selectedUser && <CometChatMessageComposer user={selectedUser} />}
+            {selectedGroup && <CometChatMessageComposer group={selectedGroup} />}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+```
+
+---
+
+## Floating widget
+
+A button-in-the-corner chat overlay. Available on every page of the app
+without a dedicated route. Common for support widgets, helpdesk chat,
+"contact us" overlays.
+
+**When to use:** chat is a secondary concern (not the core product), and
+should be accessible from anywhere without navigating. **When NOT to use:**
+if chat is central to the app, use a route placement instead — widgets
+don't scale to inbox-style usage.
+
+### Steps
+
+#### 1. Create the ChatWidget component
+
+```tsx
+// src/components/ChatWidget.tsx (or components/ChatWidget.tsx in Next.js)
+import { useState } from "react";
+import {
+  CometChatConversations,
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+export default function ChatWidget() {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<CometChat.User | CometChat.Group>();
+
+  function handleConversationClick(conv: CometChat.Conversation) {
+    const entity = conv.getConversationWith();
+    if (entity instanceof CometChat.User || entity instanceof CometChat.Group) {
+      setSelected(entity);
+    }
+  }
+
+  return (
+    <>
+      {/* Floating trigger button — always visible */}
+      <button
+        type="button"
+        aria-label={open ? "Close chat" : "Open chat"}
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          position: "fixed",
+          bottom: 24,
+          right: 24,
+          width: 56,
+          height: 56,
+          borderRadius: "50%",
+          background: "var(--cometchat-primary-color, #6c63ff)",
+          color: "white",
+          border: "none",
+          cursor: "pointer",
+          fontSize: 24,
+          boxShadow: "0 4px 16px rgba(0, 0, 0, 0.15)",
+          zIndex: 9999,
+        }}
+      >
+        {open ? "×" : "💬"}
+      </button>
+
+      {/* Widget panel — overlay, not a full-page drawer */}
+      {open && (
+        <div
+          style={{
+            position: "fixed",
+            bottom: 96,  // leave room for the button
+            right: 24,
+            width: "min(380px, calc(100vw - 48px))",
+            height: "min(600px, calc(100vh - 120px))",
+            background: "var(--cometchat-background-color-01, white)",
+            border: "1px solid var(--cometchat-border-color-light, #eee)",
+            borderRadius: 12,
+            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.2)",
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden",
+            zIndex: 9998,
+          }}
+        >
+          {selected ? (
+            <>
+              <button
+                onClick={() => setSelected(undefined)}
+                style={{ alignSelf: "flex-start", background: "none", border: "none", padding: 12, cursor: "pointer" }}
+              >
+                ← Back
+              </button>
+              {selected instanceof CometChat.User && (
+                <>
+                  <CometChatMessageHeader user={selected} />
+                  <div style={{ flex: 1, overflow: "hidden" }}>
+                    <CometChatMessageList user={selected} hideReplyInThreadOption />
+                  </div>
+                  <CometChatMessageComposer user={selected} />
+                </>
+              )}
+              {selected instanceof CometChat.Group && (
+                <>
+                  <CometChatMessageHeader group={selected} />
+                  <div style={{ flex: 1, overflow: "hidden" }}>
+                    <CometChatMessageList group={selected} hideReplyInThreadOption />
+                  </div>
+                  <CometChatMessageComposer group={selected} />
+                </>
+              )}
+            </>
+          ) : (
+            <CometChatConversations onItemClick={handleConversationClick} />
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+```
+
+**Key points:**
+- Button and panel are both `position: fixed`. `z-index: 9999` / `9998` ensures they float above the app's content but don't conflict with modals (which typically go to `z-index: 10000+`).
+- Width/height clamp against viewport (`min(...)`) so the widget shrinks gracefully on mobile. On screens < 428px you may want to switch to full-screen (`width: 100vw; height: 100vh; bottom: 0; right: 0`) — gate with a `useEffect` + `window.innerWidth` or CSS media query.
+- The panel renders conversation list by default; clicking a conversation swaps to the single-thread view with a back arrow. Mirrors WhatsApp / iMessage widget UX.
+- Wrap everything in `{open && (...)}` rather than animating transforms — the CometChat components subscribe to SDK events on mount, so keeping the panel in the tree when closed wastes resources.
+
+#### 2. Mount at the app root
+
+Where to mount depends on the framework. The widget must be a sibling (not a descendant) of the app's main layout so its fixed positioning escapes any overflow-hidden containers.
+
+| Framework | Mount location |
+|---|---|
+| React (Vite / CRA) | `src/main.tsx` or `src/App.tsx`, sibling of `<Routes>` |
+| Next.js App Router | `app/layout.tsx`, sibling of `{children}` (inside `<body>`, outside any main container with `overflow: hidden`) |
+| Next.js Pages Router | `pages/_app.tsx`, sibling of `<Component />` |
+| React Router | `app/root.tsx` (v7) or wherever `<Outlet />` lives (v6) |
+| Astro | Inside a `client:only="react"` island in `src/layouts/BaseLayout.astro` |
+
+**Example — Next.js App Router:**
+
+```tsx
+// app/layout.tsx
+import ChatWidget from "@/components/ChatWidget";
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        <ChatWidget />
+      </body>
+    </html>
+  );
+}
+```
+
+In the Pages Router and Vite cases, the provider (`CometChatProvider`) must wrap both the app content *and* the widget — otherwise the widget won't have access to the init'd SDK.
+
+#### 3. Conditional rendering per route (optional)
+
+Most apps want to hide the widget on auth pages (login, signup, password reset). Options:
+
+**React Router / Next.js** — use `useLocation()` / `usePathname()`:
+
+```tsx
+// Wrap the export with a router-aware gate
+import { useLocation } from "react-router-dom"; // or `usePathname` in Next.js
+
+export default function ChatWidgetGate() {
+  const pathname = useLocation().pathname;
+  const hiddenOn = ["/login", "/signup", "/forgot-password"];
+  if (hiddenOn.some((p) => pathname.startsWith(p))) return null;
+  return <ChatWidget />;
+}
+```
+
+**Astro** — render the island only on the pages that want it, rather than globally in the layout.
+
+#### 4. Feature toggle via config
+
+Record the choice in `.cometchat/config.json` so the integration skill knows the widget was used:
+
+```bash
+npx @cometchat/skills-cli config save --placement widget --json
+```
+
+**Do not invoke `cometchat add-widget`** — that's a v2 CLI command that writes a template-based widget. v3 skills write the widget directly using the pattern above, so it fits the project's existing code style. `add-widget` is retained only for backward compatibility with v2 integrations.
+
+---
+
+## Embedded placement
+
+Chat embedded directly in an existing page, alongside other content. Common for marketplace product pages, dashboards, or support panels.
+
+### Steps
+
+#### 1. Create a ChatPanel component
+
+The critical thing about embedded placement is the container MUST have an explicit height. CometChat components fill 100% of their container -- if the container has no height constraint, the components either collapse to zero or overflow the page.
+
+```tsx
+// ChatPanel.tsx
+import { useEffect, useState } from "react";
+import {
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+interface ChatPanelProps {
+  targetUserId?: string;
+  targetGroupId?: string;
+  height?: string;       // e.g., "500px", "60vh"
+  conversationMode?: boolean; // Show conversation list instead of single thread
+}
+
+export function ChatPanel({
+  targetUserId,
+  targetGroupId,
+  height = "500px",
+}: ChatPanelProps) {
+  const [user, setUser] = useState<CometChat.User>();
+  const [group, setGroup] = useState<CometChat.Group>();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (targetUserId) {
+      CometChat.getUser(targetUserId)
+        .then((u) => {
+          setUser(u);
+          setGroup(undefined);
+          setLoading(false);
+        })
+        .catch(() => setLoading(false));
+    } else if (targetGroupId) {
+      CometChat.getGroup(targetGroupId)
+        .then((g) => {
+          setUser(undefined);
+          setGroup(g);
+          setLoading(false);
+        })
+        .catch(() => setLoading(false));
+    }
+  }, [targetUserId, targetGroupId]);
+
+  return (
+    <div
+      style={{
+        height,
+        display: "flex",
+        flexDirection: "column",
+        border: "1px solid #eee",
+        borderRadius: "var(--cometchat-border-radius-lg, 8px)",
+        overflow: "hidden",
+      }}
+    >
+      {loading ? (
+        <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
+          Loading chat...
+        </div>
+      ) : (
+        <>
+          {user && <CometChatMessageHeader user={user} />}
+          {group && <CometChatMessageHeader group={group} />}
+          <div style={{ flex: 1, overflow: "hidden" }}>
+            {user && <CometChatMessageList user={user} hideReplyInThreadOption />}
+            {group && <CometChatMessageList group={group} hideReplyInThreadOption />}
+          </div>
+          {user && <CometChatMessageComposer user={user} />}
+          {group && <CometChatMessageComposer group={group} />}
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+#### 2. Find the container in the existing page
+
+**Read the existing page where chat should be embedded.** Understand the layout before adding anything. Common patterns:
+
+- **Product page:** Chat panel below or beside the product description
+- **Dashboard:** Chat panel in a sidebar or a dashboard card
+- **Profile page:** Chat panel as a tab or section
+
+#### 3. Render the panel with a target
+
+Connect the target user/group based on the page's data:
+
+```tsx
+// Example: embedding on a product page
+function ProductPage({ product }) {
+  return (
+    <div style={{ display: "flex", gap: 24 }}>
+      <div style={{ flex: 1 }}>
+        <h1>{product.name}</h1>
+        <p>{product.description}</p>
+        {/* other product content */}
+      </div>
+      <div style={{ width: 400 }}>
+        <h3>Chat with the seller</h3>
+        <ChatPanel
+          targetUserId={product.sellerId}
+          height="500px"
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+#### 4. Conversation-list embedded panel
+
+If you want an embedded panel with a conversation list (not just a single thread), use the multi-conversation composition from `cometchat-components` inside a container with explicit height:
+
+```tsx
+// EmbeddedInbox.tsx
+import { useState } from "react";
+import {
+  CometChatConversations,
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+interface EmbeddedInboxProps {
+  height?: string;
+}
+
+export function EmbeddedInbox({ height = "600px" }: EmbeddedInboxProps) {
+  const [selectedUser, setSelectedUser] = useState<CometChat.User>();
+  const [selectedGroup, setSelectedGroup] = useState<CometChat.Group>();
+
+  function handleConversationClick(conversation: CometChat.Conversation) {
+    const entity = conversation.getConversationWith();
+    if (entity instanceof CometChat.User) {
+      setSelectedUser(entity);
+      setSelectedGroup(undefined);
+    } else if (entity instanceof CometChat.Group) {
+      setSelectedUser(undefined);
+      setSelectedGroup(entity);
+    }
+  }
+
+  return (
+    <div style={{ height, display: "flex", border: "1px solid #eee", borderRadius: 8, overflow: "hidden" }}>
+      <div style={{ width: "300px", borderRight: "1px solid #eee" }}>
+        <CometChatConversations onItemClick={handleConversationClick} />
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        {selectedUser && (
+          <>
+            <CometChatMessageHeader user={selectedUser} />
+            <div style={{ flex: 1, overflow: "hidden" }}>
+              <CometChatMessageList user={selectedUser} hideReplyInThreadOption />
+            </div>
+            <CometChatMessageComposer user={selectedUser} />
+          </>
+        )}
+        {selectedGroup && (
+          <>
+            <CometChatMessageHeader group={selectedGroup} />
+            <div style={{ flex: 1, overflow: "hidden" }}>
+              <CometChatMessageList group={selectedGroup} hideReplyInThreadOption />
+            </div>
+            <CometChatMessageComposer group={selectedGroup} />
+          </>
+        )}
+        {!selectedUser && !selectedGroup && (
+          <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#999" }}>
+            Select a conversation
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## Hard rules
+
+These rules apply to ALL placement patterns. Violating any of them causes integration bugs or destroys the user's existing project.
+
+1. **NEVER replace the project's existing entry file** (`App.tsx`, `page.tsx`, `layout.tsx`, `main.tsx`, etc.) unless the user explicitly chose "demo mode." Replacing the entry file destroys all existing functionality.
+
+2. **ALWAYS read the project's existing files before deciding where to put things.** Do not assume a project structure. Read the router config, the nav component, the layout files. Understand what exists before adding to it.
+
+3. **ALWAYS create new files alongside existing ones.** Do not modify files you do not fully understand. The exceptions are:
+   - The router config (to add a route) -- read it first
+   - The nav component (to add a link) -- read it first
+   - The root CSS file (to add the css-variables.css import) -- read it first
+
+4. **CometChat CSS must be imported exactly once.** Before adding the import, check if it already exists:
+   ```bash
+   grep -r "css-variables.css" src/ app/ pages/ 2>/dev/null
+   ```
+   If it is already imported, do not add a duplicate.
+
+5. **CometChatProvider or init must be at the app root**, not inside a modal/drawer/panel. Re-initializing on every open causes flicker, dropped WebSocket connections, and race conditions.
+
+6. **Every CometChat container must have explicit dimensions.** Components fill 100% of their parent. If the parent has no height, the components collapse to zero. Always set `height`, `min-height`, or use flex/grid layout with a bounded container.
+
+7. **Resolve target users/groups before rendering CometChat components.** Use `CometChat.getUser(uid)` or `CometChat.getGroup(guid)` to get the full `CometChat.User` or `CometChat.Group` object. Do not pass a raw UID string to `user` props -- they expect object instances.
+
+8. **For SSR frameworks, wrap CometChat components appropriately.** See the `cometchat-core` skill, section 5 (SSR safety), for framework-specific patterns.
+
+9. **Every `<CometChatMessageList>` MUST include `hideReplyInThreadOption`** unless the integration also wires a thread panel (`CometChatThreadHeader` + scoped `MessageList` + scoped `MessageComposer` with `parentMessageId`). The kit's default (`false`) puts a "Reply in Thread" entry in the message action menu that silently does nothing when no panel is wired. Drawer, widget, modal, and embed patterns never wire a thread panel, so the prop is mandatory there. Two-pane route patterns (full messenger, social) MAY omit it if-and-only-if they implement the full thread-panel plumbing; otherwise keep it. Writing `<CometChatMessageList user={user} />` without the prop in a drawer or widget is a generation bug — every example in this skill includes it for a reason.
+
+10. **Never animate a CometChat-containing element with `transform`, `translate-*`, or any `transition-transform`.** This includes:
+    - Inline `transform: translateX(...)`, `transform: scale(...)`, etc.
+    - Tailwind utilities `translate-x-*`, `-translate-x-*`, `translate-x-0`, `translate-x-full`, `translate-y-*`, `scale-*`, `rotate-*`, `skew-*`, `transform-*`
+    - `transition-transform`, `motion-safe:translate-*`, `will-change: transform`
+    - `filter`, `perspective`, `backdrop-filter`
+
+    Any of these creates a new containing block for `position: fixed` descendants, which reparents CometChat's fixed-positioned popovers (emoji picker, message options menu, file preview, reactions popover, thread panel) to the animated container instead of the viewport. Animate the `right` / `left` offset instead (inline: `right: isOpen ? 0 : '-420px'`; Tailwind: `right-0` / `right-[-420px]` with `transition-[right]`). See `cometchat-core` § 8 anti-pattern 11 for the full CSS-spec explanation.

--- a/solutions/cometchat-chat/.agents/skills/cometchat-production/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-production/SKILL.md
@@ -1,0 +1,1020 @@
+---
+name: cometchat-production
+description: "Production readiness for CometChat — server-side token auth, user management CRUD, environment hardening, and security checklist. Replaces dev-mode authKey with server-side tokens."
+license: "MIT"
+compatibility: "Node.js >=18; @cometchat/chat-uikit-react ^6; @cometchat/chat-sdk-javascript ^4"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "cometchat production auth token security user-management rest-api"
+---
+
+## Purpose
+
+This skill teaches Claude how to harden a CometChat integration for production. It covers two critical areas:
+
+1. **Token-based authentication** — replacing client-side `authKey` with server-side token generation
+2. **User management** — server-side CRUD for CometChat users (create on signup, update on profile change, delete on account deletion)
+
+The `cometchat-core` skill's provider pattern supports both dev mode (`login(uid)`) and production mode (`loginWithAuthToken(token)`). This skill provides the server-side half: the token endpoint and user management endpoints.
+
+---
+
+## 1. Why production auth matters
+
+In development mode, `CometChatUIKit.login(uid)` uses the `authKey` configured via `UIKitSettingsBuilder.setAuthKey()`. This key is embedded in your client-side JavaScript bundle. Anyone can open browser DevTools, find the auth key, and use it to log in as ANY user in your CometChat app. They can read private messages, send messages as other users, and access every conversation.
+
+Production deployments MUST use server-side token generation. The auth key stays on your server. Clients receive short-lived tokens scoped to a single user. If a token leaks, the blast radius is one user session, not your entire app.
+
+---
+
+## 2. The token auth pattern
+
+The production auth flow has four steps:
+
+1. **Client authenticates with YOUR auth system.** The user logs into your app using your existing login flow (email/password, OAuth, magic link, etc.). This step has nothing to do with CometChat.
+
+2. **Your server calls the CometChat REST API.** After verifying the user's identity, your server makes a POST request to CometChat's token endpoint using the REST API key (a server-only secret). CometChat returns an auth token for that specific user.
+
+3. **Client receives the token.** Your server sends the auth token back to the client in the API response.
+
+4. **Client calls `CometChatUIKit.loginWithAuthToken(token)`.** The CometChat SDK uses the token to establish a session. The auth key NEVER touches the browser.
+
+```
+┌─────────┐     1. Login      ┌──────────┐    2. POST /v3/users/{uid}/auth_tokens    ┌──────────────┐
+│  Client  │ ───────────────→  │  Your    │ ──────────────────────────────────────→    │  CometChat   │
+│ (Browser)│                   │  Server  │ ←──────────────────────────────────────    │  REST API    │
+│          │ ←───────────────  │          │    { authToken: "..." }                    │              │
+│          │  3. auth token    │          │                                            │              │
+│          │                   └──────────┘                                            └──────────────┘
+│          │
+│  4. CometChatUIKit.loginWithAuthToken(token)
+└─────────┘
+```
+
+---
+
+## 3. Server endpoint implementations
+
+Each endpoint does the same thing:
+1. Receives a user UID (from the authenticated session, NOT from the request body in production)
+2. Validates that the caller is authenticated
+3. POSTs to `https://{APP_ID}.api-{REGION}.cometchat.io/v3/users/{uid}/auth_tokens`
+4. Returns the auth token to the client
+
+The CometChat REST API requires two headers:
+- `appId` — your CometChat app ID
+- `apiKey` — a **REST API Key** (NOT the Auth Key used in dev mode)
+
+**Auth Key vs REST API Key — these are different keys:**
+
+| Key type | Where to find | Purpose | Security |
+|---|---|---|---|
+| **Auth Key** | Dashboard → Your App → API & Auth Keys → "Auth Keys" table | Client-side SDK: `CometChatUIKit.login(uid)` in dev mode | Exposed in browser. Dev only. |
+| **REST API Key** | Dashboard → Your App → API & Auth Keys → "Rest API Keys" table | Server-to-server: token generation, user CRUD, message send | Server only. Never expose to client. |
+
+The `.env` should have both for production:
+```env
+# Client-side (prefixed for the framework)
+VITE_COMETCHAT_APP_ID=your_app_id
+VITE_COMETCHAT_REGION=us
+
+# Server-side (no prefix — never exposed to the client)
+COMETCHAT_APP_ID=your_app_id
+COMETCHAT_REGION=us
+COMETCHAT_REST_API_KEY=your_rest_api_key
+```
+
+If the user only has an Auth Key, tell them to create a REST API Key in the dashboard: **API & Auth Keys → Rest API Keys → Add Key.**
+
+### Next.js App Router
+
+`app/api/cometchat-token/route.ts`
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+
+const APP_ID = process.env.COMETCHAT_APP_ID!;
+const REGION = process.env.COMETCHAT_REGION!;
+const REST_API_KEY = process.env.COMETCHAT_REST_API_KEY!;
+
+export async function POST(request: NextRequest) {
+  // TODO: Replace this with your real auth check.
+  // Example with NextAuth: const session = await getServerSession(authOptions);
+  // Example with Clerk: const { userId } = auth();
+  // If not authenticated, return 401.
+  const body = await request.json();
+  const uid = body.uid as string;
+
+  if (!uid || typeof uid !== "string") {
+    return NextResponse.json({ error: "Missing uid" }, { status: 400 });
+  }
+
+  // In production, derive UID from the authenticated session, not from
+  // the request body. The body approach is shown here as a starting point.
+  // Example: const uid = session.user.id;
+
+  const response = await fetch(
+    `https://${APP_ID}.api-${REGION}.cometchat.io/v3/users/${encodeURIComponent(uid)}/auth_tokens`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        appId: APP_ID,
+        apiKey: REST_API_KEY,
+      },
+      body: JSON.stringify({}),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    console.error("CometChat token error:", error);
+    return NextResponse.json(
+      { error: "Failed to generate auth token" },
+      { status: response.status }
+    );
+  }
+
+  const data = await response.json();
+  return NextResponse.json({ authToken: data.data.authToken });
+}
+```
+
+### Next.js Pages Router
+
+`pages/api/cometchat-token.ts`
+
+```typescript
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const APP_ID = process.env.COMETCHAT_APP_ID!;
+const REGION = process.env.COMETCHAT_REGION!;
+const REST_API_KEY = process.env.COMETCHAT_REST_API_KEY!;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  // TODO: Replace with your auth check (e.g., getServerSession, Clerk, JWT).
+  const { uid } = req.body;
+
+  if (!uid || typeof uid !== "string") {
+    return res.status(400).json({ error: "Missing uid" });
+  }
+
+  const response = await fetch(
+    `https://${APP_ID}.api-${REGION}.cometchat.io/v3/users/${encodeURIComponent(uid)}/auth_tokens`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        appId: APP_ID,
+        apiKey: REST_API_KEY,
+      },
+      body: JSON.stringify({}),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    console.error("CometChat token error:", error);
+    return res.status(response.status).json({ error: "Failed to generate auth token" });
+  }
+
+  const data = await response.json();
+  return res.status(200).json({ authToken: data.data.authToken });
+}
+```
+
+### React Router v7 (framework mode)
+
+In React Router framework mode, server logic lives in `action` functions within route modules. Create a resource route (no UI) for the token endpoint.
+
+`app/routes/api.cometchat-token.ts`
+
+```typescript
+import type { ActionFunctionArgs } from "react-router";
+
+const APP_ID = process.env.COMETCHAT_APP_ID!;
+const REGION = process.env.COMETCHAT_REGION!;
+const REST_API_KEY = process.env.COMETCHAT_REST_API_KEY!;
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  // TODO: Replace with your auth check (e.g., session cookie, JWT).
+  const body = await request.json();
+  const uid = body.uid as string;
+
+  if (!uid || typeof uid !== "string") {
+    return Response.json({ error: "Missing uid" }, { status: 400 });
+  }
+
+  const response = await fetch(
+    `https://${APP_ID}.api-${REGION}.cometchat.io/v3/users/${encodeURIComponent(uid)}/auth_tokens`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        appId: APP_ID,
+        apiKey: REST_API_KEY,
+      },
+      body: JSON.stringify({}),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    console.error("CometChat token error:", error);
+    return Response.json(
+      { error: "Failed to generate auth token" },
+      { status: response.status }
+    );
+  }
+
+  const data = await response.json();
+  return Response.json({ authToken: data.data.authToken });
+}
+```
+
+Register this route in your `routes.ts` (or `app/routes.ts`):
+
+```typescript
+// Add to your route config:
+route("api/cometchat-token", "routes/api.cometchat-token.ts"),
+```
+
+### Express / Hono standalone (React + Vite projects)
+
+React/Vite projects have no built-in server. You need a separate backend. Here are patterns for the two most common choices.
+
+**Express:**
+
+```typescript
+// server/index.ts (or server.js)
+import express from "express";
+import cors from "cors";
+
+const app = express();
+app.use(cors({ origin: "http://localhost:5173" })); // Your Vite dev server
+app.use(express.json());
+
+const APP_ID = process.env.COMETCHAT_APP_ID!;
+const REGION = process.env.COMETCHAT_REGION!;
+const REST_API_KEY = process.env.COMETCHAT_REST_API_KEY!;
+
+app.post("/api/cometchat-token", async (req, res) => {
+  // TODO: Replace with your auth check.
+  const { uid } = req.body;
+
+  if (!uid || typeof uid !== "string") {
+    return res.status(400).json({ error: "Missing uid" });
+  }
+
+  const response = await fetch(
+    `https://${APP_ID}.api-${REGION}.cometchat.io/v3/users/${encodeURIComponent(uid)}/auth_tokens`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        appId: APP_ID,
+        apiKey: REST_API_KEY,
+      },
+      body: JSON.stringify({}),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    console.error("CometChat token error:", error);
+    return res.status(response.status).json({ error: "Failed to generate auth token" });
+  }
+
+  const data = await response.json();
+  return res.json({ authToken: data.data.authToken });
+});
+
+app.listen(3001, () => console.log("Server running on :3001"));
+```
+
+**Hono:**
+
+```typescript
+// server/index.ts
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { serve } from "@hono/node-server";
+
+const app = new Hono();
+app.use("/*", cors({ origin: "http://localhost:5173" }));
+
+const APP_ID = process.env.COMETCHAT_APP_ID!;
+const REGION = process.env.COMETCHAT_REGION!;
+const REST_API_KEY = process.env.COMETCHAT_REST_API_KEY!;
+
+app.post("/api/cometchat-token", async (c) => {
+  // TODO: Replace with your auth check.
+  const { uid } = await c.req.json();
+
+  if (!uid || typeof uid !== "string") {
+    return c.json({ error: "Missing uid" }, 400);
+  }
+
+  const response = await fetch(
+    `https://${APP_ID}.api-${REGION}.cometchat.io/v3/users/${encodeURIComponent(uid)}/auth_tokens`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        appId: APP_ID,
+        apiKey: REST_API_KEY,
+      },
+      body: JSON.stringify({}),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    console.error("CometChat token error:", error);
+    return c.json({ error: "Failed to generate auth token" }, { status: response.status });
+  }
+
+  const data = await response.json();
+  return c.json({ authToken: data.data.authToken });
+});
+
+serve({ fetch: app.fetch, port: 3001 });
+```
+
+### Astro
+
+`src/pages/api/cometchat-token.ts`
+
+Astro SSR endpoints work in hybrid or server mode. Make sure your `astro.config.mjs` has `output: "server"` or `output: "hybrid"`.
+
+```typescript
+import type { APIRoute } from "astro";
+
+const APP_ID = import.meta.env.COMETCHAT_APP_ID;
+const REGION = import.meta.env.COMETCHAT_REGION;
+const REST_API_KEY = import.meta.env.COMETCHAT_REST_API_KEY;
+
+export const POST: APIRoute = async ({ request }) => {
+  // TODO: Replace with your auth check (e.g., session cookie, Astro middleware).
+  const body = await request.json();
+  const uid = body.uid as string;
+
+  if (!uid || typeof uid !== "string") {
+    return new Response(JSON.stringify({ error: "Missing uid" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const response = await fetch(
+    `https://${APP_ID}.api-${REGION}.cometchat.io/v3/users/${encodeURIComponent(uid)}/auth_tokens`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        appId: APP_ID,
+        apiKey: REST_API_KEY,
+      },
+      body: JSON.stringify({}),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    console.error("CometChat token error:", error);
+    return new Response(
+      JSON.stringify({ error: "Failed to generate auth token" }),
+      { status: response.status, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const data = await response.json();
+  return new Response(JSON.stringify({ authToken: data.data.authToken }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+```
+
+---
+
+## 4. Client-side changes
+
+The `cometchat-core` skill's `CometChatProvider` already supports both `authKey` (dev) and `authToken` (production) props. To switch to production mode:
+
+### Step 1 — Create a hook to fetch the token
+
+```typescript
+// hooks/useCometChatToken.ts
+"use client"; // Required for Next.js App Router; harmless elsewhere
+
+import { useState, useEffect } from "react";
+
+/**
+ * Fetches a CometChat auth token from your server-side endpoint.
+ * Call this after the user is authenticated in your app.
+ */
+export function useCometChatToken(uid: string | null) {
+  const [token, setToken] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!uid) return;
+
+    let cancelled = false;
+    setLoading(true);
+
+    fetch("/api/cometchat-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ uid }),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Token request failed: ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (!cancelled) {
+          setToken(data.authToken);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(String(err));
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [uid]);
+
+  return { token, error, loading };
+}
+```
+
+### Step 2 — Update the CometChatProvider usage
+
+**Before (dev mode):**
+
+```typescript
+<CometChatProvider
+  appId={import.meta.env.VITE_COMETCHAT_APP_ID}
+  region={import.meta.env.VITE_COMETCHAT_REGION}
+  authKey={import.meta.env.VITE_COMETCHAT_AUTH_KEY}
+  uid="cometchat-uid-1"
+>
+  <ChatPage />
+</CometChatProvider>
+```
+
+**After (production mode):**
+
+```typescript
+function ChatWrapper() {
+  // Get the authenticated user's ID from your auth system
+  const { user } = useAuth(); // Your auth hook (NextAuth, Clerk, Supabase, etc.)
+  const { token, error, loading } = useCometChatToken(user?.id ?? null);
+
+  if (!user) return <LoginPage />;
+  if (loading) return <div>Connecting to chat...</div>;
+  if (error) return <div>Chat connection failed: {error}</div>;
+
+  return (
+    <CometChatProvider
+      appId={import.meta.env.VITE_COMETCHAT_APP_ID}
+      region={import.meta.env.VITE_COMETCHAT_REGION}
+      authToken={token!}
+      uid={user.id}
+    >
+      <ChatPage />
+    </CometChatProvider>
+  );
+}
+```
+
+Key changes:
+- Removed `authKey` prop entirely
+- Added `authToken` prop with the token from your server
+- `uid` comes from your auth system, not a hardcoded test user
+- The provider only renders after the token is fetched
+
+### Step 3 — Handle token refresh on 401
+
+CometChat auth tokens expire. When a token expires, SDK calls will fail. Handle this in your provider:
+
+```typescript
+// In your CometChatProvider or a wrapper:
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+// Listen for auth errors
+CometChat.addConnectionListener(
+  "auth-refresh-listener",
+  new CometChat.ConnectionListener({
+    onDisconnected: () => {
+      console.log("CometChat disconnected — token may have expired");
+      // Re-fetch token from your endpoint and call loginWithAuthToken again
+    },
+  })
+);
+```
+
+A simpler approach: if any CometChat operation returns a 401 or auth error, re-fetch the token and call `CometChatUIKit.loginWithAuthToken(newToken)`.
+
+**Guard refresh calls with the same concurrency pattern.** If two components both see a 401 at the same time, two `loginWithAuthToken` calls race and the SDK throws *"Please wait until the previous login request ends."* Route token refresh through the same `ensureLoggedIn(uid, authToken)` helper defined in `cometchat-core`'s provider pattern — the module-level `loginInFlight` promise dedupes concurrent refreshes automatically.
+
+Concrete refresh handler — pair the helper from `cometchat-core` with the connection listener and a token-refetch path:
+
+```typescript
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatUIKit } from "@cometchat/chat-uikit-react";
+
+// Module-level — shared across every refresh attempt.
+// Identical shape to the one in cometchat-core § 2.
+let refreshInFlight: Promise<unknown> | null = null;
+
+async function refreshSession(uid: string): Promise<void> {
+  if (refreshInFlight) {
+    // Another component already triggered a refresh — wait for it,
+    // don't fire a second loginWithAuthToken.
+    await refreshInFlight;
+    return;
+  }
+
+  refreshInFlight = (async () => {
+    // 1. Fetch a fresh token from your server endpoint.
+    //    Your existing useCometChatToken hook (Step 1) calls /api/cometchat-token.
+    //    Extract that fetch into a helper so the refresh path can reuse it.
+    const res = await fetch("/api/cometchat-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ uid }),
+    });
+    if (!res.ok) throw new Error(`Token refresh failed: ${res.status}`);
+    const { token } = (await res.json()) as { token: string };
+
+    // 2. Re-authenticate with the new token. SDK swaps the in-memory
+    //    session — no full reload needed.
+    await CometChatUIKit.loginWithAuthToken(token);
+  })();
+
+  try {
+    await refreshInFlight;
+  } finally {
+    refreshInFlight = null;
+  }
+}
+
+// Wire it into the connection listener so a disconnect triggers refresh.
+CometChat.addConnectionListener(
+  "auth-refresh-listener",
+  new CometChat.ConnectionListener({
+    onDisconnected: () => {
+      const uid = CometChatUIKit.getLoggedInUser()?.getUid();
+      if (uid) {
+        refreshSession(uid).catch((e) => {
+          console.error("CometChat refresh failed; user may need to re-login", e);
+        });
+      }
+    },
+  }),
+);
+```
+
+`refreshInFlight` mirrors `loginInFlight` from `cometchat-core` § 2 — same dedup pattern, separate promise so the initial-login and refresh paths don't accidentally serialize against each other. If the same component renders in StrictMode AND a 401 arrives during the second mount, the listener and the provider effect can both touch the SDK without colliding.
+
+---
+
+## 5. User management patterns
+
+In production, you need to keep CometChat users in sync with your app's users. CometChat users are managed via the REST API using the REST API key (server-only).
+
+### Create user — on signup
+
+When a user signs up for your app, create a corresponding CometChat user.
+
+```typescript
+// Server-side utility function
+async function createCometChatUser(uid: string, name: string, avatar?: string) {
+  const response = await fetch(
+    `https://${APP_ID}.api-${REGION}.cometchat.io/v3/users`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        appId: APP_ID,
+        apiKey: REST_API_KEY,
+      },
+      body: JSON.stringify({
+        uid,
+        name,
+        ...(avatar ? { avatar } : {}),
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json();
+    // If user already exists (409), that's OK — just log it
+    if (response.status === 409) {
+      console.log(`CometChat user ${uid} already exists`);
+      return;
+    }
+    throw new Error(`Failed to create CometChat user: ${JSON.stringify(error)}`);
+  }
+}
+```
+
+### Update user — on profile change
+
+When a user updates their name or avatar in your app, update the CometChat user.
+
+```typescript
+async function updateCometChatUser(
+  uid: string,
+  updates: { name?: string; avatar?: string; metadata?: Record<string, unknown> }
+) {
+  const response = await fetch(
+    `https://${APP_ID}.api-${REGION}.cometchat.io/v3/users/${encodeURIComponent(uid)}`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        appId: APP_ID,
+        apiKey: REST_API_KEY,
+      },
+      body: JSON.stringify(updates),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(`Failed to update CometChat user: ${JSON.stringify(error)}`);
+  }
+}
+```
+
+### Delete user — on account deletion
+
+When a user deletes their account, delete the CometChat user.
+
+```typescript
+async function deleteCometChatUser(uid: string) {
+  const response = await fetch(
+    `https://${APP_ID}.api-${REGION}.cometchat.io/v3/users/${encodeURIComponent(uid)}`,
+    {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        appId: APP_ID,
+        apiKey: REST_API_KEY,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(`Failed to delete CometChat user: ${JSON.stringify(error)}`);
+  }
+}
+```
+
+### Where to hook user management into common auth providers
+
+**NextAuth (next-auth):**
+
+```typescript
+// app/api/auth/[...nextauth]/route.ts or pages/api/auth/[...nextauth].ts
+import NextAuth from "next-auth";
+
+export default NextAuth({
+  // ... your providers ...
+  events: {
+    createUser: async ({ user }) => {
+      await createCometChatUser(user.id, user.name ?? user.email ?? "User");
+    },
+    // Note: NextAuth doesn't have a deleteUser event by default.
+    // Handle deletion in your account deletion endpoint.
+  },
+});
+```
+
+**Clerk:**
+
+```typescript
+// Clerk webhook handler — app/api/webhooks/clerk/route.ts
+import { NextResponse } from "next/server";
+import { Webhook } from "svix";
+
+export async function POST(req: Request) {
+  const body = await req.text();
+  // Verify webhook signature with svix (see Clerk docs)
+
+  const event = JSON.parse(body);
+
+  switch (event.type) {
+    case "user.created":
+      await createCometChatUser(
+        event.data.id,
+        `${event.data.first_name} ${event.data.last_name}`.trim(),
+        event.data.image_url
+      );
+      break;
+    case "user.updated":
+      await updateCometChatUser(event.data.id, {
+        name: `${event.data.first_name} ${event.data.last_name}`.trim(),
+        avatar: event.data.image_url,
+      });
+      break;
+    case "user.deleted":
+      await deleteCometChatUser(event.data.id);
+      break;
+  }
+
+  return NextResponse.json({ received: true });
+}
+```
+
+**Supabase Auth:**
+
+```typescript
+// Supabase Edge Function or webhook handler
+// Supabase fires webhooks on auth events via Database Webhooks
+// pointing at the auth.users table.
+
+// In a Next.js API route triggered by Supabase webhook:
+export async function POST(req: Request) {
+  const { type, record } = await req.json();
+
+  if (type === "INSERT") {
+    await createCometChatUser(
+      record.id,
+      record.raw_user_meta_data?.full_name ?? record.email ?? "User",
+      record.raw_user_meta_data?.avatar_url
+    );
+  } else if (type === "UPDATE") {
+    await updateCometChatUser(record.id, {
+      name: record.raw_user_meta_data?.full_name,
+      avatar: record.raw_user_meta_data?.avatar_url,
+    });
+  } else if (type === "DELETE") {
+    await deleteCometChatUser(record.id);
+  }
+
+  return new Response("OK");
+}
+```
+
+**Firebase Auth:**
+
+```typescript
+// Firebase Cloud Function triggered by auth events
+import * as functions from "firebase-functions";
+
+export const onUserCreated = functions.auth.user().onCreate(async (user) => {
+  await createCometChatUser(
+    user.uid,
+    user.displayName ?? user.email ?? "User",
+    user.photoURL ?? undefined
+  );
+});
+
+export const onUserDeleted = functions.auth.user().onDelete(async (user) => {
+  await deleteCometChatUser(user.uid);
+});
+
+// For profile updates, call updateCometChatUser from your
+// profile update endpoint — Firebase Auth doesn't fire a
+// Cloud Function on profile changes.
+```
+
+---
+
+## 6. Environment variables
+
+### Production environment variables
+
+| Variable | Where | Description |
+|---|---|---|
+| `COMETCHAT_APP_ID` | Server + Client | Your app ID. Client-side copies use the framework prefix (`NEXT_PUBLIC_`, `VITE_`, `PUBLIC_`). |
+| `COMETCHAT_REGION` | Server + Client | Region code: `us`, `eu`, `in`. Client-side copies use the framework prefix. |
+| `COMETCHAT_REST_API_KEY` | SERVER ONLY | The REST API key from your CometChat dashboard. Used for token generation and user management. |
+| `COMETCHAT_AUTH_KEY` | REMOVE in production | The auth key used in dev mode. Remove it from `.env` in production. |
+
+### Critical: REST API key must be server-only
+
+The REST API key grants full access to your CometChat app: creating users, generating tokens, deleting messages, managing groups. It MUST stay on the server.
+
+**NEVER prefix it with:**
+- `NEXT_PUBLIC_` (Next.js)
+- `VITE_` (Vite / React Router)
+- `PUBLIC_` (Astro)
+- `REACT_APP_` (Create React App)
+
+Any of these prefixes will bundle the key into your client-side JavaScript, exposing it to every visitor.
+
+### Example .env file (production)
+
+```bash
+# Client-side (with framework prefix)
+NEXT_PUBLIC_COMETCHAT_APP_ID=your-app-id
+NEXT_PUBLIC_COMETCHAT_REGION=us
+
+# Server-side ONLY (no prefix)
+COMETCHAT_APP_ID=your-app-id
+COMETCHAT_REGION=us
+COMETCHAT_REST_API_KEY=your-rest-api-key
+
+# REMOVED — do not include in production:
+# NEXT_PUBLIC_COMETCHAT_AUTH_KEY=...
+```
+
+### Finding the REST API key
+
+1. Go to [app.cometchat.com](https://app.cometchat.com)
+2. Select your app
+3. Navigate to **API & Auth Keys**
+4. Copy the **REST API Key** (it is different from the Auth Key)
+
+---
+
+## 7. Security checklist
+
+Before deploying to production, verify every item:
+
+- [ ] **Auth key removed from client-side env vars.** No `NEXT_PUBLIC_COMETCHAT_AUTH_KEY`, `VITE_COMETCHAT_AUTH_KEY`, or `PUBLIC_COMETCHAT_AUTH_KEY` in your `.env` file.
+
+- [ ] **REST API key is server-only.** The `COMETCHAT_REST_API_KEY` variable has NO framework prefix (`NEXT_PUBLIC_`, `VITE_`, `PUBLIC_`, `REACT_APP_`).
+
+- [ ] **Token endpoint validates the caller's identity.** The `/api/cometchat-token` endpoint checks that the request comes from an authenticated user (session cookie, JWT, etc.) before issuing a token. The example code includes `TODO` comments where you add this check.
+
+- [ ] **UID comes from the session, not the request.** In production, the token endpoint should derive the user's UID from the authenticated session, not from the request body. This prevents users from requesting tokens for other users.
+
+- [ ] **CORS configured.** If the token endpoint runs on a different origin than the frontend (e.g., Express on port 3001, Vite on port 5173), configure CORS to allow only your frontend origin.
+
+- [ ] **Rate limiting on the token endpoint.** Add rate limiting to prevent abuse. Most frameworks have middleware for this (e.g., `express-rate-limit`, Next.js middleware, Astro middleware).
+
+- [ ] **User management endpoints are authenticated.** The create/update/delete user endpoints must verify that the caller has permission to perform the operation (admin role, webhook signature, etc.).
+
+- [ ] **UIKitSettingsBuilder does NOT call `.setAuthKey()`.** In production, remove the `setAuthKey()` call entirely. The builder should only have `setAppId()` and `setRegion()`.
+
+---
+
+## 8. Rate limits and retry
+
+CometChat's REST API enforces per-app rate limits on the token and user-management endpoints. When limits are exceeded, the API returns **HTTP 429** with a `Retry-After` header (in seconds). Your server code should handle this gracefully — without retry logic, a burst of simultaneous logins on app startup can fail silently.
+
+### What to retry, and what not to
+
+**Retry these:**
+- `429 Too Many Requests` — rate limit hit, back off and retry
+- `502 / 503 / 504` — transient upstream failures (gateway, unavailable, timeout)
+- Network errors (`ECONNRESET`, `ETIMEDOUT`) — local/transport issues
+
+**Do NOT retry these:**
+- `400 Bad Request` — malformed payload, retry will fail identically
+- `401 Unauthorized` / `403 Forbidden` — wrong API key or missing permissions, retry can't help
+- `404 Not Found` — wrong endpoint or user/group doesn't exist
+
+### Exponential backoff pattern
+
+The minimum useful retry is exponential backoff with a cap and full jitter. The pattern below works in any Node.js / Edge runtime (Next.js API routes, Astro endpoints, Hono, Express):
+
+```typescript
+interface RetryOptions {
+  maxAttempts?: number;   // default 3 (initial + 2 retries)
+  baseDelayMs?: number;   // default 500ms
+  maxDelayMs?: number;    // default 8000ms (cap)
+}
+
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  opts: RetryOptions = {},
+): Promise<Response> {
+  const { maxAttempts = 3, baseDelayMs = 500, maxDelayMs = 8000 } = opts;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const res = await fetch(url, init);
+
+      // Retry 429 and 5xx (except 501/505 — those are protocol-level, not transient)
+      if (res.status === 429 || (res.status >= 500 && res.status !== 501 && res.status !== 505)) {
+        if (attempt === maxAttempts) return res; // give up, return the failed response
+
+        // Prefer Retry-After header when present; otherwise exponential backoff
+        const retryAfter = res.headers.get("Retry-After");
+        const delayMs = retryAfter
+          ? Math.min(parseInt(retryAfter, 10) * 1000, maxDelayMs)
+          : Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+        const jitter = Math.random() * delayMs * 0.3;  // ±30% full jitter
+        await new Promise((resolve) => setTimeout(resolve, delayMs + jitter));
+        continue;
+      }
+      return res;
+    } catch (err) {
+      lastError = err;
+      if (attempt === maxAttempts) throw err;
+      const delayMs = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastError;
+}
+```
+
+### Wire it into the token endpoint
+
+Replace the bare `fetch` in Section 3's patterns with `fetchWithRetry`:
+
+```typescript
+// Before
+const response = await fetch(
+  `https://${COMETCHAT_APP_ID}.api-${COMETCHAT_REGION}.cometchat.io/v3/users/${uid}/auth_tokens`,
+  { method: "POST", headers: { ...headers } },
+);
+
+// After
+const response = await fetchWithRetry(
+  `https://${COMETCHAT_APP_ID}.api-${COMETCHAT_REGION}.cometchat.io/v3/users/${uid}/auth_tokens`,
+  { method: "POST", headers: { ...headers } },
+  { maxAttempts: 3, baseDelayMs: 500, maxDelayMs: 4000 },
+);
+```
+
+The same wrapper applies to user-management endpoints (create/update/delete) and any other CometChat REST call.
+
+### Logging without leaking
+
+When logging retry attempts for observability, **never log the request headers as-is** — the `apiKey` and `appId` headers contain secrets. Safe shape:
+
+```typescript
+console.warn("CometChat API rate-limited", {
+  url: url.replace(/\/users\/[^/]+\/auth_tokens/, "/users/<redacted>/auth_tokens"),
+  status: res.status,
+  attempt,
+  retryAfter: res.headers.get("Retry-After"),
+});
+```
+
+Log the URL path, status, attempt number, and `Retry-After` — never the UID (user identifier), the API key, or the auth token.
+
+### Circuit breaker (for high-traffic endpoints)
+
+If you're behind a load balancer with many parallel requests, a simple backoff isn't enough — every process independently retries, amplifying the pressure. For those setups, add a circuit breaker (e.g. `opossum` for Node.js) around `fetchWithRetry` so repeated failures stop traffic to CometChat for a cooldown window instead of continuing to hammer it.
+
+**Don't prematurely add a circuit breaker** — it's only worth it once you have production metrics showing sustained 429s under normal load.
+
+---
+
+## 9. CLI complement
+
+The CLI has `production-auth` and `add-user-mgmt` commands that can scaffold the token endpoint and user management routes for supported frameworks:
+
+```bash
+npx @cometchat/skills-cli production-auth --json
+npx @cometchat/skills-cli add-user-mgmt --json
+```
+
+These commands:
+- Read `.cometchat/state.json` to detect the framework
+- Create the API route file from a template
+- Auto-patch the client login flow (replacing `CometChatUIKit.login(uid)` with `loginWithAuthToken`)
+- Update the integration state
+
+**Supported frameworks:** Next.js, React Router (framework mode), Astro.
+
+**Not supported:** React/Vite (no built-in server). For React/Vite projects, use the Express or Hono patterns in Section 3 of this skill.
+
+The CLI templates are a starting point. This skill's patterns are more complete (they cover more frameworks, show auth provider integration, and include the security checklist). Use the CLI for scaffolding, then refer to this skill for the full picture.
+
+---
+
+## 10. Common mistakes
+
+1. **Using the Auth Key instead of the REST API Key on the server.** The Auth Key (`setAuthKey()`) is for client-side dev mode. The REST API Key is for server-side API calls. They are different keys with different permissions.
+
+2. **Exposing the REST API Key to the client.** Adding `NEXT_PUBLIC_` or `VITE_` prefix to the REST API Key variable bundles it into the client. This is worse than exposing the Auth Key because the REST API Key can create and delete users.
+
+3. **Not validating the caller before issuing tokens.** If your token endpoint accepts any UID without checking the caller's identity, anyone can request tokens for any user. Always validate the session first.
+
+4. **Forgetting to create CometChat users.** If you use token auth but never create the CometChat user via the REST API, `loginWithAuthToken` will fail with "User not found." Always create the CometChat user when the app user signs up.
+
+5. **Hardcoding UIDs in production.** The example code uses `"cometchat-uid-1"` as a placeholder. In production, the UID must come from your authentication system.

--- a/solutions/cometchat-chat/.agents/skills/cometchat-react-patterns/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-react-patterns/SKILL.md
@@ -1,0 +1,527 @@
+---
+name: cometchat-react-patterns
+description: "Framework-specific patterns for integrating CometChat React UI Kit v6 into React projects (Vite or CRA). Covers provider setup, routing, layout integration, env vars, and common pitfalls."
+license: "MIT"
+compatibility: "Node.js >=18; React >=18; Vite >=4 or react-scripts (CRA); @cometchat/chat-uikit-react ^6; @cometchat/chat-sdk-javascript ^4"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "chat cometchat react vite cra patterns provider routing integration"
+---
+
+## Purpose
+
+This skill teaches Claude how to integrate CometChat into a React project that uses Vite or Create React App. These are client-only environments with no SSR, which simplifies integration significantly.
+
+**Read these companion skills first:**
+- `cometchat-core` -- initialization, login, CSS, provider pattern, anti-patterns
+- `cometchat-components` -- component catalog and composition patterns
+- `cometchat-placement` -- WHERE to put chat (route, modal, drawer, embedded)
+
+This skill covers the HOW for React specifically: project detection, provider wiring, routing patterns, env var conventions, and React-specific gotchas.
+
+---
+
+## 1. Project detection
+
+A project is a plain React project (not a meta-framework) when `package.json` has `react` and ONE of these bundlers, but NONE of the framework packages:
+
+**Bundler indicators (must have one):**
+- `vite` in `devDependencies` (Vite project)
+- `react-scripts` in `dependencies` (Create React App)
+
+**Framework exclusions (must have none):**
+- `next` -- use the `cometchat-nextjs-patterns` skill instead
+- `astro` -- use the `cometchat-astro-patterns` skill instead
+- `@remix-run/react` or `react-router` (v7 with `react-router.config.ts`) -- use the `cometchat-react-router-patterns` skill instead
+
+**Edge case:** If `react-router-dom` is present but `next`, `astro`, and `@remix-run/react` are absent, this IS a plain React project that uses React Router as a library. This skill applies.
+
+**Detection code:**
+
+```bash
+# Quick check from the project root
+cat package.json | grep -E '"(vite|react-scripts|next|astro|@remix-run)"'
+```
+
+---
+
+## 2. CometChatProvider for React
+
+React (Vite/CRA) is client-only, so there are no SSR concerns. The provider can be simple.
+
+### Full implementation
+
+```tsx
+// src/providers/CometChatProvider.tsx
+import React, { useEffect, useState, createContext, useContext } from "react";
+import { CometChatUIKit, UIKitSettingsBuilder } from "@cometchat/chat-uikit-react";
+
+interface CometChatContextValue {
+  isReady: boolean;
+  error: string | null;
+}
+
+const CometChatContext = createContext<CometChatContextValue>({
+  isReady: false,
+  error: null,
+});
+
+export const useCometChat = () => useContext(CometChatContext);
+
+// Module-level state prevents both double-init AND double-login in React
+// StrictMode. StrictMode mounts, unmounts, and remounts in development,
+// which fires useEffect twice. Without guards, init runs twice (duplicate
+// WebSocket connections) and login() is called a second time while the
+// first is still in flight, which makes the SDK throw
+// "Please wait until the previous login request ends."
+let initialized = false;
+let loginInFlight: Promise<unknown> | null = null;
+
+async function ensureLoggedIn(
+  uid: string,
+  authToken?: string,
+): Promise<void> {
+  const existing = await CometChatUIKit.getLoggedinUser();
+  if (existing) return;
+  if (loginInFlight) {
+    await loginInFlight;  // a prior mount already started login — reuse its promise
+    return;
+  }
+  loginInFlight = authToken
+    ? CometChatUIKit.loginWithAuthToken(authToken)
+    : CometChatUIKit.login(uid);
+  try {
+    await loginInFlight;
+  } finally {
+    loginInFlight = null;
+  }
+}
+
+interface CometChatProviderProps {
+  children: React.ReactNode;
+}
+
+export function CometChatProvider({ children }: CometChatProviderProps) {
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function setup() {
+      try {
+        if (!initialized) {
+          initialized = true;
+
+          const settings = new UIKitSettingsBuilder()
+            .setAppId(import.meta.env.VITE_COMETCHAT_APP_ID)
+            .setRegion(import.meta.env.VITE_COMETCHAT_REGION)
+            .setAuthKey(import.meta.env.VITE_COMETCHAT_AUTH_KEY)
+            .subscribePresenceForAllUsers()
+            .build();
+
+          await CometChatUIKit.init(settings);
+        }
+
+        await ensureLoggedIn("cometchat-uid-1"); // DEVELOPMENT ONLY — see cometchat-production skill
+
+        setIsReady(true);
+      } catch (e) {
+        setError(String(e));
+      }
+    }
+
+    setup();
+  }, []);
+
+  if (error) {
+    return (
+      <div style={{ color: "red", padding: 16, fontFamily: "monospace" }}>
+        CometChat Error: {error}
+      </div>
+    );
+  }
+
+  if (!isReady) return null;
+
+  return (
+    <CometChatContext.Provider value={{ isReady, error }}>
+      {children}
+    </CometChatContext.Provider>
+  );
+}
+```
+
+### Where to mount
+
+Mount `CometChatProvider` in the app's entry point, wrapping either the entire app or the router:
+
+```tsx
+// src/main.tsx (Vite)
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import { CometChatProvider } from "./providers/CometChatProvider";
+import "@cometchat/chat-uikit-react/css-variables.css";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <CometChatProvider>
+      <App />
+    </CometChatProvider>
+  </React.StrictMode>
+);
+```
+
+For CRA, the pattern is identical but the file is `src/index.tsx` and uses `createRoot` the same way.
+
+### Production login variant
+
+For production, replace the hardcoded `login("cometchat-uid-1")` with token-based auth. Fetch a token from your backend and use `CometChatUIKit.loginWithAuthToken(token)`. See the `cometchat-core` skill, section 2 (Login), for the full production auth pattern.
+
+---
+
+## 3. Routing integration
+
+React projects handle routing in different ways. Detect which pattern the project uses, then integrate accordingly.
+
+### How to detect the routing pattern
+
+```bash
+# Check for React Router
+grep -r "react-router-dom" package.json
+# Check for router usage patterns
+grep -rn "createBrowserRouter\|BrowserRouter\|<Routes" src/ --include="*.tsx" --include="*.jsx" 2>/dev/null | head -5
+```
+
+### Pattern A: React Router v6 with createBrowserRouter
+
+This is the modern recommended pattern. The router is defined as a data structure.
+
+```tsx
+// src/router.tsx (or wherever the router is defined)
+import { createBrowserRouter } from "react-router-dom";
+import Layout from "./components/Layout";
+import HomePage from "./pages/HomePage";
+import ChatPage from "./pages/ChatPage"; // <-- new
+
+export const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <Layout />,
+    children: [
+      { index: true, element: <HomePage /> },
+      { path: "messages", element: <ChatPage /> }, // <-- add this route
+      // ... existing routes
+    ],
+  },
+]);
+```
+
+### Pattern B: React Router v6 with JSX Routes
+
+Older pattern using `<Routes>` and `<Route>` elements:
+
+```tsx
+// Inside App.tsx or wherever routes are defined
+import { Routes, Route } from "react-router-dom";
+import ChatPage from "./pages/ChatPage";
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Layout />}>
+        <Route index element={<HomePage />} />
+        <Route path="messages" element={<ChatPage />} /> {/* add this */}
+      </Route>
+    </Routes>
+  );
+}
+```
+
+### Pattern C: No router (single-page app)
+
+Some React projects have no router at all. Chat is shown conditionally:
+
+```tsx
+// App.tsx
+import { useState } from "react";
+import ChatPage from "./pages/ChatPage";
+
+function App() {
+  const [showChat, setShowChat] = useState(false);
+
+  if (showChat) {
+    return (
+      <div>
+        <button onClick={() => setShowChat(false)}>Back</button>
+        <ChatPage />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* existing app content */}
+      <button onClick={() => setShowChat(true)}>Open Messages</button>
+    </div>
+  );
+}
+```
+
+For projects without a router, consider suggesting `react-router-dom` if the project has multiple "pages." But do not force it -- some apps are intentionally single-page.
+
+### Full chat page component
+
+See the `cometchat-placement` skill for complete `ChatPage` implementations (two-pane, full messenger, single thread). The page component itself is framework-agnostic -- the React-specific part is only how the route is wired.
+
+---
+
+## 4. Layout integration
+
+### Finding the layout
+
+Read the project's source to find the component that renders the navigation. Common locations:
+
+```bash
+# Find likely layout/nav files
+find src \( -name "*.tsx" -o -name "*.jsx" \) | xargs grep -l "nav\|Nav\|Sidebar\|Header" 2>/dev/null | head -10
+```
+
+Common patterns:
+- `src/App.tsx` with inline nav + `<Outlet />`
+- `src/components/Layout.tsx` wrapping children
+- `src/layouts/MainLayout.tsx` or `src/layouts/AppLayout.tsx`
+- `src/components/Navbar.tsx` or `src/components/Header.tsx`
+
+### Adding a navigation link
+
+Once you find the nav, add a "Messages" link alongside existing links. Match the existing style:
+
+```tsx
+// If the project uses React Router's <Link>:
+import { Link } from "react-router-dom";
+
+// In the nav component, alongside existing links:
+<Link to="/messages">Messages</Link>
+
+// If the project uses React Router's <NavLink> for active styling:
+import { NavLink } from "react-router-dom";
+
+<NavLink to="/messages" className={({ isActive }) => isActive ? "active" : ""}>
+  Messages
+</NavLink>
+```
+
+### Adding a chat drawer/modal trigger
+
+If the placement is a drawer or modal instead of (or in addition to) a route, add a trigger button to the nav:
+
+```tsx
+// In the nav component
+import { useState } from "react";
+import { ChatDrawer } from "../components/ChatDrawer";
+
+function Navbar() {
+  const [showChat, setShowChat] = useState(false);
+
+  return (
+    <nav>
+      {/* existing nav links */}
+      <button onClick={() => setShowChat(true)}>
+        Messages
+      </button>
+      <ChatDrawer isOpen={showChat} onClose={() => setShowChat(false)} />
+    </nav>
+  );
+}
+```
+
+See `cometchat-placement` for the full `ChatDrawer` and `ChatModal` implementations.
+
+---
+
+## 5. Environment variables
+
+### Vite projects
+
+Create a `.env` file in the project root:
+
+```env
+VITE_COMETCHAT_APP_ID=your_app_id_here
+VITE_COMETCHAT_REGION=us
+VITE_COMETCHAT_AUTH_KEY=your_auth_key_here
+```
+
+**Access in code:** `import.meta.env.VITE_COMETCHAT_APP_ID`
+
+Vite only exposes variables prefixed with `VITE_` to client-side code. Variables without this prefix are server-only (available in `vite.config.ts` but not in components).
+
+**Important:** Vite's `.env` is NOT gitignored by default. Add `.env` to `.gitignore`:
+
+```bash
+echo ".env" >> .gitignore
+```
+
+### CRA projects
+
+Create a `.env` file in the project root:
+
+```env
+REACT_APP_COMETCHAT_APP_ID=your_app_id_here
+REACT_APP_COMETCHAT_REGION=us
+REACT_APP_COMETCHAT_AUTH_KEY=your_auth_key_here
+```
+
+**Access in code:** `process.env.REACT_APP_COMETCHAT_APP_ID`
+
+CRA requires the `REACT_APP_` prefix for client-side variables. CRA requires a restart after changing `.env` files (Vite does not).
+
+### TypeScript type hints (Vite only)
+
+For better IDE support, add CometChat env vars to `src/vite-env.d.ts`:
+
+```typescript
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_COMETCHAT_APP_ID: string;
+  readonly VITE_COMETCHAT_REGION: string;
+  readonly VITE_COMETCHAT_AUTH_KEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+```
+
+### Production auth keys
+
+The `AUTH_KEY` is for development only. In production, you need a backend that generates auth tokens. Plain React (Vite/CRA) projects have no built-in server, so you need either:
+- A separate backend (Express, Fastify, etc.)
+- A serverless function (Vercel, Netlify, AWS Lambda)
+- A BaaS like Firebase or Supabase with a Cloud Function
+
+The backend calls CometChat's REST API with your `AUTH_TOKEN` (server-side secret, never exposed to client) to generate per-user auth tokens. See the `cometchat-core` skill, section 2, for the flow.
+
+---
+
+## 6. CSS import
+
+Import CometChat's CSS variables exactly once, at the app root. For React (Vite/CRA), the right place is `src/main.tsx` (or `src/index.tsx` for CRA):
+
+```tsx
+// src/main.tsx
+import "@cometchat/chat-uikit-react/css-variables.css";
+import "./index.css"; // your app's styles AFTER the CometChat import
+```
+
+Alternatively, use a CSS `@import` in your root stylesheet:
+
+```css
+/* src/index.css */
+@import "@cometchat/chat-uikit-react/css-variables.css";
+
+/* your styles below */
+```
+
+### Import order matters
+
+CometChat's `css-variables.css` defines `:root` CSS custom properties. Your overrides must come AFTER this import to take effect:
+
+```css
+/* CORRECT: overrides come after */
+@import "@cometchat/chat-uikit-react/css-variables.css";
+
+:root {
+  --cometchat-primary-color: #6851d6;
+}
+```
+
+```css
+/* WRONG: overrides come before -- they will be overwritten */
+:root {
+  --cometchat-primary-color: #6851d6;
+}
+
+@import "@cometchat/chat-uikit-react/css-variables.css";
+```
+
+---
+
+## 7. Common pitfalls
+
+### StrictMode double-init
+
+React's `StrictMode` (used by default in Vite and CRA development mode) intentionally double-invokes effects. Without the module-level `initialized` flag in the provider, `CometChatUIKit.init()` runs twice. The second call may silently fail or create a second WebSocket connection.
+
+The `initialized` flag in the provider pattern (section 2) handles this. Never remove it. It is not a hack -- it is the correct pattern for one-time SDK initialization in React.
+
+### CSS import duplication
+
+If `css-variables.css` is imported in multiple files (e.g., both `main.tsx` and `ChatPage.tsx`), CSS custom properties are declared twice. This usually works but can cause issues with specificity if the imports are processed in different order by the bundler. Import exactly once at the root.
+
+### Hot Module Replacement (HMR)
+
+Vite's HMR replaces modules without a full page reload. CometChat's SDK holds a WebSocket connection that survives HMR. This is generally fine -- the SDK connection persists and chat keeps working.
+
+However, if you change the provider file itself during development, HMR may re-execute the module. The `initialized` flag prevents double-init, but the WebSocket connection from the previous module instance may linger. If you see duplicate messages or connection issues during development, do a full page reload (`Ctrl+Shift+R`).
+
+### Container height
+
+CometChat components fill 100% of their container. The most common visual bug is components rendering with zero height because their container has no explicit dimensions. Always ensure the chat container has a height:
+
+```tsx
+/* CORRECT: explicit height */
+<div style={{ height: "100vh" }}>
+  <CometChatConversations ... />
+</div>
+
+/* CORRECT: flex layout with bounded parent */
+<div style={{ display: "flex", flexDirection: "column", height: "100vh" }}>
+  <nav>...</nav>
+  <div style={{ flex: 1 }}>
+    <CometChatConversations ... />
+  </div>
+</div>
+
+/* WRONG: no height constraint -- component collapses to zero */
+<div>
+  <CometChatConversations ... />
+</div>
+```
+
+### Vite dependency optimization
+
+Vite pre-bundles dependencies for faster dev startup. CometChat's packages are large and may trigger Vite's "new dependency found, reloading" message on first load. This is normal and only happens once. If it causes issues, you can pre-include the packages:
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  optimizeDeps: {
+    include: [
+      "@cometchat/chat-uikit-react",
+      "@cometchat/chat-sdk-javascript",
+    ],
+  },
+});
+```
+
+---
+
+## 8. Complete integration checklist
+
+When integrating CometChat into a React (Vite/CRA) project, follow these steps in order:
+
+1. Install packages: `npm install @cometchat/chat-uikit-react @cometchat/chat-sdk-javascript`
+2. Create `.env` with `VITE_COMETCHAT_APP_ID`, `VITE_COMETCHAT_REGION`, `VITE_COMETCHAT_AUTH_KEY`
+3. Add `.env` to `.gitignore` if not already there
+4. Import `@cometchat/chat-uikit-react/css-variables.css` in `src/main.tsx`
+5. Create `src/providers/CometChatProvider.tsx` (section 2)
+6. Mount `CometChatProvider` in `src/main.tsx` wrapping `<App />`
+7. Create the chat page component (see `cometchat-placement` for patterns)
+8. Wire the route (section 3) or trigger (section 4)
+9. Add a "Messages" link to the existing nav
+
+**Do not skip step 6.** The provider must wrap the app root so init happens once, regardless of which route or modal opens chat.

--- a/solutions/cometchat-chat/.agents/skills/cometchat-react-router-patterns/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-react-router-patterns/SKILL.md
@@ -1,0 +1,717 @@
+---
+name: cometchat-react-router-patterns
+description: "Framework-specific patterns for integrating CometChat React UI Kit v6 into React Router projects (v6 library mode and v7 framework mode). Covers SSR prevention, routing patterns, outlet nesting, and common pitfalls."
+license: "MIT"
+compatibility: "Node.js >=18; React >=18; react-router-dom ^6 or react-router ^7; @cometchat/chat-uikit-react ^6; @cometchat/chat-sdk-javascript ^4"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "chat cometchat react-router remix routing ssr patterns"
+---
+
+## Purpose
+
+This skill teaches Claude how to integrate CometChat into React Router projects. React Router exists in two distinct modes with very different integration patterns:
+
+- **v6 library mode:** React Router is used as a routing library in a Vite/CRA app. No SSR. Simple.
+- **v7 framework mode:** React Router is a full framework (successor to Remix) with file-system routing, loaders, actions, and SSR. Complex -- similar SSR concerns as Next.js.
+
+**Read these companion skills first:**
+- `cometchat-core` -- initialization, login, CSS, provider pattern, anti-patterns
+- `cometchat-components` -- component catalog and composition patterns
+- `cometchat-placement` -- WHERE to put chat (route, modal, drawer, embedded)
+
+---
+
+## 1. Project detection
+
+### Identifying React Router
+
+```bash
+# Check package.json for React Router
+grep -E '"react-router-dom"|"react-router"' package.json
+```
+
+### Distinguishing v6 library mode from v7 framework mode
+
+```bash
+# v7 framework mode: has a config file
+ls react-router.config.ts react-router.config.js 2>/dev/null
+
+# v6 library mode: uses createBrowserRouter or <BrowserRouter> in source
+grep -rn "createBrowserRouter\|BrowserRouter\|<Routes" src/ --include="*.tsx" --include="*.jsx" 2>/dev/null | head -5
+```
+
+**Decision:**
+- If `react-router.config.ts` or `react-router.config.js` exists: **v7 framework mode**
+- If `react-router-dom` is in `package.json` with `createBrowserRouter` or `<BrowserRouter>` in source: **v6 library mode**
+- If `react-router` (not `react-router-dom`) is in `package.json` without a config file: likely v7 in library mode -- treat as v6 library mode
+
+---
+
+## 2. v6 library mode patterns
+
+v6 library mode is essentially a plain React app with routing. There are no SSR concerns. CometChat integration follows the same patterns as the `cometchat-react-patterns` skill, with routing-specific additions.
+
+### CometChatProvider placement
+
+Mount the provider at the router level, wrapping the entire router or a specific route subtree:
+
+```tsx
+// src/main.tsx
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { RouterProvider } from "react-router-dom";
+import { CometChatProvider } from "./providers/CometChatProvider";
+import { router } from "./router";
+import "@cometchat/chat-uikit-react/css-variables.css";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <CometChatProvider>
+      <RouterProvider router={router} />
+    </CometChatProvider>
+  </React.StrictMode>
+);
+```
+
+The provider implementation is the same as in `cometchat-react-patterns` section 2 -- uses `import.meta.env.VITE_COMETCHAT_*` for env vars.
+
+### Adding a route with createBrowserRouter
+
+Find the router configuration and add a new route:
+
+```tsx
+// src/router.tsx
+import { createBrowserRouter } from "react-router-dom";
+import Layout from "./components/Layout";
+import HomePage from "./pages/HomePage";
+import ChatPage from "./pages/ChatPage";
+
+export const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <Layout />,
+    children: [
+      { index: true, element: <HomePage /> },
+      { path: "messages", element: <ChatPage /> },
+      // ... existing routes
+    ],
+  },
+]);
+```
+
+### Adding a route with JSX Routes
+
+```tsx
+// In App.tsx
+import { Routes, Route } from "react-router-dom";
+import Layout from "./components/Layout";
+import ChatPage from "./pages/ChatPage";
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Layout />}>
+        <Route index element={<HomePage />} />
+        <Route path="messages" element={<ChatPage />} />
+      </Route>
+    </Routes>
+  );
+}
+```
+
+### Nested conversation routes with Outlet
+
+A powerful pattern for React Router: use nested routes to show conversation details alongside the conversation list.
+
+```tsx
+// Router config
+export const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <Layout />,
+    children: [
+      {
+        path: "messages",
+        element: <ChatLayout />,
+        children: [
+          { index: true, element: <EmptyState /> },
+          { path: ":conversationId", element: <ConversationView /> },
+        ],
+      },
+    ],
+  },
+]);
+```
+
+```tsx
+// ChatLayout.tsx -- renders conversation list + Outlet for message view
+import { Outlet } from "react-router-dom";
+import { CometChatConversations } from "@cometchat/chat-uikit-react";
+import { useNavigate } from "react-router-dom";
+
+export default function ChatLayout() {
+  const navigate = useNavigate();
+
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <div style={{ width: "360px", borderRight: "1px solid #eee" }}>
+        <CometChatConversations
+          onItemClick={(conversation) => {
+            const id = conversation.getConversationId();
+            navigate(`/messages/${id}`);
+          }}
+        />
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        <Outlet />
+      </div>
+    </div>
+  );
+}
+```
+
+```tsx
+// ConversationView.tsx -- renders messages for the selected conversation
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import {
+  CometChatMessageHeader,
+  CometChatMessageList,
+  CometChatMessageComposer,
+} from "@cometchat/chat-uikit-react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+export default function ConversationView() {
+  const { conversationId } = useParams();
+  const [user, setUser] = useState<CometChat.User>();
+  const [group, setGroup] = useState<CometChat.Group>();
+
+  useEffect(() => {
+    if (!conversationId) return;
+
+    // Conversation IDs follow the pattern: "user_<uid>" or "group_<guid>"
+    if (conversationId.startsWith("user_")) {
+      const uid = conversationId.replace("user_", "");
+      CometChat.getUser(uid).then((u) => {
+        setUser(u);
+        setGroup(undefined);
+      });
+    } else if (conversationId.startsWith("group_")) {
+      const guid = conversationId.replace("group_", "");
+      CometChat.getGroup(guid).then((g) => {
+        setUser(undefined);
+        setGroup(g);
+      });
+    }
+  }, [conversationId]);
+
+  if (!user && !group) return null;
+
+  return (
+    <>
+      {user && <CometChatMessageHeader user={user} />}
+      {group && <CometChatMessageHeader group={group} />}
+      {user && <CometChatMessageList user={user} />}
+      {group && <CometChatMessageList group={group} />}
+      {user && <CometChatMessageComposer user={user} />}
+      {group && <CometChatMessageComposer group={group} />}
+    </>
+  );
+}
+```
+
+### useNavigate inside CometChat callbacks
+
+CometChat's `onItemClick` callbacks can use React Router's `useNavigate` to drive URL changes:
+
+```tsx
+import { useNavigate } from "react-router-dom";
+
+function ConversationsList() {
+  const navigate = useNavigate();
+
+  return (
+    <CometChatConversations
+      onItemClick={(conversation) => {
+        const entity = conversation.getConversationWith();
+        if (entity instanceof CometChat.User) {
+          navigate(`/messages/user_${entity.getUid()}`);
+        } else if (entity instanceof CometChat.Group) {
+          navigate(`/messages/group_${entity.getGuid()}`);
+        }
+      }}
+    />
+  );
+}
+```
+
+This works because `useNavigate` returns a stable function that CometChat's callback invokes in the browser.
+
+---
+
+## 3. v7 framework mode patterns
+
+React Router v7 in framework mode is a full meta-framework with SSR, file-system routing, loaders, and actions. It has the same SSR concerns as Next.js: CometChat components cannot run on the server.
+
+### SSR prevention
+
+v7 renders components on the server by default. CometChat components will crash during server rendering. Use a `ClientOnly` wrapper:
+
+```tsx
+// app/components/ClientOnly.tsx
+import { useState, useEffect, type ReactNode } from "react";
+
+interface ClientOnlyProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+export function ClientOnly({ children, fallback = null }: ClientOnlyProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return mounted ? <>{children}</> : <>{fallback}</>;
+}
+```
+
+Or use `React.lazy` + `Suspense`:
+
+```tsx
+import { lazy, Suspense } from "react";
+
+const ChatView = lazy(() => import("../components/ChatView"));
+
+export default function MessagesRoute() {
+  return (
+    <ClientOnly fallback={<div>Loading chat...</div>}>
+      <Suspense fallback={<div>Loading chat...</div>}>
+        <ChatView />
+      </Suspense>
+    </ClientOnly>
+  );
+}
+```
+
+### CometChatProvider for v7 framework mode
+
+The provider needs `ClientOnly` wrapping because `useEffect` runs on the client but the module import of `@cometchat/chat-uikit-react` happens on the server too:
+
+```tsx
+// app/providers/CometChatProvider.tsx
+import React, { useEffect, useState, createContext, useContext } from "react";
+
+interface CometChatContextValue {
+  isReady: boolean;
+  error: string | null;
+}
+
+const CometChatContext = createContext<CometChatContextValue>({
+  isReady: false,
+  error: null,
+});
+
+export const useCometChat = () => useContext(CometChatContext);
+
+// Module-level state prevents both double-init AND double-login in React
+// StrictMode. Without the loginInFlight guard, a second mount calls
+// login() while the first is still pending and the SDK throws
+// "Please wait until the previous login request ends."
+let initialized = false;
+let loginInFlight: Promise<unknown> | null = null;
+
+async function ensureLoggedIn(
+  uid: string,
+  authToken?: string,
+): Promise<void> {
+  const existing = await CometChatUIKit.getLoggedinUser();
+  if (existing) return;
+  if (loginInFlight) {
+    await loginInFlight;
+    return;
+  }
+  loginInFlight = authToken
+    ? CometChatUIKit.loginWithAuthToken(authToken)
+    : CometChatUIKit.login(uid);
+  try {
+    await loginInFlight;
+  } finally {
+    loginInFlight = null;
+  }
+}
+
+export function CometChatProvider({ children }: { children: React.ReactNode }) {
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function setup() {
+      try {
+        // Dynamic import to prevent server-side module resolution
+        const { CometChatUIKit, UIKitSettingsBuilder } = await import(
+          "@cometchat/chat-uikit-react"
+        );
+
+        if (!initialized) {
+          initialized = true;
+
+          const settings = new UIKitSettingsBuilder()
+            .setAppId(import.meta.env.VITE_COMETCHAT_APP_ID)
+            .setRegion(import.meta.env.VITE_COMETCHAT_REGION)
+            .setAuthKey(import.meta.env.VITE_COMETCHAT_AUTH_KEY)
+            .subscribePresenceForAllUsers()
+            .build();
+
+          await CometChatUIKit.init(settings);
+        }
+
+        await ensureLoggedIn("cometchat-uid-1"); // DEVELOPMENT ONLY — see cometchat-production skill
+
+        setIsReady(true);
+      } catch (e) {
+        setError(String(e));
+      }
+    }
+
+    setup();
+  }, []);
+
+  if (error) {
+    return (
+      <div style={{ color: "red", padding: 16, fontFamily: "monospace" }}>
+        CometChat Error: {error}
+      </div>
+    );
+  }
+
+  if (!isReady) return null;
+
+  return (
+    <CometChatContext.Provider value={{ isReady, error }}>
+      {children}
+    </CometChatContext.Provider>
+  );
+}
+```
+
+**Key difference from the plain React provider:** The `import("@cometchat/chat-uikit-react")` is done dynamically inside `useEffect`, NOT at the top level. This prevents the server from trying to resolve the module.
+
+### Mount the provider
+
+**Option A — Chat-only app (all routes use CometChat):**
+
+Wrap the entire app. This disables SSR for all routes since `ClientOnly` renders nothing on the server.
+
+```tsx
+// app/root.tsx
+import { Outlet } from "react-router";
+import { ClientOnly } from "./components/ClientOnly";
+import { CometChatProvider } from "./providers/CometChatProvider";
+
+export default function Root() {
+  return (
+    <html lang="en">
+      <body>
+        <ClientOnly>
+          <CometChatProvider>
+            <Outlet />
+          </CometChatProvider>
+        </ClientOnly>
+      </body>
+    </html>
+  );
+}
+```
+
+**Option B — Mixed app (some routes need SSR):**
+
+Keep the root clean and scope CometChat to a layout route. Non-chat routes keep full SSR.
+
+```tsx
+// app/root.tsx — no CometChat here, SSR works normally
+import { Outlet } from "react-router";
+
+export default function Root() {
+  return (
+    <html lang="en">
+      <body>
+        <Outlet />
+      </body>
+    </html>
+  );
+}
+```
+
+```tsx
+// app/routes/chat.tsx — layout route for all /chat/* paths
+import { Outlet } from "react-router";
+import { ClientOnly } from "../components/ClientOnly";
+import { CometChatProvider } from "../providers/CometChatProvider";
+
+export default function ChatLayout() {
+  return (
+    <ClientOnly fallback={<div>Loading chat...</div>}>
+      <CometChatProvider>
+        <Outlet />
+      </CometChatProvider>
+    </ClientOnly>
+  );
+}
+```
+
+Then nest chat routes under this layout (e.g. `app/routes/chat.messages.tsx`). Marketing pages, dashboards, and other non-chat routes render server-side as normal.
+
+**Use Option A** for apps where every page involves chat (messaging apps, social platforms). **Use Option B** for apps that add chat to an existing product (SaaS, marketplaces, support).
+
+### File-system routing
+
+v7 framework mode uses file-based routing. Create a route file:
+
+```tsx
+// app/routes/messages.tsx
+import { lazy, Suspense } from "react";
+import { ClientOnly } from "../components/ClientOnly";
+
+const ChatView = lazy(() => import("../components/ChatView"));
+
+export default function MessagesRoute() {
+  return (
+    <ClientOnly fallback={<div>Loading chat...</div>}>
+      <Suspense fallback={<div>Loading chat...</div>}>
+        <ChatView />
+      </Suspense>
+    </ClientOnly>
+  );
+}
+```
+
+### Loaders and actions
+
+**NEVER put CometChat initialization or SDK calls in a `loader` or `action`.** Loaders and actions run on the server in v7 framework mode. CometChat requires browser APIs.
+
+```tsx
+// WRONG -- loader runs on the server
+export async function loader() {
+  const { CometChat } = await import("@cometchat/chat-sdk-javascript");
+  const user = await CometChat.getUser("uid"); // crashes on server
+  return { user };
+}
+
+// CORRECT -- use clientLoader if you need chat data at route entry
+export async function clientLoader() {
+  const { CometChat } = await import("@cometchat/chat-sdk-javascript");
+  const user = await CometChat.getUser("uid");
+  return { user };
+}
+```
+
+`clientLoader` runs only in the browser. It is the right place for CometChat data fetching at the route level. However, most CometChat integrations do not need loaders at all -- the components handle their own data fetching.
+
+---
+
+## 4. Outlet patterns for nested conversations
+
+This pattern works in both v6 and v7. Chat as a parent route with nested child routes:
+
+```
+/messages                → Conversation list (left pane), empty state (right pane)
+/messages/:conversationId → Conversation list (left pane), messages (right pane)
+```
+
+### v6 route config
+
+```tsx
+{
+  path: "messages",
+  element: <ChatLayout />,
+  children: [
+    { index: true, element: <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#999" }}>Select a conversation</div> },
+    { path: ":conversationId", element: <ConversationView /> },
+  ],
+}
+```
+
+### v7 file-system routes
+
+```
+app/routes/
+  messages.tsx          → ChatLayout (renders <Outlet />)
+  messages._index.tsx   → Empty state
+  messages.$conversationId.tsx → ConversationView
+```
+
+```tsx
+// app/routes/messages.tsx
+import { Outlet } from "react-router";
+import { ClientOnly } from "../components/ClientOnly";
+import { lazy, Suspense } from "react";
+
+const ConversationList = lazy(() => import("../components/ConversationList"));
+
+export default function MessagesLayout() {
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <div style={{ width: "360px", borderRight: "1px solid #eee" }}>
+        <ClientOnly>
+          <Suspense fallback={<div>Loading...</div>}>
+            <ConversationList />
+          </Suspense>
+        </ClientOnly>
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        <Outlet />
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. Environment variables
+
+### v6 library mode (Vite-based)
+
+Same as `cometchat-react-patterns` -- uses `VITE_` prefix:
+
+```env
+VITE_COMETCHAT_APP_ID=your_app_id
+VITE_COMETCHAT_REGION=us
+VITE_COMETCHAT_AUTH_KEY=your_auth_key
+```
+
+Access: `import.meta.env.VITE_COMETCHAT_APP_ID`
+
+### v7 framework mode
+
+Also uses Vite under the hood, so the same `VITE_` prefix applies:
+
+```env
+VITE_COMETCHAT_APP_ID=your_app_id
+VITE_COMETCHAT_REGION=us
+VITE_COMETCHAT_AUTH_KEY=your_auth_key
+```
+
+Server-only variables (for auth token generation in actions) can omit the `VITE_` prefix so they are never exposed to the client bundle:
+
+```env
+COMETCHAT_AUTH_TOKEN=your_server_secret
+```
+
+Access server-only vars in loaders/actions via `process.env`:
+
+```tsx
+// app/routes/api.cometchat-token.tsx (runs server-side only)
+export async function action({ request }: ActionFunctionArgs) {
+  const secret = process.env.COMETCHAT_AUTH_TOKEN;
+  // ...
+}
+```
+
+> **Note:** `process.env` is available in loaders/actions when using the
+> default Node adapter (`@react-router/node`). Other adapters (Cloudflare,
+> Deno) expose env differently — check your adapter's docs.
+
+---
+
+## 6. CSS import
+
+### v6 library mode
+
+Import in `src/main.tsx`:
+
+```tsx
+import "@cometchat/chat-uikit-react/css-variables.css";
+```
+
+### v7 framework mode
+
+Import in `app/root.tsx`:
+
+```tsx
+import "@cometchat/chat-uikit-react/css-variables.css";
+```
+
+Or use the `links` export:
+
+```tsx
+// app/root.tsx
+import cometchatStyles from "@cometchat/chat-uikit-react/css-variables.css?url";
+
+export function links() {
+  return [{ rel: "stylesheet", href: cometchatStyles }];
+}
+```
+
+The `?url` suffix tells Vite to return a URL instead of injecting the CSS, which works with React Router's `links` convention.
+
+---
+
+## 7. Common pitfalls
+
+### Loaders are server-side in v7
+
+The most common mistake in v7 framework mode. Loaders and actions run on the server. Any CometChat code in a loader crashes with `window is not defined`. Use `clientLoader` instead, or handle data fetching in the component.
+
+### v7's unstable_middleware
+
+React Router v7's `unstable_middleware` feature does NOT affect CometChat. CometChat has no middleware requirements. Do not add CometChat-related middleware.
+
+### useNavigate in CometChat callbacks
+
+`useNavigate` works inside CometChat's event callbacks (`onItemClick`, etc.) because these callbacks execute in the browser within the React tree. This is safe:
+
+```tsx
+const navigate = useNavigate();
+
+<CometChatConversations
+  onItemClick={(conv) => navigate(`/messages/${conv.getConversationId()}`)}
+/>
+```
+
+### Don't init in loaders
+
+Even `clientLoader` is not the right place for CometChat initialization. Init should happen once in the provider (app root), not per-route. `clientLoader` is only appropriate for CometChat data queries (like `CometChat.getUser()`) that need to complete before the route renders.
+
+### v6 to v7 migration
+
+If a project is migrating from v6 library mode to v7 framework mode, the CometChat integration must change:
+- Add `ClientOnly` wrapper
+- Move from static imports to dynamic imports for CometChat modules
+- Move from `createBrowserRouter` routes to file-system routes
+- Add SSR guards
+
+Do not mix v6 and v7 patterns. Detect the mode (section 1) and use the correct pattern.
+
+---
+
+## 8. Complete integration checklist (v6 library mode)
+
+1. Install packages: `npm install @cometchat/chat-uikit-react @cometchat/chat-sdk-javascript`
+2. Create `.env` with `VITE_COMETCHAT_APP_ID`, `VITE_COMETCHAT_REGION`, `VITE_COMETCHAT_AUTH_KEY`
+3. Add `.env` to `.gitignore`
+4. Import `@cometchat/chat-uikit-react/css-variables.css` in `src/main.tsx`
+5. Create `src/providers/CometChatProvider.tsx` (uses `import.meta.env.VITE_*`)
+6. Mount `CometChatProvider` in `src/main.tsx` wrapping `<RouterProvider>`
+7. Create `src/pages/ChatPage.tsx` (see `cometchat-placement` for patterns)
+8. Add `{ path: "messages", element: <ChatPage /> }` to the router config
+9. Add a "Messages" link to the layout's nav
+
+## 9. Complete integration checklist (v7 framework mode)
+
+1. Install packages: `npm install @cometchat/chat-uikit-react @cometchat/chat-sdk-javascript`
+2. Create `.env` with `VITE_COMETCHAT_APP_ID`, `VITE_COMETCHAT_REGION`, `VITE_COMETCHAT_AUTH_KEY`
+3. Add `.env` to `.gitignore`
+4. Import `@cometchat/chat-uikit-react/css-variables.css` in `app/root.tsx`
+5. Create `app/components/ClientOnly.tsx` (section 3)
+6. Create `app/providers/CometChatProvider.tsx` with dynamic imports (section 3)
+7. Mount `ClientOnly` + `CometChatProvider` in `app/root.tsx`
+8. Create `app/routes/messages.tsx` with `ClientOnly` + lazy import (section 3)
+9. Add a "Messages" link to the layout's nav
+10. Verify: loaders/actions contain NO CometChat imports

--- a/solutions/cometchat-chat/.agents/skills/cometchat-theming/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-theming/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: cometchat-theming
+description: Customize CometChat UI to match the user's app design system. Covers the CSS variable cascade, preset themes, brand color overrides, design system extraction, dark mode, and framework-specific override locations.
+license: "MIT"
+compatibility: "Node.js >=18; @cometchat/chat-uikit-react ^6; integration must already be applied"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory, grepSearch"
+metadata:
+  author: "CometChat"
+  version: "3.1.0"
+  tags: "cometchat theming css customization branding dark-mode"
+---
+
+> **Companion skills:** `cometchat-core` covers CSS import placement
+> and the one-import rule; `cometchat-customization` covers
+> component-level CSS selectors for deeper overrides;
+> `cometchat-troubleshooting` handles cases where the theme doesn't
+> apply.
+
+## Purpose
+
+Teach Claude how to theme CometChat in a v3 (AI-written) integration.
+Themes are just CSS variable overrides — you write them directly into
+the project's CSS (or, for Astro, the React island file). **Do not use
+the `cometchat apply-theme` CLI command — it was a v2 tool that expects
+a CLI-generated `.cometchat/state.json` marker that v3 integrations
+don't create, and it will fail with "No integration found".**
+
+---
+
+## 1. How CometChat theming works
+
+### The CSS variable cascade
+
+CometChat's entire visual identity is driven by **200+ CSS custom
+properties** defined in `@cometchat/chat-uikit-react/css-variables.css`.
+This file is imported once at the app root (see `cometchat-core`).
+Every `<CometChat*>` component reads these variables — there is no
+component-level style-props API for colors, fonts, or spacing.
+
+To override: write CSS rules that set `--cometchat-*` variables on
+`:root` (or a scoped container), **after** the `css-variables.css`
+import. The cascade does the rest — every component picks up the new
+values automatically.
+
+```css
+/* Must appear AFTER the @import of css-variables.css */
+:root {
+  --cometchat-primary-color: #6C63FF;
+  --cometchat-background-color-01: #FFFFFF;
+  --cometchat-text-color-primary: #141414;
+  --cometchat-font-family: "Inter", sans-serif;
+  --cometchat-radius-2: 8px;
+}
+```
+
+### Dark mode
+
+Two broad strategies — pick based on how the project already handles dark mode.
+
+**Strategy A — OS-driven only** (simplest). Overrides live inside a `@media (prefers-color-scheme: dark)` block. The browser swaps themes based on the user's OS preference:
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root {
+    --cometchat-primary-color: #7B73FF;
+    --cometchat-background-color-01: #1A1A2E;
+    --cometchat-text-color-primary: #E0E0E0;
+    /* ... remaining dark overrides ... */
+  }
+}
+```
+
+**Strategy B — App-controlled theme toggle.** If the project already has a theme toggle (next-themes, Tailwind `dark:` prefix, React Context, etc.), wire CometChat's dark mode to the same trigger. The shared trigger is typically a CSS class or `data-theme` attribute on `<html>` or `<body>`. Scope the override to that selector:
+
+```css
+/* next-themes default: applies a `.dark` class to <html> */
+.dark :root {
+  --cometchat-primary-color: #7B73FF;
+  --cometchat-background-color-01: #1A1A2E;
+  --cometchat-text-color-primary: #E0E0E0;
+}
+
+/* OR if the project uses data-theme="dark" on <html> (common with Tailwind CSS v4) */
+[data-theme="dark"] :root {
+  --cometchat-primary-color: #7B73FF;
+  --cometchat-background-color-01: #1A1A2E;
+  --cometchat-text-color-primary: #E0E0E0;
+}
+
+/* OR for Tailwind's `class` strategy with `darkMode: 'class'` in tailwind.config */
+html.dark {
+  --cometchat-primary-color: #7B73FF;
+  --cometchat-background-color-01: #1A1A2E;
+  --cometchat-text-color-primary: #E0E0E0;
+}
+```
+
+**How to tell which selector the project uses:**
+
+| Library / setup | Selector to target |
+|---|---|
+| `next-themes` (Next.js default) | `.dark` on `<html>` |
+| Tailwind with `darkMode: 'class'` | `html.dark` (or `.dark` on any ancestor) |
+| Tailwind with `darkMode: 'media'` | Matches `@media (prefers-color-scheme: dark)` — use Strategy A |
+| Tailwind CSS v4 (`@custom-variant dark`) | `[data-theme="dark"]` by default |
+| Radix UI / shadcn defaults | `.dark` class on `<html>` |
+| Custom React Context (`useTheme()` hook) | Check what the context writes to the DOM — usually a class on `<html>` or `<body>` |
+
+**Rule:** whichever selector is toggled by the app's theme system, use that same selector as the CometChat override's parent. The UI Kit components sit inside the app's DOM, so they inherit whatever variable values are active at the nearest matching scope.
+
+**Do not** emit both Strategy A and Strategy B in the same stylesheet unless the user explicitly wants "follow OS except when app toggle is set." That's a legitimate pattern but usually over-engineered for a first integration — ship Strategy B alone if the project has a toggle, Strategy A if it doesn't.
+
+### Why Astro is different
+
+Astro's `client:only="react"` islands run in isolation — global
+stylesheets in `.astro` layouts do not cascade into them. CSS variable
+overrides in a global `.css` file will have no effect on CometChat
+components. The overrides must live **inside the React island `.tsx`
+file** (typically `src/cometchat/ChatApp.tsx`), as an inline `<style>`
+tag or a CSS import within the component.
+
+---
+
+## 2. Use this skill when
+
+The user wants to customize the look and feel of an already-integrated
+CometChat UI. Trigger phrases:
+
+- `/cometchat theming`, `/cometchat theme`
+- "match my brand colors"
+- "make cometchat dark mode"
+- "change the chat colors"
+- "customize the cometchat ui"
+- "the chat doesn't match my design system"
+
+## 3. Preconditions
+
+The project must already have a CometChat integration. Check by looking
+for `.cometchat/config.json` and the UI Kit dependency:
+
+```bash
+test -f .cometchat/config.json && cat package.json | grep "@cometchat/chat-uikit-react"
+```
+
+If neither is present, **stop** and tell the user to run `/cometchat`
+to create an integration first. Theming requires the provider +
+`css-variables.css` import to already be in place.
+
+## 4. When to use which path
+
+| Situation | Path |
+|---|---|
+| Complete, opinionated theme fast | **Path A** — Preset |
+| Brand color hex (and optionally font/radius) | **Path B** — Brand color |
+| Existing Tailwind config or CSS custom properties | **Path C** — Design system extraction |
+
+---
+
+## 5. Preset values
+
+Five built-in presets. All values are in the table below — write them
+directly into the override CSS; do **not** try to call a CLI for this.
+
+| Preset | `--cometchat-primary-color` | `--cometchat-text-color-primary` | `--cometchat-background-color-01` | `--cometchat-font-family` | `--cometchat-radius-2` | Dark mode included |
+|---|---|---|---|---|---|---|
+| `slack` | `#611f69` | `#1d1c1d` | `#ffffff` | `Lato, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif` | `8px` | no |
+| `whatsapp` | `#25d366` | `#111b21` | `#f0f2f5` | `'Segoe UI', Helvetica, Arial, sans-serif` | `12px` | no |
+| `imessage` | `#007aff` | `#000000` | `#ffffff` | `-apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif` | `18px` | no |
+| `discord` | `#5865f2` | `#dcddde` | `#36393f` | `'gg sans', 'Noto Sans', Helvetica, Arial, sans-serif` | `8px` | **yes** |
+| `notion` | `#2eaadc` | `#37352f` | `#ffffff` | `-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif` | `6px` | no |
+
+## 6. Where to write the overrides
+
+Target file is determined by `framework` in `.cometchat/config.json`:
+
+| Framework | Target file |
+|---|---|
+| `reactjs` | `src/index.css` (append `:root { ... }` block after the existing import) |
+| `nextjs` | `src/app/globals.css` (App Router) or `styles/globals.css` (Pages Router) |
+| `react-router` | `app/app.css` (or `src/index.css` if you used a Vite-style structure) |
+| `astro` | Inline `<style>` tag or imported CSS **inside** `src/cometchat/ChatApp.tsx` (see section 1 for why) |
+
+The override block must be written **after** the existing
+`@cometchat/chat-uikit-react/css-variables.css` import so it takes
+precedence. If the project imports the CometChat CSS in a TSX file
+(e.g. `src/main.tsx`), the override can still live in the adjacent
+`index.css` because it appears in the DOM after the JS import resolves.
+
+## 7. Steps
+
+### Step 1 — Ask what theme source to use
+
+If the user already specified a preset name, brand color, or pointed
+to a design system file, skip to Step 2.
+
+Otherwise use `AskUserQuestion`:
+- **question:** "How do you want to theme CometChat?"
+- **header:** "Theme"
+- **multiSelect:** false
+- **options:**
+  1. label: "Use a preset", description: "Pick one of: slack, whatsapp, imessage, discord, notion."
+  2. label: "Match my brand", description: "Give me your primary brand color (hex). I'll also ask about font and radius."
+  3. label: "Match my existing design system", description: "Point me at your tailwind.config.{js,ts} or your CSS variables file. I'll extract the tokens."
+
+### Step 2 — Build the override block
+
+**Path A — Preset:** Look up the preset in section 5's table. Emit a
+`:root { ... }` block with those five variables. If the preset's
+`Dark mode included` column is "yes" (currently just `discord`),
+also emit a `@media (prefers-color-scheme: dark) { :root { ... } }`
+block with sensible dark variants (invert background to dark, text to
+light, keep primary).
+
+**Path B — Custom brand color:** The user gave you a hex (e.g.
+`#853953`). Emit at minimum:
+
+```css
+:root {
+  --cometchat-primary-color: #853953;
+}
+```
+
+Then ask if they want:
+- a matching font family (defaults to the project's existing font
+  stack from `body { font-family: ... }` in the project's main CSS)
+- a border radius (defaults to `8px`)
+- dark mode variants
+
+### Step 3 — Read the current CSS file
+
+Read the target file (see section 6) so you can append to it instead
+of overwriting existing rules. Check the file doesn't already have a
+`--cometchat-primary-color` line — if it does, you're updating an
+earlier theming pass; replace that block rather than duplicating.
+
+### Step 4 — Write / update the override block
+
+Use `Edit` to insert or replace the `:root` block. Keep it grouped and
+commented so the user can see where their theme lives:
+
+```css
+/* CometChat theme override — edit these to change the chat UI */
+:root {
+  --cometchat-primary-color: #853953;
+  --cometchat-font-family: "Inter", sans-serif;
+}
+```
+
+**Path C — Design system extraction:** Read
+`tailwind.config.{js,ts}` (look for `theme.colors.primary`,
+`theme.colors.background`, `theme.fontFamily.sans`,
+`theme.borderRadius`) or the project's root CSS file (look for
+`--primary`, `--background`, etc.). Extract the tokens. Then use
+Path B's block shape with the extracted values.
+
+### Step 5 — Save the choice to config
+
+```bash
+npx @cometchat/skills-cli config set theme "<preset-or-custom>"
+```
+
+Where `<preset-or-custom>` is the preset name (e.g. `slack`) or
+`custom` for Path B / Path C.
+
+### Step 6 — Tell the user to restart the dev server
+
+The theme is applied. Tell the user:
+1. Restart the dev server (CSS changes need a fresh reload)
+2. Refresh the chat page
+3. Verify the colors match their design
+
+If the theme doesn't appear to apply:
+- Double-check the override block is **after** the css-variables.css
+  import in the DOM order
+- For Astro: confirm the override is inside the `.tsx` island, not a
+  global `.css` file
+- Route to `cometchat-troubleshooting` for deeper triage.
+
+## 8. Extended variable list (reference)
+
+Beyond the five "headline" variables in the preset table, common ones
+worth knowing:
+
+| Variable | What it controls |
+|---|---|
+| `--cometchat-primary-color` | Active message bubble, primary buttons, brand accents |
+| `--cometchat-text-color-primary` | Main body text |
+| `--cometchat-text-color-secondary` | Timestamps, muted labels |
+| `--cometchat-background-color-01` | Main app background |
+| `--cometchat-background-color-02` | Panels (conversation list, details sidebar) |
+| `--cometchat-background-color-03` | Hover / selected states |
+| `--cometchat-border-color-light` | Dividers between rows |
+| `--cometchat-font-family` | All text |
+| `--cometchat-radius-2` | Medium radius (bubbles, buttons) |
+| `--cometchat-radius-3` | Larger radius (panels) |
+
+For the full 200+ list, query the docs MCP (see below) or read
+`node_modules/@cometchat/chat-uikit-react/dist/styles/css-variables/css-variables.css`.
+
+## 9. Docs MCP contract
+
+The CometChat docs MCP at `cometchat-docs` is the canonical source for:
+
+- The full CSS variable list (200+ tokens) with descriptions
+- Component-level styling selectors (`.cometchat-message-bubble-outgoing`,
+  `.cometchat-conversations-header`, etc.)
+- Dark mode patterns beyond the simple invert
+- Font / radius / spacing token names
+
+**When to use it:**
+- Component-level overrides beyond the 10 tokens above (e.g., "make
+  incoming bubbles green" needs a specific selector) — query the docs
+  MCP. Never invent CSS class names from memory.
+- If the docs MCP is not installed and the user asks for this, tell
+  them: "I need the CometChat docs MCP for component-level styling.
+  Install it with `claude mcp add --transport http cometchat-docs
+  https://www.cometchat.com/docs/mcp` and re-run."
+
+**Canonical reference URL:**
+https://www.cometchat.com/docs/ui-kit/react/theme
+
+## Hard rules
+
+- **Do NOT call `cometchat apply-theme`.** It's a v2 CLI command that
+  requires a CLI-generated `.cometchat/state.json` and fails on v3
+  AI-written integrations. Write CSS directly instead.
+- Never apply theming to a project without an existing CometChat
+  integration (no `.cometchat/config.json` = no integration).
+- Always write theme overrides **after** the css-variables.css import.
+- Never invent CSS variable names. Use the preset table (section 5),
+  the common-variables table (section 8), or query the docs MCP.
+- Never edit `node_modules` or vendor files.
+- Astro is special: theme overrides must live inside the `.tsx`
+  React island file, not a global `.css`.
+- Always use `npx @cometchat/skills-cli` for config saves.

--- a/solutions/cometchat-chat/.agents/skills/cometchat-troubleshooting/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat-troubleshooting/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: cometchat-troubleshooting
+description: Diagnose and fix problems with a CometChat integration. Runs verify checks, detects drift, queries the docs MCP for symptom-to-cause lookups, and proposes targeted fixes. Works on any state — broken, missing, or drifted integrations.
+license: "MIT"
+compatibility: "Node.js >=18; @cometchat/chat-uikit-react ^6"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory, grepSearch"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "cometchat troubleshooting fix diagnose verify drift errors doctor"
+---
+
+> **Companion skills:** `cometchat-core` is the authoritative source for
+> correct init, login, and provider patterns; `cometchat-customization`
+> explains why drift after customization is expected;
+> `cometchat-theming` covers the CSS variable cascade for
+> theme-not-applying symptoms.
+
+## Purpose
+
+This skill teaches Claude how to diagnose CometChat integration problems
+systematically. It explains what each diagnostic tool checks, what the
+known failure modes are and why they happen, and how to distinguish
+infrastructure problems (env vars, dashboard config, network) from code
+problems (wrong init sequence, missing CSS import, drift).
+
+---
+
+## 1. Use this skill when
+
+The user has a problem with their CometChat integration. Trigger phrases:
+
+- `/cometchat troubleshoot`
+- `/cometchat fix`
+- `/cometchat fix <symptom>`
+- "chat isn't loading"
+- "i'm getting a cometchat error"
+- "the chat is broken"
+- "blank screen on /chat"
+- "401 Unauthorized from cometchat"
+- "css-variables not loading"
+- "the chat doesn't show messages"
+
+## 2. Docs MCP contract
+
+The CometChat docs MCP at `cometchat-docs` is a **hard requirement** for
+this skill. `cometchat doctor` handles the local diagnostic checks
+(integration state, drift, env vars, AST verify rules), but for any
+symptom that doesn't match a doctor known-issue code, the MCP is the
+canonical source for symptom → cause → fix.
+
+**Hard rules:**
+
+1. **Always run `cometchat doctor` first** — its known-issues table
+   covers the common failure modes (env-placeholder, env-missing, drift,
+   init-before-login, no-auth-key-in-source).
+2. **For symptoms NOT in doctor's table**, query the docs MCP with the
+   exact error message or symptom keywords. Never guess at the cause.
+3. **If the docs MCP is not installed**, STOP. Tell the user: "Doctor
+   didn't recognize this symptom and I need the CometChat docs MCP to
+   diagnose further. Install it with `claude mcp add --transport http
+   cometchat-docs https://www.cometchat.com/docs/mcp` and re-run."
+4. **Never blame the user's code** if doctor + MCP both pass — the issue
+   is probably infrastructure (network, dashboard config, auth provider).
+5. **Canonical reference URL:**
+   https://www.cometchat.com/docs/ui-kit/react/troubleshooting
+
+---
+
+## 3. What `cometchat doctor` actually checks
+
+Understanding what doctor checks helps you interpret its output and
+know when to look beyond it:
+
+1. **Detection** — reads `.cometchat/state.json` to confirm an
+   integration exists. If absent, reports `integrated: false`.
+
+2. **Env var checks** — reads the framework's env file (`.env` for
+   Vite/Astro/React Router, `.env.local` for Next.js). Checks each
+   `COMETCHAT_*` variable for:
+   - Presence (key exists in the file)
+   - Placeholder sentinels (`YOUR_*_HERE` still present = warning)
+
+3. **AST verify** — parses owned TypeScript files and runs 5 checks:
+   - `css_variables_imported_once` — counts
+     `@cometchat/chat-uikit-react/css-variables.css` imports (must be
+     exactly 1)
+   - `init_before_login` — confirms `login()` call sites appear after
+     `init()` resolves (in a `.then()` chain or after `await`)
+   - `render_gated_on_login_resolve` — checks that `createRoot().render()`
+     or JSX is not called at module top level before init completes
+   - `no_auth_key_in_source` — searches string literals for patterns
+     matching auth key format (should be in `.env`, not source)
+   - `error_ui_visible_on_failure` — confirms that catch handlers set
+     state variables that render visible error UI
+
+4. **Drift detection** — checksums each file in `state.files_owned`
+   against the originally applied template. Reports modified or missing
+   files.
+
+**When to go beyond doctor:** doctor passes but the app still shows a
+blank screen → likely SSR, network, or dashboard config. Doctor only
+checks local code and env files.
+
+---
+
+## 4. Steps
+
+### Step 1 — Triage: read the project state
+
+```bash
+npx @cometchat/skills-cli info --json
+```
+
+Three possible outcomes:
+
+| `info` says | Diagnosis | Next step |
+|---|---|---|
+| `integrated: false` | No integration exists | Check for **partial state** (below). If none, tell user to run `/cometchat` first and stop. |
+| `integrated: true, drift.has_drift: true` | User edited owned files | Step 2 + flag the drift |
+| `integrated: true, drift.has_drift: false` | Clean integration but something is broken | Step 2 |
+
+If drift is detected, surface the modified file list verbatim. **Do not
+automatically offer to restore** — drift after using
+`cometchat-customization` is expected and correct. Ask the user whether
+the changes were intentional before suggesting any restore.
+
+### Step 1a — Partial-state recovery (aborted /cometchat runs)
+
+`info` returning `integrated: false` doesn't always mean the project is
+clean. `/cometchat` may have been started, errored out, or been
+interrupted mid-flow, leaving the project in an inconsistent half-state.
+Check these markers in parallel before offering to re-run from scratch:
+
+```bash
+# All four of these can exist independently after a partial run
+test -f .cometchat/config.json && cat .cometchat/config.json
+grep -l "COMETCHAT_APP_ID" .env .env.local 2>/dev/null
+find src app -name "CometChatProvider.*" -o -name "ChatDrawer.*" 2>/dev/null
+grep -rln "@cometchat/chat-uikit-react" src app 2>/dev/null | head -5
+```
+
+Interpret the combination:
+
+| Markers present | Likely state | Recovery |
+|---|---|---|
+| config.json exists, no `COMETCHAT_APP_ID` in env | Onboarding was started but app provisioning didn't finish | Re-run the provision step only: `npx @cometchat/skills-cli provision setup --app-id <id> --framework <k>` (or `--name <n>` for a new app) |
+| env has credentials, no config.json | Credentials were pasted manually but integration wasn't recorded | Run `npx @cometchat/skills-cli config init --json` to regenerate config.json from detect + env |
+| Provider/drawer files written, no CSS import, no provider mount | Integration code was partially written | Ask user whether to finish the integration (route through `/cometchat` resuming from the plan step) or delete the partial files and start clean |
+| CSS import present, no provider wired | CSS-only leftover from an earlier attempt | Delete the stray `css-variables.css` import or mount the provider — ask user |
+| All four present but `info` still says `integrated: false` | `.cometchat/state.json` was never written — the `/cometchat` flow skipped Step 8 (`state record`), so every Phase B command (`info`, `status`, `doctor`, `verify`, `uninstall`, `apply-theme`, etc.) thinks the project is un-integrated | Run `state record` to rebuild the state.json from what's on disk. Read the list of CometChat files the user has, then: `npx @cometchat/skills-cli state record --framework "<fw>" --placement "<type>" --placement-path "<path>" --auth-mode "<mode>" --files-owned "<new-files>" --files-patched "<patched-files-with-patch-id>" --json`. After this, `info` / `status` / `doctor` all work correctly. |
+
+**Rule:** always show the user which markers you found before proposing a
+recovery path. Never delete config.json, env entries, or source files
+without explicit approval.
+
+### Step 2 — Run verify
+
+```bash
+npx @cometchat/skills-cli verify --json
+```
+
+This runs the AST checks. The output looks like:
+
+```json
+{
+  "status": "fail",
+  "checks": {
+    "css_variables_imported_once": { "status": "fail", "reason": "..." },
+    "init_before_login": { "status": "pass" },
+    ...
+  }
+}
+```
+
+For each failed check, look up the fix in the table below or via the docs MCP.
+
+### Step 3 — Match symptom to known issues
+
+Common doctor issue codes + verify failures and their fixes:
+
+| Issue code / failed check | Likely cause | Fix |
+|---|---|---|
+| `env-placeholder` | CometChat env vars still contain `YOUR_*_HERE` sentinels — user ran integration but never filled in real credentials | Open the env file doctor names (`.env` or `.env.local`) and replace each `YOUR_*_HERE` with the real value from https://app.cometchat.com → Your App → API & Auth Keys. This is the most common post-init failure. |
+| `env-missing` | A required CometChat env var key isn't in the env file at all | Run `cometchat apply --force-overwrite` to re-emit the placeholders, then fill them in. |
+| `drift-modified` | Owned files have been edited since apply | If the user used `cometchat-customization` or hand-edited intentionally, this is **expected** — not a bug. `cometchat info` flags it because the checksum changed. Only offer `cometchat apply --force` if the drift is accidental. **Ask before restoring** — force-apply destroys intentional customizations. |
+| `drift-missing` | An owned file was deleted | Run `cometchat apply --force` to recreate the missing file. |
+| `css_variables_imported_once` (count=0) | The css-variables.css import was removed | Re-add `@import url("@cometchat/chat-uikit-react/css-variables.css");` to the top of `src/index.css` (or the per-framework target). For Astro, it goes inside the .tsx file, not the global CSS. |
+| `css_variables_imported_once` (count>1) | Imported in multiple places | Remove the duplicate. Keep only the one in the canonical location. |
+| `init_before_login` | Code calls `CometChatUIKit.login` before `CometChatUIKit.init` resolves | In the provider pattern (Next.js, Astro, React Router SSR): use `await init(settings)` followed by `await login()` sequentially inside `useEffect`. In the entry-file pattern (Vite/CRA): chain `init(settings).then(() => login()).then(() => mount())`. See `cometchat-core` section 6. |
+| `render_gated_on_login_resolve` | `createRoot(...).render` is called at top level, not inside a `mount()` function | Wrap render in `mount()` and call it only after `login()` resolves. For React island frameworks, gate render with `if (!user) return null`. |
+| `no_auth_key_in_source` | Auth Key hardcoded in a source file | Move it to `.env` and reference via the framework's env prefix (`import.meta.env.VITE_COMETCHAT_AUTH_KEY`, `process.env.NEXT_PUBLIC_COMETCHAT_AUTH_KEY`, etc.). |
+| `error_ui_visible_on_failure` | No visible error state rendered on init/login failure | In the component that calls `init()`/`login()`, add a catch handler that sets an error state, then render: `<div style={{ color: "red", padding: 16 }}>CometChat Error: {error}</div>`. The full pattern is in `cometchat-core` section 6 (CometChatProvider). |
+
+For symptoms not in this table, proceed to Step 4.
+
+### Step 4 — Framework-specific patterns
+
+Many issues are framework-specific. Check against these common patterns:
+
+| Framework | Symptom | Likely cause | Fix |
+|---|---|---|---|
+| Next.js | Blank screen / hydration mismatch | CometChat components rendered on the server | Add `"use client"` to the file, or use `dynamic(() => import(...), { ssr: false })`. See `cometchat-core` section 5. |
+| Astro | Theme not applying | CSS override in a global `.css` file instead of inside the React island | Move `--cometchat-*` overrides inside `src/cometchat/ChatApp.tsx`. See `cometchat-theming` section 1. |
+| Astro | Components not rendering | Missing `client:only="react"` directive | Add `client:only="react"` to the island component in the `.astro` file. |
+| React Router v7 | `window is not defined` at build | CometChat imported in a module that runs on the server | Wrap in `React.lazy` + `Suspense` with a `ClientOnly` guard. See `cometchat-react-router-patterns` section 3. |
+| Vite / CRA | CSS variables not taking effect | Override block appears BEFORE the `@import` of css-variables.css | Reorder: the `@import` must come first, overrides must follow. |
+| Any | 401 Unauthorized | Wrong or expired auth key in `.env` | Check `.env` for `YOUR_AUTH_KEY_HERE`. Replace with real value from app.cometchat.com → API & Auth Keys. |
+| Any | `CometChat is not initialized` | Component renders before `init()` resolves | Use the provider pattern from `cometchat-core` section 6, or add an `isReady` gate before rendering CometChat components. |
+| Any (React 19) | `Cannot update a component (ForwardRef) while rendering a different component` | Known React 19 warning from CometChat UI Kit internals (`closePopover` calls setState during render). **Not a bug in your code.** | Ignore — this is a cosmetic warning from inside the UI Kit's minified bundle. The UI works correctly. Will be fixed in a future UI Kit release. Do NOT try to patch this in user code. |
+
+### Step 5 — Symptom-driven lookup via the docs MCP
+
+If the user has reported a specific symptom that isn't covered by verify
+checks or the framework table, query the CometChat docs MCP:
+
+```
+Use the cometchat-docs MCP to search for "<symptom keywords>"
+```
+
+Common symptom searches:
+
+| Symptom | MCP search query |
+|---|---|
+| Blank screen at /chat | "blank screen ssr nextjs" or "blank screen react-router" |
+| 401 Unauthorized | "401 unauthorized authentication" |
+| Chat doesn't load | "chat not loading init login" |
+| Build error | "<exact error message from build output>" |
+| CORS error | "cors origin allowed" |
+| Mixed user/group error | "user group same component" |
+| Theme not applying | "theming css variables override" |
+
+The docs MCP returns the canonical fix. Apply it as a targeted patch.
+
+### Step 6 — Propose the fix
+
+Show the user:
+1. What's broken (verify output, drift report, or symptom)
+2. The likely cause (from the table or docs MCP)
+3. The exact fix (file path + content change)
+4. Whether to:
+   - **Patch the specific issue** — targeted edit to the broken file.
+     Preferred for most issues.
+   - **Restore from the registry** — `cometchat apply --force` rewrites
+     all owned files back to their template state. Safe only if the
+     user hasn't customized them. **Ask first.**
+   - **Re-run the integration cleanly** — `cometchat uninstall --force`
+     followed by `/cometchat`. Wipes state.json and starts over. Last
+     resort.
+
+For dashboard/network/auth issues, the fix is on the user's side
+(CometChat dashboard, .env values, network connectivity) — `cometchat
+doctor` surfaces the issue and the fix verbatim. Don't try to "fix"
+infrastructure issues from the CLI.
+
+### Step 7 — Verify the fix
+
+After any fix is applied, re-run:
+
+```bash
+npx @cometchat/skills-cli verify --json
+```
+
+Confirm `status: "pass"`. If anything is still failing, repeat from Step 2.
+
+## Hard rules
+
+- Never apply a fix without showing the user what will change first.
+- Never invent error causes — query the docs MCP if you don't know.
+- Never blame the user's code if the verify checks are passing — the issue
+  is probably in the docs MCP territory (network, auth, dashboard config).
+- For drift, default to **showing** the drift and asking if it was
+  intentional, not auto-restoring. Drift after customization is expected.
+- Always use `npx @cometchat/skills-cli`.

--- a/solutions/cometchat-chat/.agents/skills/cometchat/SKILL.md
+++ b/solutions/cometchat-chat/.agents/skills/cometchat/SKILL.md
@@ -1,0 +1,862 @@
+---
+name: cometchat
+description: Entry-point for CometChat integration in any React project — web (React/Next.js/React Router/Astro) and React Native (Expo/bare). Detects the framework, gathers requirements through an interactive conversation, and writes production-quality integration code.
+license: "MIT"
+allowed-tools: "executeBash, readFile, fileSearch, listDirectory, AskUserQuestion"
+metadata:
+  author: "CometChat"
+  version: "3.0.0"
+  tags: "cometchat dispatcher entry react nextjs react-router astro expo react-native chat"
+---
+
+## Use this skill when
+
+The user wants to add CometChat to any kind of project. Trigger phrases:
+
+- `/cometchat`
+- "add cometchat", "integrate cometchat", "add chat to my app"
+- "add messaging", "add chat ui", "add in-app chat"
+
+This is the **entry point for every framework**. Do NOT invoke
+framework-specific skills directly — this dispatcher detects the
+framework first and routes to the right ones.
+
+**Supported frameworks:**
+
+| Family | Frameworks |
+|---|---|
+| **Web** | React (Vite/CRA), Next.js, React Router v6/v7, Astro |
+| **React Native** | Expo (managed + Expo Router), bare RN CLI |
+
+The web family loads `@cometchat/chat-uikit-react` + `@cometchat/chat-sdk-javascript`. The RN family loads `@cometchat/chat-uikit-react-native` + `@cometchat/chat-sdk-react-native`. The dispatcher decides which set after Step 1's detection.
+
+## How v3 works
+
+v3 skills are **interactive and conversational**. You don't just detect
+the framework and dump code. You have a conversation with the developer
+to understand their project, their use case, and exactly where chat
+should go — THEN you write code that fits.
+
+Pattern skills (loaded from your context, not via `Skill()`):
+- `cometchat-core` (web) / `cometchat-native-core` (RN) — init, login, provider chain, env vars, anti-patterns
+- `cometchat-components` (web) / `cometchat-native-components` (RN) — component catalog, props, composition
+- `cometchat-placement` (web) / `cometchat-native-placement` (RN) — WHERE to put chat
+- One per-framework skill (`cometchat-{react,nextjs,react-router,astro}-patterns` or `cometchat-native-{expo,bare}-patterns`) — framework-specific details
+
+**Key principle: ask, don't assume.** Every piece of information you need
+from the user should be asked explicitly. Don't guess the route path,
+don't guess where the trigger button goes, don't guess the auth system.
+
+## Steps
+
+### Step 1 — Detect framework + map the project
+
+First, check if `.cometchat/config.json` exists:
+```bash
+npx @cometchat/skills-cli config show --json
+```
+
+If config exists with previous answers, tell the user:
+> "I see you've set up CometChat before. Using your saved config:
+> Framework: {framework}, App: {appId}, Intent: {intent}.
+> Want to continue with these, or start fresh?"
+
+If no config, run detection:
+```bash
+npx @cometchat/skills-cli detect --json
+```
+
+The JSON output includes `framework` (one of `reactjs`, `nextjs`, `react-router`, `astro`, `expo`, `react-native`, or `null`), framework-specific fields (`router`, `expo_mode`, `react_native_version`, `env_prefix`), and a `compatibility.supported` flag. If `supported` is `false`, stop and surface the warnings.
+
+**Then read the project yourself — this is critical.**
+
+**For web frameworks (`reactjs`, `nextjs`, `react-router`, `astro`):**
+- `package.json` — name, dependencies, scripts
+- The source directory structure — list all directories under `src/` or `app/`
+- Find the router: `createBrowserRouter`, `app/` directory, `pages/`, `react-router.config.ts`, `astro.config.*`
+- Find the layout: `App.tsx`, `layout.tsx`, `root.tsx`, `Layout.astro`
+- Find the nav: components with "nav", "header", "sidebar" in name
+- Find existing pages/routes: list them so you can reference them later
+
+**For React Native (`expo`, `react-native`):**
+- `package.json` — name, RN version, all dependencies, scripts
+- Entry file — `index.js` or `App.{tsx,jsx}` or `app/_layout.tsx` (Expo Router)
+- Navigation — look for `@react-navigation/native`, `@react-navigation/stack`, `@react-navigation/bottom-tabs`, or `expo-router`
+- Existing screens — list all files under `screens/`, `src/screens/`, `app/`, or wherever routes live
+- Existing nav structure — read the root navigator to see stack vs tab vs drawer layout
+
+Store this mental map — you'll use it throughout the conversation.
+
+**Compatibility baselines (the CLI enforces these):**
+- Web: react@<18 → upgrade required; nextjs@<13 → warning; astro@<4 → warning
+- RN: react-native@<0.70 → upgrade required; expo@<49 → upgrade required
+
+#### Pattern skills not installed?
+
+The dispatcher routes to either web pattern skills (`cometchat-{core,components,placement,*-patterns}`) or RN pattern skills (`cometchat-native-{core,components,placement,*-patterns}`) based on the detected framework. If the matching set isn't loaded in your context — i.e. the user installed only one of `@cometchat/skills` (web) or `@cometchat/skills-native` (RN) and the framework doesn't match — stop and tell them which package to install:
+
+**If `framework` is `expo` or `react-native` AND `cometchat-native-core` is NOT loaded:**
+> "This is a React Native / Expo project, but the React Native pattern
+> skills aren't installed in this workspace. Install them with:
+> ```
+> npx @cometchat/skills-native add
+> ```
+> then run `/cometchat` again."
+
+**If `framework` is `reactjs`, `nextjs`, `react-router`, or `astro` AND `cometchat-core` is NOT loaded:**
+> "This is a {framework} project, but the web pattern skills aren't
+> installed in this workspace. Install them with:
+> ```
+> npx @cometchat/skills add
+> ```
+> then run `/cometchat` again."
+
+To check, attempt to read `cometchat-core/SKILL.md` (web) or `cometchat-native-core/SKILL.md` (RN) from your loaded skills context. If the read fails, the package isn't installed.
+
+Do NOT attempt to write web UI Kit code into an RN project (CSS imports + `<a href>` + `document.*` will fail at runtime) or RN UI Kit code into a web project (`react-native-gesture-handler`, `@gorhom/bottom-sheet`, native bubble components have no browser equivalents).
+
+### Step 2 — Set up credentials (onboarding)
+
+**CRITICAL: All onboarding happens via CLI commands. NEVER send the user
+to a browser or dashboard for credential copy-pasting. The CLI handles
+signup, login, app creation, and credential writing — all from the
+terminal — for every framework.**
+
+If config has `appId` set, verify credentials are in `.env` and skip to Step 3.
+
+Otherwise check:
+```bash
+npx @cometchat/skills-cli auth status --json
+```
+
+If `status` is `"logged-in"`, skip to **Step 2c** (app selection).
+
+If `status` is `"logged-out"`, ask:
+
+Use `AskUserQuestion`:
+- **question:** "Let's set up CometChat. Do you have an account?"
+- **header:** "Account"
+- **multiSelect:** false
+- **options:**
+  1. label: "Create a new account", description: "Free signup — I'll handle it right here, no browser needed."
+  2. label: "Sign in to existing account", description: "Log in and pick one of your apps."
+  3. label: "I'll paste credentials myself", description: "I already have my App ID, Region, and Auth Key."
+
+Option 1 → **Step 2b**. Option 2 → **Step 2a**. Option 3 → **Step 2d**.
+
+#### Step 2a — Sign in (existing account, browser flow)
+
+```bash
+npx @cometchat/skills-cli auth login
+```
+
+This command:
+1. Generates a short-lived session via the CLI auth API.
+2. Opens `https://app.cometchat.com/login?sessionId=<hex>` in the user's default browser.
+3. Polls the auth API every 5 seconds for up to 15 minutes.
+4. When the user finishes signing in, the dashboard marks the session authenticated. The next poll receives the bearer token and stores it in the OS keychain.
+5. Prints `✓ Logged in as <email> (backend: keychain-macos).`
+
+Let the CLI block — do NOT background it, do NOT race it with other prompts.
+
+Terminal error handling (surface verbatim, stop, do not retry silently):
+- `ACCESS_DENIED` — user clicked Deny in the dashboard.
+- `EXPIRED` — 15-minute window elapsed.
+- `TIMEOUT` — max polls exhausted before user authorized.
+- `ABORTED` — user Ctrl-C'd the CLI.
+- `NETWORK` — couldn't reach the auth host.
+- `ALREADY_AUTHENTICATED` — this session was already consumed. Re-run `auth login` to mint a fresh session.
+
+After success, verify via `auth status --json` and proceed to **Step 2c**.
+
+#### Step 2b — Sign up (new account, browser flow)
+
+```bash
+npx @cometchat/skills-cli auth signup
+```
+
+Same polling flow as Step 2a, but the CLI opens the signup URL. The browser handles email, name, password, verification email, role, industry. The CLI never sees any of those values.
+
+No role / name / verification-code questions in the chat. The dashboard owns that flow now; skipping it keeps the user's password and verification code out of the transcript.
+
+Error codes match Step 2a. After success, verify via `auth status --json` and proceed to **Step 2c**.
+
+#### Step 2c — Pick or create an app
+
+**Run this immediately — do NOT ask the user to go to any dashboard:**
+```bash
+npx @cometchat/skills-cli provision list --json
+```
+
+**If the user has existing apps**, show them and ask which to use:
+> "I found these CometChat apps on your account:
+> 1. my-marketplace-chat (us) — Developer plan
+> 2. test-app (eu) — Developer plan
+>
+> Which one should I use, or should I create a new one?"
+
+**For an existing app**, fetch credentials and wire everything in one call. Pass `--framework` from Step 1 detection (one of `reactjs`, `nextjs`, `react-router`, `astro`, `expo`, `react-native`):
+```bash
+npx @cometchat/skills-cli provision setup \
+  --app-id "<selected-appId>" --framework "<framework>" --json
+```
+
+This creates/updates the env file with the correct prefix AND writes `.cometchat/config.json` in one step. Output is compact: `{ appId, region, framework, envFile, configPath }` — no authKey echoed back.
+
+**If no apps exist** (or user wants new), collect:
+1. App name — suggest `<project-name>-chat` from package.json `name`
+2. Region — `AskUserQuestion`:
+   - **question:** "Which region for your CometChat app?"
+   - **header:** "Region"
+   - **options:** US (recommended), EU, India
+
+   **Region key mapping** (CLI expects lowercase):
+   | Label | `--region` value |
+   |---|---|
+   | US | `us` |
+   | EU | `eu` |
+   | India | `in` |
+3. Industry — `AskUserQuestion`:
+   - **options:** SaaS / Business, Marketplace, Social / Community, Other (or finer-grained from the table below)
+
+**Industry key mapping:**
+
+| Label | `--industry` value |
+|---|---|
+| SaaS / Business | `saas_businesses` |
+| Marketplace | `online_marketplaces` |
+| Social / Community | `community_and_social` |
+| Healthcare | `healthcare` |
+| Dating | `dating` |
+| Education | `online_education` |
+| Events / Streaming | `events_and_streaming` |
+| Sports / Gaming | `sports_and_gaming` |
+| Team Communication | `team_comms_and_workflows` |
+| On-demand Services | `on_demand_services` |
+| Other | `other` |
+
+**Confirm before creating, then:**
+```bash
+npx @cometchat/skills-cli provision setup \
+  --name "<name>" --region "<region>" --industry "<industry_key>" \
+  --framework "<framework>" --json
+```
+
+The authKey is written to the env file but is NOT echoed to stdout, so credentials don't appear multiple times in the transcript.
+
+Tell the user: "Your CometChat account and app are ready. Credentials saved to `<envFile>`. Let's set up the integration."
+
+#### Step 2d — Paste keys manually
+
+Tell the user which env vars to set based on the detected framework:
+
+| Framework | Env file | Variables |
+|---|---|---|
+| reactjs (Vite) | `.env` | `VITE_COMETCHAT_APP_ID`, `VITE_COMETCHAT_REGION`, `VITE_COMETCHAT_AUTH_KEY` |
+| nextjs | `.env.local` | `NEXT_PUBLIC_COMETCHAT_APP_ID`, `NEXT_PUBLIC_COMETCHAT_REGION`, `NEXT_PUBLIC_COMETCHAT_AUTH_KEY` |
+| react-router | `.env` | `VITE_COMETCHAT_APP_ID`, `VITE_COMETCHAT_REGION`, `VITE_COMETCHAT_AUTH_KEY` |
+| astro | `.env` | `PUBLIC_COMETCHAT_APP_ID`, `PUBLIC_COMETCHAT_REGION`, `PUBLIC_COMETCHAT_AUTH_KEY` |
+| expo (managed + Expo Router) | `.env` | `EXPO_PUBLIC_COMETCHAT_APP_ID`, `EXPO_PUBLIC_COMETCHAT_REGION`, `EXPO_PUBLIC_COMETCHAT_AUTH_KEY` |
+| react-native (bare CLI) | `.env` | `COMETCHAT_APP_ID`, `COMETCHAT_REGION`, `COMETCHAT_AUTH_KEY` (paired with `react-native-dotenv`) |
+
+> "Grab your credentials from https://app.cometchat.com → Your App →
+> API & Auth Keys. Create the env file above and tell me when done."
+
+**Bare RN extra step.** Bare RN doesn't ship a public-env-prefix convention — pair the env file with `react-native-dotenv`:
+```bash
+npm install --save-dev react-native-dotenv
+```
+and add the plugin to `babel.config.js`:
+```js
+module.exports = {
+  presets: ["module:@react-native/babel-preset"],
+  plugins: [["module:react-native-dotenv"]],
+};
+```
+Then `import { COMETCHAT_APP_ID, COMETCHAT_REGION, COMETCHAT_AUTH_KEY } from "@env";` in the provider.
+
+After they confirm, verify:
+```bash
+npx @cometchat/skills-cli config init --json
+```
+
+#### Never log the Auth Key
+
+After writing credentials, don't echo the Auth Key back in the transcript. Confirm as `✓ Wrote <PREFIX>COMETCHAT_AUTH_KEY (hidden)`.
+
+### Step 3 — Interactive requirements gathering
+
+This is the core of v3. A multi-step conversation that gathers everything you need before writing a single line of code.
+
+#### 3a. "What are you building?"
+
+If config has `intent` set, confirm it and move on.
+
+Otherwise, use `AskUserQuestion`:
+- **question:** "What kind of app are you building?"
+- **header:** "Your app"
+- **multiSelect:** false
+- **options:**
+  1. label: "Messaging app", description: "Chat is the main feature — like Slack, Discord, WhatsApp, or Telegram."
+  2. label: "Marketplace or platform", description: "Buyers and sellers communicate — like Airbnb, eBay, OfferUp, or Depop."
+  3. label: "SaaS or productivity", description: "Team chat or support chat inside a product — like Notion, Intercom, or Linear."
+  4. label: "Social or community", description: "User profiles with messaging — like a dating app or community forum."
+  5. label: "Support or helpdesk", description: "Customer-to-agent communication."
+  6. label: "Just exploring", description: "Quick demo — fastest path to see chat working."
+
+**If "Just exploring":** skip the rest of Step 3 and scaffold the minimal integration in Step 5 — one route/screen showing `<CometChatConversations />` with `cometchat-uid-1` pre-logged-in.
+
+#### 3b. Show what you recommend and why
+
+The recommendation table differs by family because the placement vocabulary is different (web has routes/drawers/widgets; RN has screens/tabs/sheets):
+
+**Web family (reactjs, nextjs, react-router, astro):**
+
+| Intent | What you'll set up |
+|---|---|
+| **Messaging app** | A dedicated messages page at a route you choose. Two-pane: conversation list + active chat. |
+| **Marketplace** | A "Chat with seller" drawer on your product page + an inbox page at /messages. |
+| **SaaS / dashboard** | A chat modal triggered from your navbar + a full messages page. |
+| **Social / community** | A full messenger page with tabs: Chats, Calls, Users, Groups. |
+| **Support** | A floating widget bubble in the bottom-right corner. |
+
+**React Native family (expo, react-native):**
+
+| Intent | What you'll set up |
+|---|---|
+| **Messaging app** | A dedicated "Messages" bottom tab. Conversations list → tap a conversation → message thread. |
+| **Marketplace** | A "Chat with seller" button on the product screen that opens a modal with the message thread. Plus an "Inbox" stack screen for all conversations. |
+| **SaaS / productivity** | A "Chat" stack screen accessible from the nav or a header button. Optionally a bottom sheet for quick replies. |
+| **Social / community** | A "Messages" bottom tab with conversations list + message thread. Plus a "Message" button on user profile screens that opens a modal. |
+| **Support** | A modal triggered from a "Help" or "Support" button in the header or settings. |
+
+When explaining, reference the ASCII diagrams from `cometchat-placement` (web) or `cometchat-native-placement` (RN) so the user can visualize.
+
+Ask: "Does this sound right, or do you want a different approach?" Let them override.
+
+#### 3c. Ask where things should go
+
+**Show the user their actual project structure** — list the pages/routes/screens you found in Step 1. Then ask placement-specific questions appropriate to the family.
+
+**Web — Route placement (messaging, social):**
+> "I found these pages in your project:
+>   - /  (home)
+>   - /about
+>   - /products
+>   - /profile
+>
+> Where should the messages page live?"
+
+Default: `/messages`. Let user type a custom path.
+
+**Web — Drawer placement (marketplace):**
+> "Which page should have the 'Chat' button that opens the drawer?
+> I found these pages: ..."
+
+Read the picked page. Look for existing buttons, actions, or interactive elements. Ask whether to wire to the existing button or add a new one.
+
+**Web — Modal placement (SaaS):**
+> "Where should the 'Open chat' button go? I found these components
+> that look like navigation: ..."
+
+**Web — Widget placement (support):**
+> "Should the widget appear on all pages, or only specific ones?"
+
+**RN — Bottom tab placement (messaging, social):**
+> "I found these bottom tabs in your navigator at App.tsx:
+>   - Home
+>   - Profile
+>   - Settings
+>
+> Where should the 'Messages' tab go? (At the end, or pick a position.)"
+
+**RN — Stack screen placement (saas, marketplace inbox):**
+> "I found these stack screens in your root navigator: ...
+>
+> What should I call the chat screen? Default: MessagesScreen."
+
+**RN — Modal placement (marketplace, support):**
+> "Which screen should have the 'Chat' button that opens the modal?
+> I found these screens: ..."
+
+Read the picked screen. Look for existing buttons. Ask whether to wire to it or add a new one.
+
+**RN — BottomSheet placement (quick reply, support):**
+> "Bottom sheets slide up from below. Should the sheet be:
+>   1. Draggable (user can dismiss by swiping down) — uses @gorhom/bottom-sheet
+>   2. Fixed overlay — uses CometChat's built-in CometChatBottomSheet
+>
+> Which one?"
+
+**Combinations** (marketplace = drawer/modal + inbox): ask both questions in sequence — they're separate components wired into separate places.
+
+**Expo Router projects** — adapt screen names to file paths:
+- Stack screen → `app/messages.tsx` (or the path the user picks)
+- Bottom tab → file under `app/(tabs)/messages.tsx` + update `app/(tabs)/_layout.tsx`
+- Modal → `app/(modals)/chat.tsx` with `presentation: "modal"` in the parent `_layout.tsx`
+
+#### 3d. Detect and ask about authentication
+
+Read the project's `package.json` and source files. Look for auth.
+
+**Web auth libraries:**
+- `next-auth` / `@auth/core` → NextAuth
+- `@clerk/nextjs` / `@clerk/clerk-react` → Clerk
+- `@supabase/supabase-js` + auth usage → Supabase Auth
+- `firebase` / `firebase/auth` → Firebase Auth
+- `passport` → Passport.js
+- `jsonwebtoken` / `jose` → Custom JWT
+
+**RN auth libraries:**
+- `firebase` / `@react-native-firebase/auth` → Firebase Auth
+- `@clerk/clerk-expo` / `@clerk/clerk-react-native` → Clerk
+- `@supabase/supabase-js` + auth usage → Supabase Auth
+- `react-native-auth0` → Auth0
+- `aws-amplify` + auth module → AWS Cognito
+- `@react-native-google-signin/google-signin` → Google Sign-In (usually paired with something above)
+- `expo-auth-session` / `expo-secure-store` → Expo Auth Session (custom)
+
+**None detected** → no auth.
+
+Report what you found and ask:
+
+If auth detected:
+> "I see you're using [NextAuth / Firebase Auth / etc.]. Here's how
+> CometChat will work with it:
+>
+> - **Development (now):** I'll use CometChat's Auth Key for quick
+>   testing with pre-seeded users (cometchat-uid-1 through uid-5).
+> - **Production (later):** Your server will mint per-user auth tokens
+>   via the CometChat REST API. I can set this up now or later
+>   (see `cometchat-production` / `cometchat-native-production`).
+>
+> Start with dev mode for now? You can upgrade to production auth
+> anytime by choosing 'Set up production auth' from the menu."
+
+If no auth detected:
+> "I don't see an authentication system in your project yet. For now,
+> I'll set up CometChat with a hardcoded test user (cometchat-uid-1).
+>
+> When you add auth later, run `/cometchat` again and choose
+> 'Set up production auth' to connect them."
+
+#### 3e. Ask about user mapping (if auth detected)
+
+If the user has auth AND wants to set up production mode now:
+
+> "How should your app's users map to CometChat users?
+>
+> 1. Use your existing user ID as the CometChat UID (simplest)
+> 2. Generate a separate CometChat UID and store it alongside your user record
+> 3. Let me just set up dev mode for now"
+
+If they share an example, validate it's CometChat-compatible (alphanumeric, underscores, hyphens — no spaces or special chars; max 100 chars). Firebase UIDs, Clerk user IDs, Supabase UUIDs, and Auth0 `sub` claims are all CometChat-compatible by default.
+
+#### 3f. Confirm the plan
+
+**This is critical. Show EXACTLY what you'll do before doing it.** The plan format differs by framework.
+
+**Web example (Next.js, marketplace):**
+> "Here's what I'll create:
+>
+> **New files:**
+> - `app/providers/CometChatProvider.tsx`
+> - `app/messages/page.tsx`
+> - `app/components/ChatDrawer.tsx`
+> - `.env.local`
+>
+> **Files I'll modify:**
+> - `app/products/[id]/page.tsx` — add ChatDrawer trigger
+> - `app/layout.tsx` — wrap with CometChatProvider
+> - `app/components/Navbar.tsx` — add 'Messages' link
+>
+> **Dependencies:** @cometchat/chat-sdk-javascript, @cometchat/chat-uikit-react
+>
+> **Auth mode:** Development (Auth Key).
+> Proceed? [y/n]"
+
+**RN example (Expo Router, messaging):**
+> "Here's what I'll create:
+>
+> **New files:**
+> - `providers/CometChatProvider.tsx`
+> - `app/(tabs)/messages.tsx`
+> - `.env`
+>
+> **Files I'll modify:**
+> - `app/_layout.tsx` — wrap with the four-wrapper chain
+> - `app/(tabs)/_layout.tsx` — add the Messages tab
+> - `index.js` — `import 'react-native-gesture-handler'` at line 1 (if missing)
+>
+> **Dependencies (via `npx expo install`):**
+> @cometchat/chat-uikit-react-native, @cometchat/chat-sdk-react-native,
+> react-native-gesture-handler, react-native-reanimated,
+> react-native-safe-area-context, react-native-screens,
+> @react-native-async-storage/async-storage, @react-native-community/netinfo,
+> react-native-video, react-native-image-picker, react-native-document-picker,
+> react-native-vector-icons, react-native-fs
+>
+> **Auth mode:** Development (Auth Key).
+> Proceed? [y/n]"
+
+**Bare RN variant** — same as Expo, except `npm install` instead of `npx expo install`, plus:
+- Run `cd ios && pod install`
+- Patch `ios/<Name>/Info.plist`, `android/app/src/main/AndroidManifest.xml` for permissions
+- Add `ios/<Name>/PrivacyInfo.xcprivacy` (Apple Privacy Manifest)
+- Patch `android/build.gradle` for the async-storage Maven repo (v3+)
+
+Wait for explicit confirmation. If the user says no or wants changes, go back to the relevant question and re-ask.
+
+### Step 4 — Reference pattern skills
+
+**All skills are already loaded in your context** as `.claude/skills/` files. Do NOT use the `Skill()` tool. Read and follow them directly.
+
+**For web frameworks:**
+1. `cometchat-core` — initialization, provider, CSS, anti-patterns
+2. `cometchat-components` — component catalog, composition patterns
+3. Framework-specific:
+   - `reactjs` → `cometchat-react-patterns`
+   - `nextjs` → `cometchat-nextjs-patterns`
+   - `react-router` → `cometchat-react-router-patterns`
+   - `astro` → `cometchat-astro-patterns`
+4. `cometchat-placement` — placement pattern for the chosen approach
+
+**For React Native:**
+1. `cometchat-native-core` — init, login, four-wrapper provider chain, env vars, anti-patterns
+2. `cometchat-native-components` — component catalog
+3. Framework-specific:
+   - `expo` (managed + Expo Router) → `cometchat-native-expo-patterns`
+   - `react-native` (bare CLI) → `cometchat-native-bare-patterns`
+4. `cometchat-native-placement` — placement pattern (stack/tab/modal/bottom-sheet/embed)
+
+### Step 5 — Write the integration
+
+Execute the confirmed plan. The order of operations is the same for every framework, but the file names + provider shape differ.
+
+**Web — common steps:**
+
+1. **CometChatProvider** — follow the framework skill's provider pattern. Use the correct env var prefix. Module-level `initialized` guard. Mount at the level agreed in Step 3f.
+2. **Chat component(s)** — follow the placement skill's pattern.
+3. **Wire into existing project** — READ each file before modifying. Add the route, nav link, drawer/modal trigger.
+4. **CSS import** — add once at the root level per framework conventions.
+5. **Environment variables** — write the env file with the correct prefix.
+6. **Install dependencies:**
+   ```bash
+   npm install @cometchat/chat-sdk-javascript @cometchat/chat-uikit-react
+   ```
+
+**React Native — common steps:**
+
+1. **Entry file** (`index.js` / `App.tsx` / `app/_layout.tsx`) — verify `import "react-native-gesture-handler";` is **line 1**. Not line 2, not after another import. Non-negotiable.
+2. **CometChatProvider** — follow `cometchat-native-core` § 6. Module-level `initialized` guard. Module-level `loginInFlight` promise for login concurrency.
+3. **Four-wrapper chain** — wrap the app's root in this exact order:
+   ```tsx
+   <GestureHandlerRootView style={{ flex: 1 }}>
+     <SafeAreaProvider>
+       <CometChatThemeProvider>
+         <CometChatProvider>
+           {/* navigator / Expo Router <Stack> */}
+         </CometChatProvider>
+       </CometChatThemeProvider>
+     </SafeAreaProvider>
+   </GestureHandlerRootView>
+   ```
+4. **Chat screen(s)** — follow `cometchat-native-placement`'s pattern.
+5. **Every `<CometChatMessageList>` MUST pass `hideReplyInThreadOption={true}`** (see hard rules).
+6. **Wire into existing project** — READ each file before modifying.
+7. **Environment variables** — write `.env` with the correct prefix (`EXPO_PUBLIC_` for Expo, bare for `react-native`).
+8. **Install dependencies:**
+
+   **Expo managed:**
+   ```bash
+   npx expo install @cometchat/chat-uikit-react-native @cometchat/chat-sdk-react-native \
+     react-native-gesture-handler react-native-reanimated react-native-safe-area-context \
+     react-native-screens @react-native-async-storage/async-storage \
+     @react-native-community/netinfo react-native-video react-native-image-picker \
+     react-native-document-picker react-native-vector-icons react-native-fs
+   ```
+
+   **Bare RN:**
+   ```bash
+   npm install @cometchat/chat-uikit-react-native @cometchat/chat-sdk-react-native \
+     react-native-gesture-handler react-native-reanimated react-native-safe-area-context \
+     react-native-screens @react-native-async-storage/async-storage \
+     @react-native-community/netinfo react-native-video react-native-image-picker \
+     react-native-document-picker react-native-vector-icons react-native-fs
+   cd ios && pod install && cd ..
+   ```
+
+   **Reanimated plugin (both):** verify `react-native-reanimated/plugin` is the LAST entry in `babel.config.js` `plugins` array. Metro cache is sensitive to plugin order.
+
+9. **Native config (bare RN only):**
+   - `ios/<Name>/Info.plist` — add `NSCameraUsageDescription`, `NSPhotoLibraryUsageDescription`, `NSMicrophoneUsageDescription`
+   - `android/app/src/main/AndroidManifest.xml` — add `CAMERA`, `RECORD_AUDIO`, `READ_MEDIA_IMAGES`, `READ_EXTERNAL_STORAGE` permissions
+   - `ios/<Name>/PrivacyInfo.xcprivacy` — add the 4 required API codes (C617.1, CA92.1, 35F9.1, E174.1). See `cometchat-native-bare-patterns`.
+   - `android/build.gradle` — async-storage Maven repo if v3+
+
+   **Expo managed** — all of this goes in `app.json` under `plugins` and `ios.infoPlist` / `android.permissions`. See `cometchat-native-expo-patterns`.
+
+#### Step 5 — common to ALL frameworks
+
+After the framework-specific work above, every integration ends the same way:
+
+10. **Update config.json** — save all the choices in one call:
+    ```bash
+    npx @cometchat/skills-cli config save \
+      --intent "<intent>" \
+      --placement "<type>" \
+      --placement-path "<path>" \
+      --auth-mode "<mode>" --json
+    ```
+    Pass only the fields you have — `config save` accepts any subset.
+
+11. **Record state so Phase B commands work — DO NOT SKIP.** Every Phase B command (`info`, `status`, `doctor`, `verify`, `uninstall`, `apply-theme`, `apply-feature`, `add-widget`, `add-user-mgmt`, `production-auth`) reads `.cometchat/state.json` to know what the integration looks like. Without this step, every one of them reports "not integrated in this project" even though the code is there.
+
+    Pass every file you wrote (owned) and every existing file you patched:
+    ```bash
+    npx @cometchat/skills-cli state record \
+      --framework "<framework>" \
+      --placement "<type>" \
+      --placement-path "<path>" \
+      --auth-mode "<mode>" \
+      --files-owned "<comma-list of new files>" \
+      --files-patched "<comma-list of path:patch_id pairs>" \
+      --json
+    ```
+
+    - `--files-owned` — comma-separated list of every NEW file you wrote (provider, drawer, inbox page, screen). The CLI computes SHA-256 checksums for each so it can detect drift later.
+    - `--files-patched` — comma-separated `path:patch_id` pairs for every EXISTING file you modified. `patch_id` can be any stable label — `v3/<filename>` is a reasonable default.
+
+    If this call errors (CLI flag mismatch, missing `--framework`, etc.), surface the error and retry. A completed Phase A with a missing state.json is worse than a visible error — the user discovers the breakage later when they try to add a feature or run diagnostics.
+
+**Exception — "Just exploring" / demo mode (web only):**
+```bash
+npx @cometchat/skills-cli apply --experience 1 --framework <detected>
+npx @cometchat/skills-cli verify --json
+npx @cometchat/skills-cli install
+```
+
+For RN demo mode, scaffold the minimal integration directly — there's no `apply` template path for RN.
+
+### Step 6 — Verify + show result
+
+Run a TypeScript check to verify the code compiles:
+```bash
+npx tsc --noEmit
+```
+
+**Do NOT run `npx @cometchat/skills-cli verify`** — it checks for CLI-generated `.cometchat/state.json` that's authored by `cometchat apply`, not by AI integration. Use `tsc` instead.
+
+**RN extra: do not start Metro automatically** — let the user do that in their own terminal. Metro blocks the terminal and cannot be meaningfully observed from here.
+
+Surface any common issues:
+
+**Web:**
+- `Module not found: @cometchat/chat-uikit-react` → install didn't complete
+- CSS variable warnings → CSS import not at root or wrong path
+
+**RN:**
+- `Cannot find module '@cometchat/chat-uikit-react-native'` → install didn't complete
+- `JSX element 'GestureHandlerRootView' has no corresponding closing tag` → wrapper chain partially applied
+- `Property 'hideReplyInThreadOption' does not exist on type '...'` → v3 types installed; user needs v5 (`^5.0.0`)
+
+Then:
+
+**Web result message:**
+> "CometChat is integrated! Here's what was set up:
+>
+> - <list of new + patched files> ✓
+> - Provider + CSS wired ✓
+> - Dependencies installed ✓
+>
+> Run `npm run dev` and open the app:
+> - **Vite (reactjs)**: http://localhost:5173
+> - **Next.js**: http://localhost:3000/chat
+> - **React Router v7**: http://localhost:5173/chat
+> - **Astro**: http://localhost:4321/chat"
+
+**RN result message:**
+> "CometChat is integrated! Here's what was set up:
+>
+> - <list of new + patched files> ✓
+> - Provider + four-wrapper chain ✓
+> - `import 'react-native-gesture-handler'` verified at line 1 ✓
+> - Dependencies installed ✓
+> - `hideReplyInThreadOption={true}` on MessageList ✓
+>
+> Next steps:
+>
+> **Expo managed:**
+> 1. `npx expo start --clear`
+> 2. Open the app in Expo Go (if no native modules) or a dev build
+>
+> **Bare RN:**
+> 1. `npm start -- --reset-cache`
+> 2. In another terminal: `npm run ios` or `npm run android`"
+
+**Common ending — what you'll see on first load (every framework):**
+
+> ---
+>
+> **Pre-seeded test data — chat works immediately, no dashboard setup needed:**
+>
+> Every CometChat app ships with **5 pre-created test users**
+> (`cometchat-uid-1` through `cometchat-uid-5`), a **"Hello" test group**,
+> and **sample messages between them**. Your integration is logged in
+> as `cometchat-uid-1` by default, so on first load the conversation
+> list is already populated — you'll see existing 1:1 threads and the
+> test group with message history. Open any conversation and reply;
+> round-trip is ~50ms. Receipts, typing indicators, presence, and
+> reactions all work out of the box.
+>
+> **Want to see real-time delivery between two users?** Open the
+> integration in two browser windows (or two simulators on RN), and
+> temporarily change the login UID in your provider — `cometchat-uid-2`
+> in one window, `cometchat-uid-1` in the other. Messages from one
+> arrive live in the other without refresh.
+>
+> The dashboard at `https://app.cometchat.com` is useful later for
+> creating real users, configuring extensions, and viewing analytics
+> — but you don't need it to confirm the integration is working.
+>
+> What would you like to do next?"
+
+### Step 7 — Iteration menu
+
+Use `AskUserQuestion`. The option set differs by family — RN has two extra options (push notifications + testing) that don't apply to web.
+
+**Web — 8 canonical options:**
+- **question:** "What would you like to do next?"
+- **header:** "Next step"
+- **multiSelect:** false
+- **options:**
+  1. label: "Customize look and feel (themes)", description: "Pick a preset (slack, whatsapp, imessage, discord, notion) or set brand colors."
+  2. label: "Add a feature", description: "Browse ~35 features — calls, reactions, polls, AI, and more."
+  3. label: "Customize a component", description: "Custom bubbles, headers, composer actions, details views — I'll read the docs and write it."
+  4. label: "Add a floating chat widget", description: "An overlay button + drawer on top of your existing app."
+  5. label: "Set up production auth", description: "Replace the dev Auth Key with a server-side token endpoint. Read `cometchat-production` skill."
+  6. label: "Set up user management", description: "Server endpoints for creating, updating, deleting CometChat users."
+  7. label: "Run diagnostics", description: "Check for drift, missing env vars, broken imports."
+  8. label: "I'm done", description: "Exit."
+
+**RN — 10 canonical options:**
+- **question:** "What would you like to do next?"
+- **header:** "Next step"
+- **multiSelect:** false
+- **options:**
+  1. label: "Customize look and feel (themes)", description: "Colors, typography, dark mode — edit CometChatThemeProvider."
+  2. label: "Add a feature", description: "Calls, reactions, polls, extensions, AI agent — browse the catalog."
+  3. label: "Customize a component", description: "Custom bubbles, headers, message composer actions, empty states."
+  4. label: "Add another placement", description: "Add a modal chat, a bottom sheet, or another tab — without touching the existing integration."
+  5. label: "Set up push notifications", description: "APNs + FCM setup, CometChat dashboard config, client registration, tap-to-deep-link. Required for production."
+  6. label: "Set up production auth", description: "Replace the dev Auth Key with a server-minted auth token. Read `cometchat-native-production` skill."
+  7. label: "Set up user management", description: "Server endpoints for creating, updating, deleting CometChat users."
+  8. label: "Set up testing", description: "Jest + React Native Testing Library setup, mocks for the UI Kit / SDK, E2E with Detox or Maestro."
+  9. label: "Troubleshoot an issue", description: "Metro cache, pod install, iOS privacy manifest, push notifications, native module linking."
+  10. label: "I'm done", description: "Exit."
+
+For **theme customization**: read the framework-appropriate theming skill and write the customization code.
+
+For **adding features**: read the framework-appropriate features skill. Features fall into buckets (Default, Dashboard-toggle, Package-install, Component-swap). Ask which feature, then follow the right bucket's recipe.
+
+For **component customization**: read the customization + components skills, then write the customization code directly. Ask the user what they want to customize, read the relevant component's props from the catalog, propose changes.
+
+For **production auth**: read the framework-appropriate production skill. It's interactive — ask the user about their auth system and generate the server-side token endpoint for their backend.
+
+For **push notifications (RN only)**: read `cometchat-native-push`. Structured 12-section walkthrough.
+
+For **testing (RN only)**: read `cometchat-native-testing`. Ask the user whether they want unit tests (Jest + RNTL), E2E (Detox vs Maestro), or both.
+
+For **troubleshooting (RN)**: read `cometchat-native-troubleshooting` and match the symptom to a triage table. (Web: option 7 "Run diagnostics" runs `cometchat doctor` against `.cometchat/state.json`.)
+
+### Re-rendering the menu after each action
+
+After every Phase B action completes, you **MUST** re-invoke `AskUserQuestion` with the **exact same option set** (web: 8 options, RN: 10) — same `question`, `header`, `multiSelect: false`, same labels and descriptions, verbatim. This gives the user arrow-key selection in their terminal.
+
+**Do NOT:**
+- Present the options as a prose bullet list — forces typed answers, worse UX.
+- Invent new options based on what the user just did. The canonical set doesn't change between iterations.
+- Skip the menu and ask freeform "What's next?" — always route through `AskUserQuestion`.
+- Drop options or add new ones. The user expects the same choices every time, even if some are redundant with what they just did (they may want to do the same kind of action twice).
+
+The iteration loop is the whole point of Phase B. Re-rendering the canonical menu via `AskUserQuestion` after every action is how the user controls the session.
+
+## Hard rules
+
+### Always (every framework)
+
+- **Ask, don't assume.** Every integration decision should be confirmed.
+- **Always run `detect` first.** Do not assume the framework.
+- Always use `npx @cometchat/skills-cli` for CLI commands.
+- NEVER replace existing project files unless the user chose demo mode.
+- ALWAYS read existing files before modifying them.
+- ALWAYS show the plan (Step 3f) and get confirmation before writing.
+- **Every `<CometChatMessageList>` must pass `hideReplyInThreadOption={true}`** unless the user has explicitly opted into thread support and you've built the thread screen too. Without it, tapping a message shows a "Reply in Thread" action that leads to a broken (undefined) thread view.
+- **NEVER build a custom search UI.** The UI Kit ships `<CometChatSearch>` — full dual-scope search across conversations + messages with built-in filter chips, pagination, and result highlighting. Any request involving "search", "find messages", "search conversations" MUST use the built-in component (and `showSearchBar` / `onSearchBarClicked` on `CometChatConversations` for web; `hideSearch={false}` for RN). Do NOT create custom search bars, hand-rolled result lists, or filter UIs.
+- For component names and props, use the framework-appropriate `*-components` skill or docs MCP — never invent from training data.
+- After writing code, record state in `.cometchat/state.json` (Step 5 step 11) so the iteration menu can detect the integration in a future session.
+- **NEVER use the `Skill()` tool** to load CometChat skills. They're already in your context as `.claude/skills/` files. Just read and follow them directly.
+
+### Web only
+
+- **CSS import goes once at the root level** per framework conventions. The framework skill (cometchat-{react,nextjs,react-router,astro}-patterns) tells you exactly where.
+- **For drawer / widget animations, animate `right` / `left`, NEVER `transform` / `translate-*`.** A `transform` on a CometChat-containing element creates a new containing block that re-anchors absolutely-positioned overlays (emoji picker, action sheet, reactions, thread panel) to the transformed element instead of the viewport. Tailwind utilities `translate-x-*`, `-translate-x-*`, `scale-*`, `rotate-*`, `transform-*` are also banned for this reason. See `cometchat-placement` § 10.
+
+### React Native only
+
+- **`import "react-native-gesture-handler"` must be line 1 of the entry file.** Not line 2. Not after another import. This is non-negotiable.
+- **All four wrappers are required, in this order:** `GestureHandlerRootView → SafeAreaProvider → CometChatThemeProvider → CometChatProvider`. Omitting any of them breaks gestures, safe areas, theming, or login state — and it fails silently in dev.
+- **Login API is `CometChatUIKit.login({ uid })` or `CometChatUIKit.login({ authToken })`** — same method, different object key. There is no `loginWithAuthToken`. Passing a bare string like `login("cometchat-uid-1")` silently fails on RN.
+
+## Error handling
+
+If the CLI's `--json` output includes `human_message` / `suggestion` fields, show those to the user. Then show the raw `error` in parentheses for debuggability. If `retryable: false`, do NOT offer a retry.
+
+For RN: if a command errors (e.g., `pod install` fails, `npx expo install` fails), surface the raw error output and consult `cometchat-native-troubleshooting` for the relevant triage table before retrying. Don't loop silently.
+
+If the user's project is bare RN with `ios/` and `android/` but no `package.json` scripts for `ios`/`android` (common when React Native was added incrementally to an existing native app), flag that and pause. Writing integration code won't help if the app can't build.
+
+## Optional: docs MCP
+
+For deeper component customization:
+```
+claude mcp add --transport http cometchat-docs https://www.cometchat.com/docs/mcp
+```
+
+Not required for integration or Phase B CLI flows.
+
+## Skill routing reference
+
+### Web family
+
+| Skill | When to load |
+|---|---|
+| `cometchat-core` | Always — before any integration code |
+| `cometchat-components` | Always — before writing component code |
+| `cometchat-placement` | When integrating — for placement patterns |
+| `cometchat-react-patterns` | framework = reactjs |
+| `cometchat-nextjs-patterns` | framework = nextjs |
+| `cometchat-react-router-patterns` | framework = react-router |
+| `cometchat-astro-patterns` | framework = astro |
+| `cometchat-theming` | When customizing themes |
+| `cometchat-features` | When adding features |
+| `cometchat-customization` | When writing custom formatters, events, request-builder filters |
+| `cometchat-production` | When setting up production auth |
+| `cometchat-troubleshooting` | When diagnosing problems |
+
+### React Native family
+
+| Skill | When to load |
+|---|---|
+| `cometchat-native-core` | Always — before any integration code |
+| `cometchat-native-components` | Always — before writing component code |
+| `cometchat-native-placement` | When integrating — for placement patterns |
+| `cometchat-native-expo-patterns` | framework = expo (managed + Expo Router) |
+| `cometchat-native-bare-patterns` | framework = react-native (bare CLI) |
+| `cometchat-native-theming` | When customizing themes |
+| `cometchat-native-features` | When adding features |
+| `cometchat-native-customization` | When writing custom text formatters, events, request-builder filters, or DataSource decorators |
+| `cometchat-native-production` | When setting up production auth or user management |
+| `cometchat-native-push` | When setting up push notifications |
+| `cometchat-native-testing` | When adding tests |
+| `cometchat-native-troubleshooting` | When diagnosing problems |

--- a/solutions/cometchat-chat/.env.example
+++ b/solutions/cometchat-chat/.env.example
@@ -1,0 +1,11 @@
+# CometChat credentials. The /cometchat skill writes these for you when
+# you run it for the first time — leave this as a reference for what
+# the integration needs.
+#
+# Get values from app.cometchat.com → your app → API & Auth Keys, OR run
+# `npx @cometchat/skills-cli auth login` in this project's terminal and
+# the CLI fetches them automatically.
+
+NEXT_PUBLIC_COMETCHAT_APP_ID=
+NEXT_PUBLIC_COMETCHAT_REGION=
+NEXT_PUBLIC_COMETCHAT_AUTH_KEY=

--- a/solutions/cometchat-chat/.eslintrc.json
+++ b/solutions/cometchat-chat/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": "next/core-web-vitals"
+}

--- a/solutions/cometchat-chat/.gitignore
+++ b/solutions/cometchat-chat/.gitignore
@@ -1,0 +1,39 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# Dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# Testing
+/coverage
+
+# Next.js
+/.next/
+/out/
+next-env.d.ts
+
+# Production
+build
+dist
+
+# Misc
+.DS_Store
+*.pem
+
+# Debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Local ENV files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Vercel
+.vercel
+
+# Turborepo
+.turbo

--- a/solutions/cometchat-chat/README.md
+++ b/solutions/cometchat-chat/README.md
@@ -1,0 +1,103 @@
+---
+name: CometChat Chat Starter
+slug: cometchat-chat
+description: Add real-time chat to a Next.js app with one AI-agent prompt. CometChat skills pre-installed at .agents/skills/.
+framework: Next.js
+useCase:
+  - SaaS
+  - Realtime Apps
+css: CSS
+deployUrl: https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fsolutions%2Fcometchat-chat&project-name=cometchat-chat&repository-name=cometchat-chat&demo-title=CometChat%20Chat%20Starter&demo-description=Add%20real-time%20chat%20to%20a%20Next.js%20app%20with%20one%20AI-agent%20prompt%20-%20CometChat%20skills%20pre-installed&demo-url=https%3A%2F%2Fcometchat-vercel-template.vercel.app&env=NEXT_PUBLIC_COMETCHAT_APP_ID,NEXT_PUBLIC_COMETCHAT_REGION,NEXT_PUBLIC_COMETCHAT_AUTH_KEY&envDescription=CometChat%20credentials%20-%20optional%20at%20deploy%20time%2C%20the%20%2Fcometchat%20skill%20fills%20them%20in%20later&envLink=https%3A%2F%2Fwww.cometchat.com%2Fdocs
+demoUrl: https://cometchat-vercel-template.vercel.app
+relatedTemplates:
+  - slackbot
+---
+
+# CometChat Chat Starter
+
+A blank Next.js (App Router) app with [CometChat](https://www.cometchat.com) AI-coding skills pre-installed at `.agents/skills/`. Deploy to Vercel, clone the resulting repo, open it in Claude Code / Cursor / any AI coding IDE, and ask "add chat to my app" — the agent walks you through signup, app creation, and writes a working chat integration. No CometChat account required up front.
+
+## Demo
+
+https://cometchat-vercel-template.vercel.app
+
+## How to Use
+
+You can choose from one of the following two methods to use this repository:
+
+### One-Click Deploy
+
+Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=examples-repo):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fexamples%2Ftree%2Fmain%2Fsolutions%2Fcometchat-chat&project-name=cometchat-chat&repository-name=cometchat-chat&demo-title=CometChat%20Chat%20Starter&demo-description=Add%20real-time%20chat%20to%20a%20Next.js%20app%20with%20one%20AI-agent%20prompt%20-%20CometChat%20skills%20pre-installed&demo-url=https%3A%2F%2Fcometchat-vercel-template.vercel.app&env=NEXT_PUBLIC_COMETCHAT_APP_ID,NEXT_PUBLIC_COMETCHAT_REGION,NEXT_PUBLIC_COMETCHAT_AUTH_KEY&envDescription=CometChat%20credentials%20-%20optional%20at%20deploy%20time%2C%20the%20%2Fcometchat%20skill%20fills%20them%20in%20later&envLink=https%3A%2F%2Fwww.cometchat.com%2Fdocs)
+
+The three `NEXT_PUBLIC_COMETCHAT_*` env vars are optional at deploy time — leave them blank, and the `/cometchat` skill fills them in when you run it from your AI agent.
+
+### Clone and Deploy
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [pnpm](https://pnpm.io/installation) to bootstrap the example:
+
+```bash
+pnpm create next-app --example https://github.com/vercel/examples/tree/main/solutions/cometchat-chat cometchat-chat
+```
+
+Next, install dependencies and run the dev server:
+
+```bash
+cd cometchat-chat
+pnpm install
+pnpm dev
+```
+
+## What's pre-installed
+
+```
+.agents/skills/
+├── cometchat/                    Dispatcher — detects framework, gathers requirements, writes code
+├── cometchat-core/               Init / login / provider / env vars / SSR safety
+├── cometchat-components/         60+ component catalog with props and slot views
+├── cometchat-placement/          Where to put chat (route, modal, drawer, widget)
+├── cometchat-react-patterns/     React + Vite integration patterns
+├── cometchat-nextjs-patterns/    Next.js App Router + Pages Router patterns
+├── cometchat-react-router-patterns/
+├── cometchat-astro-patterns/
+├── cometchat-theming/            5 presets (Slack / WhatsApp / iMessage / Discord / Notion) + brand colors
+├── cometchat-features/           40+ features — calls, polls, AI, reactions, file sharing
+├── cometchat-customization/      Custom message bubbles, headers, composer actions
+├── cometchat-production/         Server-minted auth tokens, user management
+└── cometchat-troubleshooting/    Diagnostics — verify, drift, doctor
+```
+
+## How to use the skills
+
+After deploying or cloning, open the project in an AI coding IDE that reads `.agents/skills/` (Cursor, Cline, Codex, GitHub Copilot, Windsurf, Replit Agent). Ask the agent:
+
+```
+add chat to my app
+```
+
+The agent reads the dispatcher skill, detects this is a Next.js App Router project, asks 4–5 setup questions (account, app name, region, intent, placement), and writes a working chat integration into `app/`.
+
+**Claude Code users:** Claude Code reads `.claude/skills/` instead. After cloning, run once:
+
+```bash
+npx @cometchat/skills add
+```
+
+This copies the same skills into `.claude/skills/` so Claude Code picks them up.
+
+## What you can build
+
+- **Marketplace chat** (buyer ↔ seller drawer + inbox page)
+- **SaaS productivity chat** (modal from navbar + full messages page)
+- **Social / community** (full messenger with Chats / Calls / Users / Groups tabs)
+- **Customer support** (floating widget bubble in the bottom-right)
+- **Just messaging** (dedicated `/messages` route with two-pane layout)
+
+The agent picks the placement based on what you say you're building.
+
+## Source
+
+- Skills source-of-truth: [github.com/cometchat/cometchat-skills](https://github.com/cometchat/cometchat-skills)
+- UI Kit: [@cometchat/chat-uikit-react](https://www.npmjs.com/package/@cometchat/chat-uikit-react)
+- Docs: [cometchat.com/docs](https://www.cometchat.com/docs)

--- a/solutions/cometchat-chat/app/globals.css
+++ b/solutions/cometchat-chat/app/globals.css
@@ -1,0 +1,15 @@
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: #fff;
+  color: #111;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: #2563eb;
+}

--- a/solutions/cometchat-chat/app/layout.tsx
+++ b/solutions/cometchat-chat/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "CometChat × Vercel — Add chat in one prompt",
+  description:
+    "Next.js starter with CometChat AI-coding skills pre-installed. Open your AI agent and ask 'add chat to my app'.",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/solutions/cometchat-chat/app/page.tsx
+++ b/solutions/cometchat-chat/app/page.tsx
@@ -1,0 +1,90 @@
+export default function Home() {
+  return (
+    <main
+      style={{
+        fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+        maxWidth: 720,
+        margin: "0 auto",
+        padding: "48px 24px",
+        lineHeight: 1.6,
+        color: "#111",
+      }}
+    >
+      <h1 style={{ fontSize: 28, marginBottom: 12 }}>CometChat × Vercel</h1>
+      <p style={{ fontSize: 18, color: "#444", marginTop: 0 }}>
+        This is a blank Next.js (App Router) app with CometChat skills
+        pre-installed. Ask your AI coding agent to add chat — it already knows
+        how.
+      </p>
+
+      <section style={{ marginTop: 32 }}>
+        <h2 style={{ fontSize: 20 }}>Try this</h2>
+        <p>
+          Open this project in Claude Code, Cursor, Copilot, or any
+          Agent-Skills-compatible IDE, then ask:
+        </p>
+        <pre
+          style={{
+            background: "#f4f4f5",
+            padding: 16,
+            borderRadius: 8,
+            fontSize: 15,
+          }}
+        >
+          add chat to my app
+        </pre>
+        <p>
+          The agent reads <code>.agents/skills/cometchat/SKILL.md</code>,
+          detects this is a Next.js App Router project, asks 4–5 setup
+          questions, and writes a working chat integration into{" "}
+          <code>app/</code>.
+        </p>
+        <p style={{ fontSize: 14, color: "#666" }}>
+          <strong>Claude Code users:</strong> after cloning, run{" "}
+          <code>npx @cometchat/skills add</code> once — Claude Code reads from{" "}
+          <code>.claude/skills/</code> rather than <code>.agents/skills/</code>.
+        </p>
+      </section>
+
+      <section style={{ marginTop: 32 }}>
+        <h2 style={{ fontSize: 20 }}>What CometChat ships</h2>
+        <ul>
+          <li>
+            <strong>Conversations list, message thread, composer</strong> —
+            drop-in React components that handle real-time messaging out of the
+            box.
+          </li>
+          <li>
+            <strong>40+ features</strong> — calls, polls, reactions, smart
+            replies, translations, AI agents, file sharing, presence.
+          </li>
+          <li>
+            <strong>5 theme presets</strong> — Slack, WhatsApp, iMessage,
+            Discord, Notion. Or your own brand color.
+          </li>
+        </ul>
+      </section>
+
+      <section style={{ marginTop: 32, fontSize: 14, color: "#666" }}>
+        <p>
+          New to CometChat?{" "}
+          <a
+            href="https://www.cometchat.com/docs"
+            target="_blank"
+            rel="noreferrer"
+          >
+            cometchat.com/docs
+          </a>{" "}
+          ·{" "}
+          <a
+            href="https://github.com/cometchat/cometchat-skills"
+            target="_blank"
+            rel="noreferrer"
+          >
+            skills repo
+          </a>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/solutions/cometchat-chat/next.config.ts
+++ b/solutions/cometchat-chat/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/solutions/cometchat-chat/package.json
+++ b/solutions/cometchat-chat/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cometchat-chat",
+  "repository": "https://github.com/vercel/examples.git",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^16.0.10",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^8.45.0",
+    "eslint-config-next": "^13.4.10",
+    "typescript": "^5"
+  }
+}

--- a/solutions/cometchat-chat/tsconfig.json
+++ b/solutions/cometchat-chat/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Adds `solutions/cometchat-chat/` — a blank Next.js (App Router) starter with [CometChat](https://www.cometchat.com) AI-coding skills pre-installed at `.agents/skills/`.

The pitch: deploy or clone, open the project in any Agent-Skills-compatible IDE (Cursor / Cline / Codex / Replit Agent / Copilot / Windsurf), and ask the agent `add chat to my app`. The CometChat dispatcher skill walks through signup, app provisioning, and writes a working chat integration into `app/`. No CometChat account required up front.

## Demo

Live at https://cometchat-vercel-template.vercel.app — deployed via `vercel --prod` from the canonical [cometchat/cometchat-vercel-template](https://github.com/cometchat/cometchat-vercel-template) repo (the source-of-truth from which this example was bundled).

## Front matter

- `framework: Next.js`
- `useCase: SaaS, Realtime Apps`
- `css: CSS`
- `relatedTemplates: slackbot` (closest analog — third-party SaaS via Next.js)

## What's bundled

- Standard Next.js 16 + React 19 scaffold
- `.agents/skills/` with the 13-skill CometChat web set: dispatcher + foundation (core / components / placement) + per-framework patterns (react / nextjs / react-router / astro) + Phase B (theming / features / customization / production / troubleshooting)
- `.env.example` declaring `NEXT_PUBLIC_COMETCHAT_{APP_ID,REGION,AUTH_KEY}`
- `.eslintrc.json` extending `next/core-web-vitals`

## Test plan

- [x] Verified Deploy with Vercel button (the version pointing at the canonical repo) — deploys cleanly with empty env vars, landing page renders
- [x] Skills package canonical at [github.com/cometchat/cometchat-skills](https://github.com/cometchat/cometchat-skills) (open source, MIT)
- [ ] Reviewer: confirm the front matter renders correctly into a Draft template in Contentful

🤖 Authored with [Claude Code](https://claude.com/claude-code)