### PR TITLE
Fix fallback image variable name in index.tsx

### DIFF
--- a/solutions/image-fallback/pages/index.tsx
+++ b/solutions/image-fallback/pages/index.tsx
@@ -28,7 +28,7 @@ const ImageWithFallback = ({
     <Image
       alt={alt}
       onError={setError}
-      src={error ? fallbackImage : src}
+      src={error ? fallback : src}
       {...props}
     />
   )


### PR DESCRIPTION
### Description

<!--
 The fallback variable is not used and fallback Image is stale despite of provided fallback from props
-->

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [X] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
