### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,6 @@
 # Learn how to add code owners here:
 # https://help.github.com/en/articles/about-code-owners
 
-# Solutions Eng and Dev Rel are the default owners of everything
-* @okbel @lfades @goncy @dominiksipowicz @lpalmes
-
 # For examples that are a Monorepo we add the Turbo team and some members
 # from Solutions and Dev Rel
 solutions/monorepo @vercel/turbo-oss @goncy @lfades @lpalmes
@@ -29,4 +26,4 @@ microfrontends @kitfoster @lazarv @mknichel
 
 cdn @vercel/edge-ingress @vercel/edge-content @vercel/edge-security @pranavkarthik10
 
-websockets @vercel/edge-ingress @vercel/team-backends @vercel/team-python
+websockets @vercel/edge-ingress @vercel/team-backends @vercel/team-python @vercel/compute


### PR DESCRIPTION
Removed default codeowners
Added @vercel/compute as a code owner for websockets.

### Description

This removes the default codeowners requirement from this repo.
We want to ship a lot of improvements and it's just very hard with this requirement constantly.


### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
