### PR TITLE
bun(websockets): add bun websocket example

### DIFF
--- a/websockets/bun/.gitignore
+++ b/websockets/bun/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.vercel

--- a/websockets/bun/README.md
+++ b/websockets/bun/README.md
@@ -1,0 +1,60 @@
+# Bun WebSockets on Vercel
+
+Minimal native [Bun](https://bun.com/) WebSocket example: one `Bun.serve()`
+server, one `/ws` endpoint, and one HTML page that sends a message and renders
+the echoed response.
+
+## How to Use
+
+You can choose from one of the following two methods to use this repository:
+
+### One-Click Deploy
+
+Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=vercel-examples):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/examples/tree/main/websockets/bun&project-name=bun-websockets&repository-name=bun-websockets)
+
+### Clone and Deploy
+
+```bash
+git clone https://github.com/vercel/examples/tree/main/websockets/bun
+```
+
+Install the dependencies:
+
+```bash
+bun install
+```
+
+Run the app locally:
+
+```bash
+bun dev
+```
+
+Open <http://localhost:3000>, send a message, and the server echoes it back.
+
+## Project structure
+
+```text
+bun/
+├── public/
+│   └── index.html     # WebSocket client UI
+├── bun.lock           # Bun framework preset detection and dependencies
+├── server.ts          # Bun server with /ws echo endpoint
+├── tsconfig.json
+├── vercel.json        # Enables Bun and includes the client in the function
+└── package.json
+```
+
+## Scripts
+
+```bash
+bun dev          # run server.ts with hot reload
+bun start        # run server.ts
+bun type-check   # check TypeScript types
+```
+
+The `bun.lock` file and root `server.ts` let Vercel detect the Bun framework
+preset. The `bunVersion` setting in `vercel.json` runs the Vercel Function with
+the Bun runtime.

--- a/websockets/bun/bun.lock
+++ b/websockets/bun/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "bun-websockets",
+      "devDependencies": {
+        "@types/bun": "1.3.13",
+        "typescript": "6.0.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.13", "https://registry.npmjs.org/@types/bun/-/bun-1.3.13.tgz", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/node": ["@types/node@26.1.2", "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "bun-types": ["bun-types@1.3.13", "https://registry.npmjs.org/bun-types/-/bun-types-1.3.13.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "typescript": ["typescript@6.0.3", "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@8.3.0", "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/websockets/bun/package.json
+++ b/websockets/bun/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bun-websockets",
+  "name": "websockets-bun",
   "version": "0.0.0",
   "private": true,
   "description": "Minimal native Bun WebSocket echo server on Vercel",
@@ -9,11 +9,11 @@
     "start": "bun server.ts",
     "type-check": "tsc --noEmit"
   },
-  "engines": {
-    "bun": "1.x"
-  },
   "devDependencies": {
     "@types/bun": "1.3.13",
     "typescript": "6.0.3"
+  },
+  "engines": {
+    "bun": "1.x"
   }
 }

--- a/websockets/bun/package.json
+++ b/websockets/bun/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "bun-websockets",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Minimal native Bun WebSocket echo server on Vercel",
+  "license": "MIT",
+  "scripts": {
+    "dev": "bun --hot server.ts",
+    "start": "bun server.ts",
+    "type-check": "tsc --noEmit"
+  },
+  "engines": {
+    "bun": "1.x"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.13",
+    "typescript": "6.0.3"
+  }
+}

--- a/websockets/bun/package.json
+++ b/websockets/bun/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "websockets-bun",
+  "name": "example-websockets-bun",
   "version": "0.0.0",
   "private": true,
   "description": "Minimal native Bun WebSocket echo server on Vercel",

