### PR TITLE
docs: clarify hono mcp setup

### DIFF
--- a/cdn/mintlify-docs-rewrite/vercel.ts
+++ b/cdn/mintlify-docs-rewrite/vercel.ts
@@ -1,6 +1,7 @@
 import { routes, type VercelConfig } from '@vercel/config/v1'
 
-const MINTLIFY_DOCS_URL = process.env.MINTLIFY_DOCS_URL || 'https://vercel-fcadfe60.mintlify.dev'
+const MINTLIFY_DOCS_URL =
+  process.env.MINTLIFY_DOCS_URL || 'https://vercel-fcadfe60.mintlify.dev'
 
 export const config: VercelConfig = {
   framework: 'nextjs',
@@ -13,7 +14,8 @@ export const config: VercelConfig = {
     routes.header('/(.*)', [
       {
         key: 'Content-Security-Policy',
-        value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com; font-src 'self' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com; img-src 'self' data: blob: d3gk2c5xim1je2.cloudfront.net mintcdn.com *.mintcdn.com cdn.jsdelivr.net; connect-src 'self' *.mintlify.dev *.mintlify.com d1ctpt7j8wusba.cloudfront.net mintcdn.com *.mintcdn.com api.mintlifytrieve.com; frame-src 'self' *.mintlify.dev;",
+        value:
+          "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com; font-src 'self' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com; img-src 'self' data: blob: d3gk2c5xim1je2.cloudfront.net mintcdn.com *.mintcdn.com cdn.jsdelivr.net; connect-src 'self' *.mintlify.dev *.mintlify.com d1ctpt7j8wusba.cloudfront.net mintcdn.com *.mintcdn.com api.mintlifytrieve.com; frame-src 'self' *.mintlify.dev;",
       },
     ]),
   ],

--- a/cdn/mintlify-docs-rewrite/vercel.ts
+++ b/cdn/mintlify-docs-rewrite/vercel.ts
@@ -1,4 +1,4 @@
-import type { VercelConfig } from '@vercel/config/v1'
+import { routes, type VercelConfig } from '@vercel/config/v1'
 
 const MINTLIFY_DOCS_URL = process.env.MINTLIFY_DOCS_URL || 'https://vercel-fcadfe60.mintlify.dev'
 
@@ -6,25 +6,15 @@ export const config: VercelConfig = {
   framework: 'nextjs',
   outputDirectory: '.next',
   rewrites: [
-    {
-      source: '/docs',
-      destination: `${MINTLIFY_DOCS_URL}/docs`,
-    },
-    {
-      source: '/docs/:match*',
-      destination: `${MINTLIFY_DOCS_URL}/docs/:match*`,
-    },
+    routes.rewrite('/docs', `${MINTLIFY_DOCS_URL}/docs`),
+    routes.rewrite('/docs/:match*', `${MINTLIFY_DOCS_URL}/docs/:match*`),
   ],
   headers: [
-    {
-      source: '/(.*)',
-      headers: [
-        {
-          key: 'Content-Security-Policy',
-          value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com; font-src 'self' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com; img-src 'self' data: blob: d3gk2c5xim1je2.cloudfront.net mintcdn.com *.mintcdn.com cdn.jsdelivr.net; connect-src 'self' *.mintlify.dev *.mintlify.com d1ctpt7j8wusba.cloudfront.net mintcdn.com *.mintcdn.com api.mintlifytrieve.com; frame-src 'self' *.mintlify.dev;",
-        },
-      ],
-    },
+    routes.header('/(.*)', [
+      {
+        key: 'Content-Security-Policy',
+        value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com; font-src 'self' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com; img-src 'self' data: blob: d3gk2c5xim1je2.cloudfront.net mintcdn.com *.mintcdn.com cdn.jsdelivr.net; connect-src 'self' *.mintlify.dev *.mintlify.com d1ctpt7j8wusba.cloudfront.net mintcdn.com *.mintcdn.com api.mintlifytrieve.com; frame-src 'self' *.mintlify.dev;",
+      },
+    ]),
   ],
 }
-

--- a/starter/hono-mcp/README.md
+++ b/starter/hono-mcp/README.md
@@ -22,17 +22,24 @@ The Model Context Protocol (MCP) is an open protocol that standardizes how appli
 ## Prerequisites
 
 - [Vercel CLI](https://vercel.com/docs/cli) installed globally
+- Node.js 20 or later
 
 ## Development
 
-To develop locally:
+Run commands from this example directory, not from the repository root:
 
-```
+```bash
+cd starter/hono-mcp
 npm install
-vc dev
+vercel dev
 ```
 
-```
+When the Vercel CLI asks for the project root, keep the default current
+directory (`starter/hono-mcp`). Do not point the project root at `src`; `src`
+contains the Hono entrypoint, but the package metadata and lockfile live one
+level above it.
+
+```bash
 open http://localhost:3000
 ```
 
@@ -40,18 +47,18 @@ open http://localhost:3000
 
 To build locally:
 
-```
+```bash
 npm install
-vc build
+vercel build
 ```
 
 ## Deployment
 
 To deploy:
 
-```
+```bash
 npm install
-vc deploy
+vercel deploy
 ```
 
 ## API Endpoints


### PR DESCRIPTION
## Summary
- Clarifies that local commands should be run from `starter/hono-mcp` rather than `src`
- Expands setup details for the Vercel CLI project root prompt
- Uses explicit `vercel` commands in the README examples

Fixes #1217.

## Verification
- git diff --check