### PR TITLE
bun: fix file path for vanilla bun example

### DIFF
--- a/framework-boilerplates/bun/server.ts
+++ b/framework-boilerplates/bun/server.ts
@@ -1,9 +1,8 @@
 Bun.serve({
   routes: {
-    "/": () =>
-      new Response(Bun.file("public/index.html"), {
-        headers: { "content-type": "text/html; charset=utf-8" },
-      }),
+    "/": new Response(Bun.file(new URL("./public/index.html", import.meta.url)), {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    }),
     "/api/hello": (request) =>
       Response.json({
         message: "Hello from a Bun route handler!",

--- a/framework-boilerplates/bun/vercel.json
+++ b/framework-boilerplates/bun/vercel.json
@@ -1,8 +1,3 @@
 {
-  "bunVersion": "1.x",
-  "functions": {
-    "server.ts": {
-      "includeFiles": "public/**"
-    }
-  }
+  "bunVersion": "1.x"
 }


### PR DESCRIPTION
### Description

Logs show `index.html` cannot be resolved. So using same logic as in websockets example.

### Demo URL

<!--
  Provide a URL to a live deployment where we can test your PR. If a demo isn't possible feel free to omit this section.
-->

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

### New Example Checklist

- [ ] 🛫 `npm run new-example` was used to create the example
- [ ] 📚 The template wasn't used but I carefuly read the [Adding a new example](https://github.com/vercel/examples#adding-a-new-example) steps and implemented them in the example
- [ ] 📱 Is it responsive? Are mobile and tablets considered?
