### PR TITLE
docs(aws-message-queue-elasticache): use "Amazon ElastiCache" on first mention

### DIFF
--- a/solutions/aws-message-queue-elasticache/README.md
+++ b/solutions/aws-message-queue-elasticache/README.md
@@ -11,7 +11,7 @@ demoUrl: https://aws-message-queue-elasticache.vercel.app
 
 # Next.js + Amazon ElastiCache Message Queue
 
-This is an example of a Next.js application using ElastiCache for implementing a reliable message queue with streams. The template demonstrates a contact form processor where messages are queued, consumed, and acknowledged using Valkey's streaming capabilities.
+This is an example of a Next.js application using Amazon ElastiCache for implementing a reliable message queue with streams. The template demonstrates a contact form processor where messages are queued, consumed, and acknowledged using Valkey's streaming capabilities.
 
 ## How to Use
 

--- a/solutions/aws-message-queue-elasticache/README.md
+++ b/solutions/aws-message-queue-elasticache/README.md
@@ -1,21 +1,21 @@
 ---
-name: Message Queue with AWS ElastiCache and Next.js
+name: Valkey Message Queue with Amazon ElastiCache and Next.js
 slug: aws-message-queue-elasticache
-description: Learn to use AWS ElastiCache with Next.js API Routes for reliable message queue processing using streams.
+description: Learn to use Amazon ElastiCache with Next.js API Routes for reliable message queue processing using streams.
 framework: Next.js
 css: Tailwind
 type: Starter
-deployUrl: https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/aws-message-queue-elasticache&project-name=aws-message-queue-elasticache&repository-name=aws-message-queue-elasticache&env=VALKEY_ENDPOINT&envDescription=Valkey%20endpoint%20URL
+deployUrl: https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/aws-message-queue-elasticache&project-name=Valkey%20Message%20Queue%20with%20Amazon%20ElastiCache%20and%20Next.js&repository-name=aws-message-queue-elasticache&demo-title=Valkey%20Message%20Queue%20with%20Amazon%20ElastiCache%20and%20Next.js&env=VALKEY_ENDPOINT&envDescription=Valkey%20endpoint%20URL
 demoUrl: https://aws-message-queue-elasticache.vercel.app
 ---
 
-# Next.js + AWS ElastiCache Message Queue
+# Next.js + Amazon ElastiCache Message Queue
 
-This is an example of a Next.js application using AWS ElastiCache for implementing a reliable message queue with streams. The template demonstrates a contact form processor where messages are queued, consumed, and acknowledged using Valkey's streaming capabilities.
+This is an example of a Next.js application using ElastiCache for implementing a reliable message queue with streams. The template demonstrates a contact form processor where messages are queued, consumed, and acknowledged using Valkey's streaming capabilities.
 
 ## How to Use
 
-This template demonstrates the code pattern for implementing message queues with Valkey streams. It's designed to work with AWS ElastiCache in production environments.
+This template demonstrates the code pattern for implementing message queues with Valkey streams. It's designed to work with Amazon ElastiCache in production environments.
 
 ### Local Development
 
@@ -51,13 +51,13 @@ pnpm dev
 
 Visit <http://localhost:3000> to see the application.
 
-### Production Deployment with AWS ElastiCache
+### Production Deployment with Amazon ElastiCache
 
-AWS ElastiCache clusters run within a VPC (private network), which requires network connectivity setup for production deployments on Vercel.
+ElastiCache clusters run within a VPC (private network), which requires network connectivity setup for production deployments on Vercel.
 
 #### Networking Requirements
 
-**For Vercel Enterprise customers**, connectivity to AWS ElastiCache is available through [Vercel Secure Compute](https://vercel.com/docs/connectivity/secure-compute), which enables private network access between Vercel Functions and AWS VPC resources.
+**For Vercel Enterprise customers**, connectivity to Amazon ElastiCache is available through [Vercel Secure Compute](https://vercel.com/docs/connectivity/secure-compute), which enables private network access between Vercel Functions and AWS VPC resources.
 
 **High-level setup steps:**
 
@@ -80,7 +80,7 @@ VALKEY_ENDPOINT=your-cluster.cache.amazonaws.com:6379
 
 4. Deploy your application
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/aws-message-queue-elasticache&project-name=aws-message-queue-elasticache&repository-name=aws-message-queue-elasticache&env=VALKEY_ENDPOINT&envDescription=Valkey%20endpoint%20URL)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/examples/tree/main/solutions/aws-message-queue-elasticache&project-name=Valkey%20Message%20Queue%20with%20Amazon%20ElastiCache%20and%20Next.js&repository-name=aws-message-queue-elasticache&demo-title=Valkey%20Message%20Queue%20with%20Amazon%20ElastiCache%20and%20Next.js&env=VALKEY_ENDPOINT&envDescription=Valkey%20endpoint%20URL)
 
 For detailed networking configuration, refer to the [Vercel Secure Compute documentation](https://vercel.com/docs/connectivity/secure-compute).
 
@@ -100,7 +100,7 @@ This template demonstrates a reliable serverless message queue workflow:
 - Message acknowledgment ensures reliable processing
 - Automatic reclaim of messages idle longer than 60 seconds (prevents stuck messages)
 - Refreshing the page won't cause duplicate processing
-- Demonstrates how ElastiCache Streams support reliable serverless workflows
+- Demonstrates how Amazon ElastiCache Streams support reliable serverless workflows
 
 ## API Endpoints
 

--- a/solutions/aws-message-queue-elasticache/app/layout.tsx
+++ b/solutions/aws-message-queue-elasticache/app/layout.tsx
@@ -5,9 +5,9 @@ import '@vercel/examples-ui/globals.css'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'AWS Message Queue + ElastiCache',
+  title: 'Amazon ElastiCache Message Queue',
   description:
-    'A Next.js demo using Valkey streams for message queuing with AWS ElastiCache',
+    'A Next.js demo using Valkey streams for message queuing with Amazon ElastiCache',
 }
 
 export const viewport: Viewport = {
@@ -55,7 +55,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                   className="font-medium text-gray-500 hover:text-gray-900"
                   style={{ letterSpacing: '.01px' }}
                 >
-                  AWS Message Queue + ElastiCache
+                  Amazon ElastiCache Message Queue
                 </a>
               </div>
               <div className="flex-1 justify-end hidden md:flex">


### PR DESCRIPTION
### What

Use "Amazon ElastiCache" on the first mention within each section of the `solutions/aws-message-queue-elasticache` template, per AWS service-naming convention, and use the short form "ElastiCache" for subsequent mentions within the same section.

Closes #1563 (the in-repo portion).

### Changes

- **README front-matter**: `name` → `Valkey Message Queue with Amazon ElastiCache and Next.js`; `description` first mention → "Amazon ElastiCache".
- **README `deployUrl` + Deploy button**: set `demo-title` and `project-name` to the updated title.
- **README body**: first mention per section uses "Amazon ElastiCache"; subsequent mentions within the same section use "ElastiCache". Legitimate AWS nouns (AWS VPC, AWS Side, AWS PrivateLink) left unchanged.
- **`app/layout.tsx`**: metadata `title`/`description` and nav label first mention → "Amazon ElastiCache".

### Not covered here

The live template page H1 and the Deploy-link `demo-title`/`project-name` shown on vercel.com are served from Vercel's hosted template catalog, not this repo. See #1563 for that catalog-side update.

### Verification

- `pnpm test` — 26/26 pass.
- `pnpm build` — compiles successfully. (A pre-existing `vercel.ts` type-resolution issue for `@vercel/config` is unrelated to these text-only changes.)
