### PR TITLE
add team-backends to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,10 +15,17 @@ solutions/testing @vercel/turbo-oss @goncy @lfades @lpalmes
 # A member of Solutions and Dev Rel is also added
 build-output-api @tootallnate @lfades @lpalmes
 
+# Backend language and service examples
+/go/ @vercel/team-backends
+/rust/ @vercel/team-backends
+/ruby/ @vercel/team-backends
+/services/ @vercel/team-backends
+/python/ @vercel/team-backends @vercel/team-python
+
 vercel-tutor @chibicode
 
 microfrontends @kitfoster @lazarv @mknichel
 
 cdn @vercel/edge-ingress @vercel/edge-content @vercel/edge-security @pranavkarthik10
 
-websockets @vercel/edge-ingress
+websockets @vercel/edge-ingress @vercel/team-backends @vercel/team-python


### PR DESCRIPTION
### Description

add team-backends to codeowners

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
