### PR TITLE
fix: remove TS5-only option from hono boilerplate tsconfig

### DIFF
--- a/framework-boilerplates/hono/tsconfig.json
+++ b/framework-boilerplates/hono/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ESNext",
     "module": "NodeNext",
     "strict": true,
-    "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "types": [
       "node"


### PR DESCRIPTION
### Description

Fixes the local `vercel dev` failure for the Hono boilerplate by removing the TS5-only `verbatimModuleSyntax` compiler option from `framework-boilerplates/hono/tsconfig.json`.

This addresses issue #1240 where local dev could fail before startup with `TS5023: Unknown compiler option 'verbatimModuleSyntax'` when a TS4.9 toolchain path is used.

**Before**
```bash
# Local dev can fail before serving requests
npx vercel@48.1.6 dev --yes

# Representative failure in affected toolchain paths
TS5023: Unknown compiler option 'verbatimModuleSyntax'

# Runtime symptom when function fails to boot
502 BAD_GATEWAY
NO_RESPONSE_FROM_FUNCTION
```

**After**
```bash
# TS4.9 config parse no longer fails
npx -y -p typescript@4.9.5 tsc --showConfig -p framework-boilerplates/hono/tsconfig.json

# Project still typechecks
npx tsc --noEmit

# Local dev starts successfully
npx vercel@48.1.6 dev --yes
# -> Ready! Available at http://localhost:3000

# Endpoint responds successfully
curl -i http://localhost:3000
# -> HTTP/1.1 200 OK
```

### Demo URL

N/A (local dev server validation only)

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?