--- a/websockets/bun/package.json
+++ b/websockets/bun/package.json
@@ -2,6 +2,7 @@
   "name": "example-websockets-bun",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "description": "Minimal native Bun WebSocket echo server on Vercel",
   "license": "MIT",
   "scripts": {

--- a/websockets/bun/public/index.html
+++ b/websockets/bun/public/index.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bun WebSocket Echo</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --border: color-mix(in oklab, currentColor 15%, transparent);
+        --muted: color-mix(in oklab, currentColor 55%, transparent);
+      }
+
+      body {
+        font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+        max-width: 32rem;
+        margin: 3rem auto;
+        padding: 0 1rem;
+        line-height: 1.5;
+      }
+
+      h1 {
+        margin-bottom: 0.25rem;
+        font-size: 1.25rem;
+      }
+
+      .lead {
+        margin: 0 0 1.25rem;
+        color: var(--muted);
+      }
+
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: var(--muted);
+        font-size: 0.875rem;
+      }
+
+      .dot {
+        width: 0.625rem;
+        height: 0.625rem;
+        border-radius: 50%;
+        background: #d4d4d4;
+      }
+
+      .dot.on {
+        background: #22c55e;
+      }
+
+      .dot.off {
+        background: #ef4444;
+      }
+
+      form {
+        display: flex;
+        gap: 0.5rem;
+        margin: 1.5rem 0 1rem;
+      }
+
+      input {
+        flex: 1;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid var(--border);
+        border-radius: 0.5rem;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+      }
+
+      button {
+        padding: 0.5rem 1rem;
+        border: 1px solid var(--border);
+        border-radius: 0.5rem;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        cursor: pointer;
+      }
+
+      button:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+      }
+
+      #log {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 0.875rem;
+      }
+
+      .line {
+        display: flex;
+        gap: 0.5rem;
+        padding: 0.1875rem 0;
+        word-break: break-word;
+      }
+
+      .arrow {
+        width: 1ch;
+        flex: none;
+      }
+
+      .text {
+        flex: 1;
+        white-space: pre-wrap;
+      }
+
+      .latency {
+        flex: none;
+        color: var(--muted);
+      }
+
+      .sent {
+        color: var(--muted);
+      }
+
+      .received .arrow {
+        color: #22c55e;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Bun WebSocket Echo</h1>
+    <p class="lead">
+      Type a message and the native Bun server echoes it over a WebSocket.
+    </p>
+    <p class="status">
+      <span id="dot" class="dot"></span>
+      <span id="status">Connecting...</span>
+    </p>
+
+    <form>
+      <input name="message" autocomplete="off" placeholder="Type a message" />
+      <button type="submit" disabled>Send</button>
+    </form>
+
+    <div id="log"></div>
+
+    <script>
+      const dot = document.querySelector('#dot')
+      const status = document.querySelector('#status')
+      const form = document.querySelector('form')
+      const input = document.querySelector('input')
+      const button = document.querySelector('button')
+      const log = document.querySelector('#log')
+      const pending = []
+      const protocol = location.protocol === 'https:' ? 'wss' : 'ws'
+      const socket = new WebSocket(`${protocol}://${location.host}/ws`)
+
+      function addLine(direction, text, latency) {
+        const line = document.createElement('div')
+        const arrow = document.createElement('span')
+        const content = document.createElement('span')
+
+        line.className = `line ${direction}`
+        arrow.className = 'arrow'
+        arrow.textContent = direction === 'sent' ? '>' : '<'
+        content.className = 'text'
+        content.textContent = text
+        line.append(arrow, content)
+
+        if (latency !== undefined) {
+          const timing = document.createElement('span')
+          timing.className = 'latency'
+          timing.textContent = `${latency} ms`
+          line.append(timing)
+        }
+
+        log.append(line)
+      }
+
+      socket.addEventListener('open', () => {
+        dot.className = 'dot on'
+        status.textContent = 'Connected'
+        button.disabled = false
+      })
+
+      socket.addEventListener('close', () => {
+        dot.className = 'dot off'
+        status.textContent = 'Disconnected'
+        button.disabled = true
+      })
+
+      socket.addEventListener('message', (event) => {
+        const sentAt = pending.shift()
+        const latency = sentAt === undefined ? undefined : Date.now() - sentAt
+        addLine('received', event.data, latency)
+      })
+
+      form.addEventListener('submit', (event) => {
+        event.preventDefault()
+        const message = input.value.trim()
+        if (!message) return
+
+        pending.push(Date.now())
+        addLine('sent', message)
+        socket.send(message)
+        input.value = ''
+      })
+    </script>
+  </body>
+</html>

--- a/websockets/bun/server.ts
+++ b/websockets/bun/server.ts
@@ -1,9 +1,12 @@
 const server = Bun.serve({
   port: Number(process.env.PORT || 3000),
   routes: {
-    '/': new Response(Bun.file('public/index.html'), {
-      headers: { 'Content-Type': 'text/html; charset=utf-8' },
-    }),
+    '/': new Response(
+      Bun.file(new URL('./public/index.html', import.meta.url)),
+      {
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      },
+    ),
     '/health': Response.json({ status: 'ok' }),
   },
   fetch(request, server) {

--- a/websockets/bun/server.ts
+++ b/websockets/bun/server.ts
@@ -1,28 +1,22 @@
 const server = Bun.serve({
-  port: Number(process.env.PORT || 3000),
   routes: {
-    '/': new Response(
-      Bun.file(new URL('./public/index.html', import.meta.url)),
-      {
-        headers: { 'Content-Type': 'text/html; charset=utf-8' },
-      },
-    ),
-    '/health': Response.json({ status: 'ok' }),
+    "/": new Response(Bun.file(new URL("./public/index.html", import.meta.url)), {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    }),
+    "/health": Response.json({ status: "ok" }),
   },
   fetch(request, server) {
-    const { pathname } = new URL(request.url)
-
-    if (pathname === '/ws' && server.upgrade(request)) {
-      return
+    const { pathname } = new URL(request.url);
+    if (pathname === "/ws" && server.upgrade(request)) {
+      return;
     }
-
-    return new Response('Not found', { status: 404 })
+    return new Response("Not found", { status: 404 });
   },
   websocket: {
     message(socket, message) {
-      socket.send(message)
+      socket.send(message);
     },
   },
-})
+});
 
-console.log(`Listening on ${server.url}`)
+console.log(`Listening on ${server.url}`);

--- a/websockets/bun/server.ts
+++ b/websockets/bun/server.ts
@@ -1,0 +1,25 @@
+const server = Bun.serve({
+  port: Number(process.env.PORT || 3000),
+  routes: {
+    '/': new Response(Bun.file('public/index.html'), {
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    }),
+    '/health': Response.json({ status: 'ok' }),
+  },
+  fetch(request, server) {
+    const { pathname } = new URL(request.url)
+
+    if (pathname === '/ws' && server.upgrade(request)) {
+      return
+    }
+
+    return new Response('Not found', { status: 404 })
+  },
+  websocket: {
+    message(socket, message) {
+      socket.send(message)
+    },
+  },
+})
+
+console.log(`Listening on ${server.url}`)

--- a/websockets/bun/server.ts
+++ b/websockets/bun/server.ts
@@ -1,4 +1,4 @@
-const server = Bun.serve({
+Bun.serve({
   routes: {
     "/": new Response(Bun.file(new URL("./public/index.html", import.meta.url)), {
       headers: { "Content-Type": "text/html; charset=utf-8" },
@@ -18,5 +18,3 @@ const server = Bun.serve({
     },
   },
 });
-
-console.log(`Listening on ${server.url}`);

--- a/websockets/bun/tsconfig.json
+++ b/websockets/bun/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext", "DOM"],
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["server.ts"]
+}

--- a/websockets/bun/vercel.json
+++ b/websockets/bun/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "bunVersion": "1.x",
+  "functions": {
+    "server.ts": {
+      "includeFiles": "public/index.html"
+    }
+  }
+}

--- a/websockets/bun/vercel.json
+++ b/websockets/bun/vercel.json
@@ -1,9 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "bunVersion": "1.x",
-  "functions": {
-    "server.ts": {
-      "includeFiles": "public/index.html"
-    }
-  }
+  "bunVersion": "1.x"
 }


### PR DESCRIPTION
## TLDR

Adds a deployable native Bun WebSocket echo example for Vercel.

## Problem

The WebSocket examples do not show how to deploy a dependency-free Bun application using `Bun.serve()` and its native WebSocket handlers on Vercel.

## Solution

Adds a `websockets/bun` example with a native `/ws` upgrade handler, echo behavior, health endpoint, and responsive browser client. Includes Bun framework preset detection, pinned type dependencies, public registry lockfile entries, Vercel runtime configuration, explicit client asset bundling, local scripts, and one-click deployment instructions.

