### PR TITLE
feat(vibe-coding-platform): add AI Gateway app attribution headers

### DIFF
--- a/apps/vibe-coding-platform/ai/gateway.ts
+++ b/apps/vibe-coding-platform/ai/gateway.ts
@@ -6,6 +6,10 @@ import type { LanguageModelV3 } from '@ai-sdk/provider'
 
 const gateway = createGatewayProvider({
   baseURL: process.env.AI_GATEWAY_BASE_URL,
+  headers: {
+    'http-referer': 'https://oss-vibe-coding-platform.vercel.app/',
+    'x-title': 'Vibe Coding Platform',
+  },
 })
 
 export interface ModelOptions {


### PR DESCRIPTION
## Summary
- Adds Vercel AI Gateway app attribution headers (`http-referer` and `x-title`) to the gateway provider configuration in the vibe-coding-platform example app
- Headers are set at the provider level so they're automatically included in all AI SDK requests (chat, error analysis, and file generation)

## Test plan
- [ ] Verify the app builds successfully
- [ ] Confirm AI Gateway requests include the `http-referer` and `x-title` headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)