### PR TITLE
docs: update templates for rust websocket / container images

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,11 +16,12 @@ solutions/testing @vercel/turbo-oss @goncy @lfades @lpalmes
 build-output-api @tootallnate @lfades @lpalmes
 
 # Backend language and service examples
-/go/ @vercel/team-backends
-/rust/ @vercel/team-backends
-/ruby/ @vercel/team-backends
-/services/ @vercel/team-backends
-/python/ @vercel/team-backends @vercel/team-python
+/go/ @vercel/team-backends @vercel/compute
+/rust/ @vercel/team-backends @vercel/compute
+/ruby/ @vercel/team-backends @vercel/compute
+/services/ @vercel/team-backends @vercel/compute
+/python/ @vercel/team-backends @vercel/team-python @vercel/compute
+/container-images/ @vercel/team-backends @vercel/compute
 
 vercel-tutor @chibicode
 

--- a/container-images/demo/README.md
+++ b/container-images/demo/README.md
@@ -1,3 +1,24 @@
+---
+name: Container Images
+slug: container-images-demo
+description: Containerized services built from their own Dockerfiles, running as Vercel Functions behind a single domain.
+framework:
+  - Next.js
+  - Other
+type:
+  - Starter
+css:
+  - Tailwind
+githubUrl: https://github.com/vercel/examples/tree/main/container-images/demo
+demoUrl: https://container-images-demo.vercel.app
+deployUrl: https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/container-images/demo&project-name=container-images-demo&repository-name=container-images-demo
+publisher: Vercel
+relatedTemplates:
+  - rust-axum
+  - rust-websocket
+  - rust-hello-world
+---
+
 # Dockerfile Runtime
 
 A collection of containerized services running as [Vercel Functions](https://vercel.com/docs/functions), each built from its own `Dockerfile` and routed through a single [`vercel.json`](./vercel.json). It showcases the Vercel Dockerfile runtime alongside the native Next.js runtime — nine independent services sharing one domain.

--- a/internal/scripts/lib/update-changed-templates.ts
+++ b/internal/scripts/lib/update-changed-templates.ts
@@ -2,7 +2,15 @@ import path from 'path'
 import log from './log'
 import updateTemplate from './contentful/update-template'
 
-const DIRS = ['edge-middleware', 'python', 'rust', 'solutions', 'starter', 'storage']
+const DIRS = [
+  'container-images',
+  'edge-middleware',
+  'python',
+  'rust',
+  'solutions',
+  'starter',
+  'storage',
+]
 const IS_README = /readme\.md$/i
 
 export default async function updateChangedTemplates(changedFiles: string[]) {

--- a/rust/websocket/README.md
+++ b/rust/websocket/README.md
@@ -1,8 +1,9 @@
 ---
 name: Rust WebSocket
 slug: rust-websocket
-description: A Rust WebSocket server Vercel
+description: Rust WebSocket Server
 framework:
+  - Axum
   - Other
 type:
   - Starter


### PR DESCRIPTION
### Description

Updates template generation to account for container-images example
Also updates template for rust websocket (need to retrigger because token was broken)

Also makes `@vercel/compute` CODEOWNERS of services / go / rust etc.

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
