### PR TITLE
[vercel-flags] use oidc

### DIFF
--- a/flags-sdk/vercel/.env.example
+++ b/flags-sdk/vercel/.env.example
@@ -1,7 +1,4 @@
 # For @flags-sdk/vercel
-# The FLAGS environment variable is automatically provisioned by Vercel when you
-# create your first flag in the Vercel Dashboard. Pull it with `vercel env pull`.
-FLAGS=""
 
 # Required for precompute and secure local overrides in Flags Explorer
 # node -e 'console.log(`${crypto.randomBytes(32).toString("base64url")}`)'

--- a/flags-sdk/vercel/app/setup/page.tsx
+++ b/flags-sdk/vercel/app/setup/page.tsx
@@ -41,7 +41,6 @@ function StatusPill({ ready }: { ready: boolean }) {
 
 export default function SetupPage() {
   // Demo-only signal check for this template.
-  const hasFlags = Boolean(process.env.FLAGS)
   const hasFlagsSecret = Boolean(process.env.FLAGS_SECRET)
 
   return (
@@ -59,10 +58,6 @@ export default function SetupPage() {
             feature flags and pulling environment variables
           </p>
           <div className="mt-4 flex flex-wrap gap-3">
-            <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-2 py-1.5">
-              <code className="text-sm">FLAGS</code>
-              <StatusPill ready={hasFlags} />
-            </div>
             <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-2 py-1.5">
               <code className="text-sm">FLAGS_SECRET</code>
               <StatusPill ready={hasFlagsSecret} />
@@ -181,8 +176,8 @@ export default function SetupPage() {
                 className="text-link"
               >
                 Quickstart guide
-              </Link>
-              {' '}for more information.
+              </Link>{' '}
+              for more information.
             </p>
           </div>
         </section>

--- a/flags-sdk/vercel/flags.ts
+++ b/flags-sdk/vercel/flags.ts
@@ -2,13 +2,7 @@ import { flag } from 'flags/next'
 import { createVercelAdapter } from '@flags-sdk/vercel'
 import { identify, type Entities } from './lib/identify'
 
-if (!process.env.FLAGS) {
-  throw new Error(
-    'Missing Vercel Flags SDK key. Set FLAGS by linking your project and running `vercel env pull`.'
-  )
-}
-
-const vercelFlagsAdapter = createVercelAdapter(process.env.FLAGS)
+const vercelFlagsAdapter = createVercelAdapter()
 
 export const showSummerBannerFlag = flag<boolean, Entities>({
   key: 'summer-sale',

--- a/flags-sdk/vercel/proxy.ts
+++ b/flags-sdk/vercel/proxy.ts
@@ -8,9 +8,8 @@ export const config = {
 }
 
 export async function proxy(request: NextRequest) {
-  const hasFlags = Boolean(process.env.FLAGS)
   const hasFlagsSecret = Boolean(process.env.FLAGS_SECRET)
-  if (!hasFlags || !hasFlagsSecret) {
+  if (!hasFlagsSecret) {
     return NextResponse.rewrite(new URL('/setup', request.url))
   }
 


### PR DESCRIPTION
### Description

I upgraded the flags sdk's here: https://github.com/vercel/examples/pull/1495

Now we can make use of the oidc support added by removing all process.env.FLAGS references

### Type of Change

- [ ] New Example
- [x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

