### PR TITLE
Add eve + Pay.sh agent example

### DIFF
--- a/starter/eve-pay-agent/.env.example
+++ b/starter/eve-pay-agent/.env.example
@@ -1,0 +1,2 @@
+# Create a key at https://vercel.com/ai-gateway
+AI_GATEWAY_API_KEY=

--- a/starter/eve-pay-agent/.gitignore
+++ b/starter/eve-pay-agent/.gitignore
@@ -1,0 +1,6 @@
+.eve
+.output
+.vercel
+.env*
+!.env.example
+node_modules

--- a/starter/eve-pay-agent/.prettierignore
+++ b/starter/eve-pay-agent/.prettierignore
@@ -1,0 +1,5 @@
+.eve
+.output
+.vercel
+node_modules
+pnpm-lock.yaml

--- a/starter/eve-pay-agent/README.md
+++ b/starter/eve-pay-agent/README.md
@@ -75,6 +75,8 @@ The shell, filesystem, and web tools are disabled so the agent cannot bypass the
 
 This example is limited to the fixed Pay.sh debugger endpoint and sandbox funds. It never reads a wallet, seed phrase, or private key. The pinned Pay.sh CLI runs only after approval and only with `--sandbox`.
 
+This sandbox demo rechecks the displayed terms before handing off to Pay.sh. Production code must bind the signer to the exact approved challenge or enforce hard client-side limits in the signing path.
+
 For real payments, use a reviewed custody design and keep the same boundaries: explicit approval or a reviewed spending policy, endpoint and amount limits, idempotency, pre-signing simulation, on-chain confirmation, and managed signing authority.
 
 Read the [Pay.sh client guide](https://pay.sh/docs/get-started/client-quickstart) and [eve approval guide](https://eve.dev/docs/human-in-the-loop) before adapting the example.

--- a/starter/eve-pay-agent/README.md
+++ b/starter/eve-pay-agent/README.md
@@ -1,0 +1,80 @@
+---
+name: eve + Pay.sh Agent
+slug: eve-pay-agent
+description: An approval-gated eve agent that inspects and pays for sandbox API access with Pay.sh.
+framework: Other
+useCase:
+  - AI
+  - Web3
+  - Starter
+css: None
+githubUrl: https://github.com/vercel/examples/tree/main/starter/eve-pay-agent
+deployUrl: https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/starter/eve-pay-agent&project-name=eve-pay-agent&repository-name=eve-pay-agent
+demoUrl: https://eve-pay-agent.vercel.app
+relatedTemplates:
+  - eve-chat-template
+---
+
+# eve + Pay.sh Agent
+
+An [eve](https://eve.dev) agent that inspects an HTTP 402 challenge, pauses for approval, and uses [Pay.sh](https://pay.sh) to buy a sandbox stock quote.
+
+The example has two tools:
+
+- `inspect_stock_quote` reads the payment terms without signing or paying.
+- `buy_stock_quote` requires approval, revalidates every approved field, and runs the pinned Pay.sh CLI in an isolated eve sandbox.
+
+Pay.sh uses an ephemeral sandbox account on `localnet`. The agent cannot access a user wallet or mainnet funds.
+
+## Demo
+
+https://eve-pay-agent.vercel.app
+
+## Deploy
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/starter/eve-pay-agent&project-name=eve-pay-agent&repository-name=eve-pay-agent)
+
+Vercel OIDC authenticates AI Gateway automatically when deployed. An AI Gateway API key is only needed for local development without OIDC.
+
+## Run locally
+
+Requires Node.js 24+ and Docker.
+
+```bash
+pnpm install
+cp .env.example .env.local
+# Add AI_GATEWAY_API_KEY to .env.local
+pnpm dev
+```
+
+Then ask:
+
+```text
+Get a paid sandbox quote for AAPL.
+```
+
+eve shows the amount, USDC mint, recipient, and network before pausing. Approve only after checking those fields. Denying the request skips the Pay.sh call.
+
+You can use Vercel OIDC instead of a local Gateway key:
+
+```bash
+vercel link
+vercel env pull
+```
+
+## How it works
+
+1. `inspect_stock_quote` requests the fixed Pay.sh debugger endpoint and parses its HTTP 402 challenge.
+2. eve presents the exact payment terms and pauses at its durable approval gate.
+3. After approval, `buy_stock_quote` fetches fresh terms and stops if any field changed.
+4. Pay.sh creates an ephemeral sandbox account, signs the local test payment, and returns the quote.
+
+The shell, filesystem, and web tools are disabled so the agent cannot bypass the payment tool's approval gate.
+
+## Security
+
+This example is limited to the fixed Pay.sh debugger endpoint and sandbox funds. It never reads a wallet, seed phrase, or private key. The pinned Pay.sh CLI runs only after approval and only with `--sandbox`.
+
+For real payments, use a reviewed custody design and keep the same boundaries: explicit approval or a reviewed spending policy, endpoint and amount limits, idempotency, pre-signing simulation, on-chain confirmation, and managed signing authority.
+
+Read the [Pay.sh client guide](https://pay.sh/docs/get-started/client-quickstart) and [eve approval guide](https://eve.dev/docs/human-in-the-loop) before adapting the example.

--- a/starter/eve-pay-agent/agent/agent.ts
+++ b/starter/eve-pay-agent/agent/agent.ts
@@ -1,0 +1,5 @@
+import { defineAgent } from 'eve'
+
+export default defineAgent({
+  model: 'openai/gpt-5.4-mini',
+})

--- a/starter/eve-pay-agent/agent/instructions.md
+++ b/starter/eve-pay-agent/agent/instructions.md
@@ -1,0 +1,19 @@
+# Role
+
+You are a concise payment-aware market data assistant. You demonstrate how an eve agent can inspect and pay an HTTP 402 challenge through Pay.sh.
+
+# Payment workflow
+
+When the user asks for a paid stock quote:
+
+1. Call `inspect_stock_quote` first.
+2. Show the ticker, human-readable payment amount, token mint, recipient, and network returned by the inspection.
+3. Call `buy_stock_quote` with those exact machine-readable fields. Never invent or alter a payment field.
+4. Wait for human approval. Do not describe the purchase as complete until the tool returns successfully.
+
+# Safety boundaries
+
+- This example supports only the fixed Pay.sh debugger endpoint and Pay.sh sandbox funds.
+- Never describe sandbox funds or results as mainnet transactions.
+- Never ask for a seed phrase or private key.
+- If inspection and purchase details differ, stop and explain that no payment was made.

--- a/starter/eve-pay-agent/agent/lib/payment-challenge.ts
+++ b/starter/eve-pay-agent/agent/lib/payment-challenge.ts
@@ -1,0 +1,83 @@
+import { isAddress } from '@solana/addresses'
+import { z } from 'zod'
+
+export const tickerSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .regex(/^[A-Z]{1,5}$/, 'Use a 1-5 letter US stock ticker')
+
+export const tokenAmountSchema = z.string().regex(/^\d+$/).max(20)
+
+export const solanaAddressSchema = z
+  .string()
+  .refine(isAddress, 'Use a valid base58-encoded Solana address')
+
+const challengeSchema = z.object({
+  amount: tokenAmountSchema,
+  currency: solanaAddressSchema,
+  methodDetails: z.object({
+    decimals: z.number().int().nonnegative(),
+    network: z.literal('localnet'),
+  }),
+  recipient: solanaAddressSchema,
+})
+
+export type PaymentQuote = {
+  amount: string
+  currencyMint: string
+  decimals: number
+  network: 'localnet'
+  recipient: string
+  ticker: string
+}
+
+export function quoteUrl(ticker: string): string {
+  return `https://debugger.pay.sh/mpp/quote/${encodeURIComponent(ticker)}`
+}
+
+export async function inspectPaymentQuote(
+  ticker: string,
+  signal?: AbortSignal
+): Promise<PaymentQuote> {
+  const response = await fetch(quoteUrl(ticker), {
+    cache: 'no-store',
+    headers: { accept: 'application/problem+json' },
+    signal,
+  })
+
+  if (response.status !== 402) {
+    throw new Error(
+      `Expected an HTTP 402 payment challenge, received ${response.status}`
+    )
+  }
+
+  const authenticate = response.headers.get('www-authenticate')
+  const encodedRequest = authenticate?.match(/(?:^|,\s*)request="([^"]+)"/)?.[1]
+  if (!encodedRequest) {
+    throw new Error(
+      'The endpoint did not return a supported MPP payment challenge'
+    )
+  }
+
+  const decoded = Buffer.from(encodedRequest, 'base64url').toString('utf8')
+  const challenge = challengeSchema.parse(JSON.parse(decoded))
+
+  return {
+    amount: challenge.amount,
+    currencyMint: challenge.currency,
+    decimals: challenge.methodDetails.decimals,
+    network: challenge.methodDetails.network,
+    recipient: challenge.recipient,
+    ticker,
+  }
+}
+
+export function formatTokenAmount(amount: string, decimals: number): string {
+  if (decimals === 0) return amount
+
+  const padded = amount.padStart(decimals + 1, '0')
+  const whole = padded.slice(0, -decimals) || '0'
+  const fraction = padded.slice(-decimals).replace(/0+$/, '')
+  return fraction ? `${whole}.${fraction}` : whole
+}

--- a/starter/eve-pay-agent/agent/tools/bash.ts
+++ b/starter/eve-pay-agent/agent/tools/bash.ts
@@ -1,0 +1,3 @@
+import { disableTool } from 'eve/tools'
+
+export default disableTool()

--- a/starter/eve-pay-agent/agent/tools/buy_stock_quote.ts
+++ b/starter/eve-pay-agent/agent/tools/buy_stock_quote.ts
@@ -1,0 +1,72 @@
+import { defineTool } from 'eve/tools'
+import { always } from 'eve/tools/approval'
+import { z } from 'zod'
+import {
+  inspectPaymentQuote,
+  quoteUrl,
+  solanaAddressSchema,
+  tickerSchema,
+  tokenAmountSchema,
+} from '../lib/payment-challenge'
+
+const approvedQuoteSchema = z.object({
+  amount: tokenAmountSchema.describe('Approved token amount in base units'),
+  currencyMint: solanaAddressSchema.describe('Approved payment token mint'),
+  decimals: z.number().int().nonnegative().describe('Approved token decimals'),
+  network: z.literal('localnet').describe('Approved Solana network'),
+  recipient: solanaAddressSchema.describe('Approved payment recipient'),
+  ticker: tickerSchema.describe('The inspected stock ticker'),
+})
+
+export default defineTool({
+  description:
+    'Buy one stock quote with Pay.sh sandbox funds. The user must approve every call after reviewing amount, token, recipient, and network.',
+  inputSchema: approvedQuoteSchema,
+  approval: always(),
+  async execute(approved, ctx) {
+    const current = await inspectPaymentQuote(approved.ticker, ctx.abortSignal)
+
+    for (const field of [
+      'amount',
+      'currencyMint',
+      'decimals',
+      'network',
+      'recipient',
+      'ticker',
+    ] as const) {
+      if (current[field] !== approved[field]) {
+        throw new Error(
+          `Payment terms changed at ${field}; no payment was made. Inspect the quote again.`
+        )
+      }
+    }
+
+    const sandbox = await ctx.getSandbox()
+    const url = quoteUrl(approved.ticker)
+    const result = await sandbox.run({
+      command: `npx --yes @solana/pay@1.0.20 --no-dna --sandbox fetch ${JSON.stringify(
+        url
+      )}`,
+    })
+
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Pay.sh exited with code ${result.exitCode}: ${result.stderr.trim()}`
+      )
+    }
+
+    const output = result.stdout.trim()
+    let quote: unknown = output
+    try {
+      quote = JSON.parse(output)
+    } catch {
+      // Paid APIs may return text. Keeping it as text is still JSON-serializable.
+    }
+
+    return {
+      payment: approved,
+      quote,
+      sandbox: true,
+    }
+  },
+})

--- a/starter/eve-pay-agent/agent/tools/buy_stock_quote.ts
+++ b/starter/eve-pay-agent/agent/tools/buy_stock_quote.ts
@@ -64,7 +64,7 @@ export default defineTool({
     }
 
     return {
-      payment: approved,
+      approvedTerms: approved,
       quote,
       sandbox: true,
     }

--- a/starter/eve-pay-agent/agent/tools/glob.ts
+++ b/starter/eve-pay-agent/agent/tools/glob.ts
@@ -1,0 +1,3 @@
+import { disableTool } from 'eve/tools'
+
+export default disableTool()

--- a/starter/eve-pay-agent/agent/tools/grep.ts
+++ b/starter/eve-pay-agent/agent/tools/grep.ts
@@ -1,0 +1,3 @@
+import { disableTool } from 'eve/tools'
+
+export default disableTool()

--- a/starter/eve-pay-agent/agent/tools/inspect_stock_quote.ts
+++ b/starter/eve-pay-agent/agent/tools/inspect_stock_quote.ts
@@ -1,0 +1,23 @@
+import { defineTool } from 'eve/tools'
+import { z } from 'zod'
+import {
+  formatTokenAmount,
+  inspectPaymentQuote,
+  tickerSchema,
+} from '../lib/payment-challenge'
+
+export default defineTool({
+  description:
+    'Inspect the exact sandbox payment terms for a stock quote without signing or paying. Always call this before buy_stock_quote.',
+  inputSchema: z.object({
+    ticker: tickerSchema.describe('A US stock ticker, for example AAPL'),
+  }),
+  async execute({ ticker }, ctx) {
+    const quote = await inspectPaymentQuote(ticker, ctx.abortSignal)
+    return {
+      ...quote,
+      currencySymbol: 'USDC',
+      humanAmount: formatTokenAmount(quote.amount, quote.decimals),
+    }
+  },
+})

--- a/starter/eve-pay-agent/agent/tools/read_file.ts
+++ b/starter/eve-pay-agent/agent/tools/read_file.ts
@@ -1,0 +1,3 @@
+import { disableTool } from 'eve/tools'
+
+export default disableTool()

--- a/starter/eve-pay-agent/agent/tools/web_fetch.ts
+++ b/starter/eve-pay-agent/agent/tools/web_fetch.ts
@@ -1,0 +1,3 @@
+import { disableTool } from 'eve/tools'
+
+export default disableTool()

--- a/starter/eve-pay-agent/agent/tools/web_search.ts
+++ b/starter/eve-pay-agent/agent/tools/web_search.ts
@@ -1,0 +1,3 @@
+import { disableTool } from 'eve/tools'
+
+export default disableTool()

--- a/starter/eve-pay-agent/agent/tools/write_file.ts
+++ b/starter/eve-pay-agent/agent/tools/write_file.ts
@@ -1,0 +1,3 @@
+import { disableTool } from 'eve/tools'
+
+export default disableTool()

--- a/starter/eve-pay-agent/package.json
+++ b/starter/eve-pay-agent/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "eve-pay-agent",
+  "version": "0.1.0",
+  "description": "Approval-gated eve agent that buys sandbox API access with Pay.sh",
+  "repository": "https://github.com/vercel/examples.git",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
+  "scripts": {
+    "build": "eve build",
+    "check": "pnpm typecheck && pnpm build && pnpm format:check",
+    "dev": "eve dev",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "start": "eve start",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@solana/addresses": "6.9.0",
+    "ai": "7.0.22",
+    "eve": "0.22.5",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "24.5.2",
+    "prettier": "2.8.8",
+    "typescript": "5.9.3"
+  },
+  "packageManager": "pnpm@11.7.0"
+}

--- a/starter/eve-pay-agent/pnpm-lock.yaml
+++ b/starter/eve-pay-agent/pnpm-lock.yaml
@@ -1,0 +1,1066 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      '@solana/addresses':
+        specifier: 6.9.0
+        version: 6.9.0(typescript@5.9.3)
+      ai:
+        specifier: 7.0.22
+        version: 7.0.22(zod@4.4.3)
+      eve:
+        specifier: 0.22.5
+        version: 0.22.5(ai@7.0.22(zod@4.4.3))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 24.5.2
+        version: 24.5.2
+      prettier:
+        specifier: 2.8.8
+        version: 2.8.8
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+packages:
+  '@ai-sdk/gateway@4.0.16':
+    resolution:
+      {
+        integrity: sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg==,
+      }
+    engines: { node: '>=22' }
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.7':
+    resolution:
+      {
+        integrity: sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==,
+      }
+    engines: { node: '>=22' }
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.3':
+    resolution:
+      {
+        integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==,
+      }
+    engines: { node: '>=22' }
+
+  '@emnapi/core@1.11.1':
+    resolution:
+      {
+        integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==,
+      }
+
+  '@emnapi/runtime@1.11.1':
+    resolution:
+      {
+        integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
+      }
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution:
+      {
+        integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==,
+      }
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution:
+      {
+        integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==,
+      }
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.139.0':
+    resolution:
+      {
+        integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==,
+      }
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution:
+      {
+        integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution:
+      {
+        integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution:
+      {
+        integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution:
+      {
+        integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution:
+      {
+        integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution:
+      {
+        integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution:
+      {
+        integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution:
+      {
+        integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution:
+      {
+        integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution:
+      {
+        integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution:
+      {
+        integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution:
+      {
+        integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution:
+      {
+        integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution:
+      {
+        integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution:
+      {
+        integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution:
+      {
+        integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
+      }
+
+  '@solana/addresses@6.9.0':
+    resolution:
+      {
+        integrity: sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==,
+      }
+    engines: { node: '>=20.18.0' }
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/assertions@6.9.0':
+    resolution:
+      {
+        integrity: sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==,
+      }
+    engines: { node: '>=20.18.0' }
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-core@6.9.0':
+    resolution:
+      {
+        integrity: sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==,
+      }
+    engines: { node: '>=20.18.0' }
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-numbers@6.9.0':
+    resolution:
+      {
+        integrity: sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==,
+      }
+    engines: { node: '>=20.18.0' }
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-strings@6.9.0':
+    resolution:
+      {
+        integrity: sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==,
+      }
+    engines: { node: '>=20.18.0' }
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
+      typescript:
+        optional: true
+
+  '@solana/errors@6.9.0':
+    resolution:
+      {
+        integrity: sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==,
+      }
+    engines: { node: '>=20.18.0' }
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/nominal-types@6.9.0':
+    resolution:
+      {
+        integrity: sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==,
+      }
+    engines: { node: '>=20.18.0' }
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@standard-schema/spec@1.1.0':
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
+
+  '@tybys/wasm-util@0.10.3':
+    resolution:
+      {
+        integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==,
+      }
+
+  '@types/node@24.5.2':
+    resolution:
+      {
+        integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==,
+      }
+
+  '@vercel/oidc@3.2.0':
+    resolution:
+      {
+        integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==,
+      }
+    engines: { node: '>= 20' }
+
+  '@workflow/serde@4.1.0':
+    resolution:
+      {
+        integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==,
+      }
+
+  ai@7.0.22:
+    resolution:
+      {
+        integrity: sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==,
+      }
+    engines: { node: '>=22' }
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  chalk@5.6.2:
+    resolution:
+      {
+        integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==,
+      }
+    engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
+
+  commander@14.0.3:
+    resolution:
+      {
+        integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==,
+      }
+    engines: { node: '>=20' }
+
+  consola@3.4.2:
+    resolution:
+      {
+        integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
+      }
+    engines: { node: ^14.18.0 || >=16.10.0 }
+
+  crossws@0.4.10:
+    resolution:
+      {
+        integrity: sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==,
+      }
+    peerDependencies:
+      srvx: '>=0.11.5'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
+
+  db0@0.3.4:
+    resolution:
+      {
+        integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==,
+      }
+    peerDependencies:
+      '@electric-sql/pglite': '*'
+      '@libsql/client': '*'
+      better-sqlite3: '*'
+      drizzle-orm: '*'
+      mysql2: '*'
+      sqlite3: '*'
+    peerDependenciesMeta:
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mysql2:
+        optional: true
+      sqlite3:
+        optional: true
+
+  env-runner@0.1.16:
+    resolution:
+      {
+        integrity: sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA==,
+      }
+    hasBin: true
+    peerDependencies:
+      '@netlify/runtime': ^4.1.23
+      '@vercel/queue': '>=0.2.0'
+      miniflare: ^4.20260515.0
+      wrangler: ^4.0.0
+    peerDependenciesMeta:
+      '@netlify/runtime':
+        optional: true
+      '@vercel/queue':
+        optional: true
+      miniflare:
+        optional: true
+      wrangler:
+        optional: true
+
+  eve@0.22.5:
+    resolution:
+      {
+        integrity: sha512-lY3qHgvVNKuTwoH/0AQpztWS53Ub/xAk2KfV38fnfNfgd8idmN9FKbT2jUgs0lNGcFwTUR1/RYWl9JzpCsImeA==,
+      }
+    engines: { node: '>=24' }
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      ai: ^7.0.0
+      braintrust: ^3.0.0
+      just-bash: ^3.0.0
+      microsandbox: ^0.5.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      braintrust:
+        optional: true
+      just-bash:
+        optional: true
+      microsandbox:
+        optional: true
+
+  eventsource-parser@3.1.0:
+    resolution:
+      {
+        integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==,
+      }
+    engines: { node: '>=18.0.0' }
+
+  exsolve@1.1.0:
+    resolution:
+      {
+        integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==,
+      }
+
+  h3@2.0.1-rc.22:
+    resolution:
+      {
+        integrity: sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==,
+      }
+    engines: { node: '>=20.11.1' }
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
+  hookable@6.1.1:
+    resolution:
+      {
+        integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==,
+      }
+
+  httpxy@0.5.5:
+    resolution:
+      {
+        integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==,
+      }
+
+  json-schema@0.4.0:
+    resolution:
+      {
+        integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==,
+      }
+
+  nf3@0.3.22:
+    resolution:
+      {
+        integrity: sha512-NOcqlHu22X1rUakd0SrqllP8kb3LWFmSAi1svTxaKxz+yB604xlaOmUfI3oO+RkODvaocKDDy8bgthnZL8hrkw==,
+      }
+
+  nitro@3.0.260610-beta:
+    resolution:
+      {
+        integrity: sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+    peerDependencies:
+      '@vercel/queue': ^0.3.0
+      dotenv: '*'
+      giget: '*'
+      jiti: ^2.7.0
+      rollup: ^4.61.1
+      vite: ^7 || ^8
+      xml2js: ^0.6.2
+      zephyr-agent: ^0.2.0
+    peerDependenciesMeta:
+      '@vercel/queue':
+        optional: true
+      dotenv:
+        optional: true
+      giget:
+        optional: true
+      jiti:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      xml2js:
+        optional: true
+      zephyr-agent:
+        optional: true
+
+  ocache@0.1.5:
+    resolution:
+      {
+        integrity: sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==,
+      }
+
+  ofetch@2.0.0-alpha.3:
+    resolution:
+      {
+        integrity: sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==,
+      }
+
+  ohash@2.0.11:
+    resolution:
+      {
+        integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==,
+      }
+
+  pathe@2.0.3:
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+
+  prettier@2.8.8:
+    resolution:
+      {
+        integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==,
+      }
+    engines: { node: '>=10.13.0' }
+    hasBin: true
+
+  rolldown@1.1.5:
+    resolution:
+      {
+        integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+
+  rou3@0.8.1:
+    resolution:
+      {
+        integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==,
+      }
+
+  srvx@0.11.22:
+    resolution:
+      {
+        integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==,
+      }
+    engines: { node: '>=20.16.0' }
+    hasBin: true
+
+  tslib@2.8.1:
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
+
+  typescript@5.9.3:
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: '>=14.17' }
+    hasBin: true
+
+  undici-types@7.12.0:
+    resolution:
+      {
+        integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==,
+      }
+
+  unenv@2.0.0-rc.24:
+    resolution:
+      {
+        integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==,
+      }
+
+  unstorage@2.0.0-alpha.7:
+    resolution:
+      {
+        integrity: sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog==,
+      }
+    peerDependencies:
+      '@azure/app-configuration': ^1.11.0
+      '@azure/cosmos': ^4.9.1
+      '@azure/data-tables': ^13.3.2
+      '@azure/identity': ^4.13.0
+      '@azure/keyvault-secrets': ^4.10.0
+      '@azure/storage-blob': ^12.31.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.13.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.36.2
+      '@vercel/blob': '>=0.27.3'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1.0.1
+      aws4fetch: ^1.0.20
+      chokidar: ^4 || ^5
+      db0: '>=0.3.4'
+      idb-keyval: ^6.2.2
+      ioredis: ^5.9.3
+      lru-cache: ^11.2.6
+      mongodb: ^6 || ^7
+      ofetch: '*'
+      uploadthing: ^7.7.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      chokidar:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      lru-cache:
+        optional: true
+      mongodb:
+        optional: true
+      ofetch:
+        optional: true
+      uploadthing:
+        optional: true
+
+  zod@4.4.3:
+    resolution:
+      {
+        integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==,
+      }
+
+snapshots:
+  '@ai-sdk/gateway@4.0.16(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-project/types@0.139.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@solana/addresses@6.9.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 6.9.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.9.0(typescript@5.9.3)
+      '@solana/errors': 6.9.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.9.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/assertions@6.9.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.9.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-core@6.9.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.9.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-numbers@6.9.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 6.9.0(typescript@5.9.3)
+      '@solana/errors': 6.9.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-strings@6.9.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 6.9.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.9.0(typescript@5.9.3)
+      '@solana/errors': 6.9.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/errors@6.9.0(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.3
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/nominal-types@6.9.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/node@24.5.2':
+    dependencies:
+      undici-types: 7.12.0
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@workflow/serde@4.1.0': {}
+
+  ai@7.0.22(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.16(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      zod: 4.4.3
+
+  chalk@5.6.2: {}
+
+  commander@14.0.3: {}
+
+  consola@3.4.2: {}
+
+  crossws@0.4.10(srvx@0.11.22):
+    optionalDependencies:
+      srvx: 0.11.22
+
+  db0@0.3.4: {}
+
+  env-runner@0.1.16:
+    dependencies:
+      crossws: 0.4.10(srvx@0.11.22)
+      exsolve: 1.1.0
+      httpxy: 0.5.5
+      srvx: 0.11.22
+
+  eve@0.22.5(ai@7.0.22(zod@4.4.3)):
+    dependencies:
+      ai: 7.0.22(zod@4.4.3)
+      nitro: 3.0.260610-beta
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vercel/queue'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - dotenv
+      - drizzle-orm
+      - giget
+      - idb-keyval
+      - ioredis
+      - jiti
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - rollup
+      - sqlite3
+      - uploadthing
+      - vite
+      - wrangler
+      - xml2js
+      - zephyr-agent
+
+  eventsource-parser@3.1.0: {}
+
+  exsolve@1.1.0: {}
+
+  h3@2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22)):
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.22
+    optionalDependencies:
+      crossws: 0.4.10(srvx@0.11.22)
+
+  hookable@6.1.1: {}
+
+  httpxy@0.5.5: {}
+
+  json-schema@0.4.0: {}
+
+  nf3@0.3.22: {}
+
+  nitro@3.0.260610-beta:
+    dependencies:
+      consola: 3.4.2
+      crossws: 0.4.10(srvx@0.11.22)
+      db0: 0.3.4
+      env-runner: 0.1.16
+      h3: 2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22))
+      hookable: 6.1.1
+      nf3: 0.3.22
+      ocache: 0.1.5
+      ofetch: 2.0.0-alpha.3
+      ohash: 2.0.11
+      rolldown: 1.1.5
+      srvx: 0.11.22
+      unenv: 2.0.0-rc.24
+      unstorage: 2.0.0-alpha.7(db0@0.3.4)(ofetch@2.0.0-alpha.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - drizzle-orm
+      - idb-keyval
+      - ioredis
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - sqlite3
+      - uploadthing
+      - wrangler
+
+  ocache@0.1.5:
+    dependencies:
+      ohash: 2.0.11
+
+  ofetch@2.0.0-alpha.3: {}
+
+  ohash@2.0.11: {}
+
+  pathe@2.0.3: {}
+
+  prettier@2.8.8: {}
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  rou3@0.8.1: {}
+
+  srvx@0.11.22: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@5.9.3: {}
+
+  undici-types@7.12.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
+  unstorage@2.0.0-alpha.7(db0@0.3.4)(ofetch@2.0.0-alpha.3):
+    optionalDependencies:
+      db0: 0.3.4
+      ofetch: 2.0.0-alpha.3
+
+  zod@4.4.3: {}

--- a/starter/eve-pay-agent/tsconfig.json
+++ b/starter/eve-pay-agent/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "useUnknownInCatchVariables": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "rootDir": "."
+  },
+  "include": ["agent/**/*"],
+  "exclude": ["node_modules", ".eve", "dist", ".vercel"]
+}


### PR DESCRIPTION
### Description

Adds a minimal eve agent that demonstrates an approval-gated Pay.sh sandbox payment.

- Inspects the HTTP 402 terms without paying
- Shows the amount, USDC mint, recipient, and `localnet` network before approval
- Rechecks every approved field before handing off to the pinned Pay.sh CLI
- Disables general shell, filesystem, and web tools
- Includes Vercel Templates metadata and a one-click deploy link

The sandbox CLI performs its own final challenge fetch, so the recheck is defense in depth rather than a cryptographic binding. Production signing must bind to the approved challenge or enforce hard client-side limits.

No user wallet, private key, mainnet funds, or real payment is used.

### Demo URL

https://eve-pay-agent.vercel.app

Connect with `eve dev https://eve-pay-agent.vercel.app` to try the agent flow.

### Type of Change

- [x] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [x] 📚 The template was not used, but I carefully read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered? N/A: there is no authored web UI; the deployment uses eve generated status page and terminal client.